### PR TITLE
Patch to workaround a bug in Ubuntu Precise where networking restart does not work

### DIFF
--- a/share/scripts/context-packages/base_deb/etc/one-context.d/00-network
+++ b/share/scripts/context-packages/base_deb/etc/one-context.d/00-network
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2010-2012, C12G Labs S.L.                                        #
+# Copyright 2010-2014, C12G Labs S.L.                                        #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #


### PR DESCRIPTION
I've made a patch to work around a bug in Ubuntu Precise where "service network restart" is broken :(. I've tested this on a Ubuntu VM with a couple of network interfaces and it seems to work allright.
