### PR TITLE
Context-Script on Debian: Restart Network

### DIFF
--- a/share/scripts/context-packages/base_deb/etc/one-context.d/00-network
+++ b/share/scripts/context-packages/base_deb/etc/one-context.d/00-network
@@ -146,6 +146,8 @@ configure_network()
 {
     gen_network_configuration > /etc/network/interfaces
 
+    service networking stop
+    sleep 1
     service networking start
 
     sleep 2


### PR DESCRIPTION
Hi there

If network is already up, the Debian machine won't use the new configured interfaces file. Only with stop and start this is working (On Debian, restart is deprecated).

The symptoms are:
False IP and Netmask on startup.
- Boris
