### PR TITLE
Fix minor typo in cli_helper. (Expresion vs Expression)

### DIFF
--- a/src/cli/cli_helper.rb
+++ b/src/cli/cli_helper.rb
@@ -368,7 +368,7 @@ module CLIHelper
                         exit(-1)
                     end
                 else
-                    STDERR.puts "Expresion '#{s}' incorrect"
+                    STDERR.puts "Expression '#{s}' incorrect"
                     exit(-1)
                 end
             end


### PR DESCRIPTION
Hi everyone,

this pull request fixes a minor typo in cli_helper.rb. The word 'Expression' misses a 's' :-). 

```
[matthias@one ~]$ onetemplate list  -f ID
  ID USER            GROUP           NAME                                REGTIME
Expresion 'ID' incorrect
[matthias@one ~]$ 
```

best regards,
Matthias
