### PR TITLE
Update ceph monitor to take into account user/pool

### DIFF
--- a/src/datastore_mad/remotes/ceph/monitor
+++ b/src/datastore_mad/remotes/ceph/monitor
@@ -46,10 +46,13 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
-                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/POOL_NAME)
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/POOL_NAME \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/CEPH_USER)
+
 
 BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 POOL_NAME="${XPATH_ELEMENTS[j++]:-$POOL_NAME}"
+CEPH_USER="${XPATH_ELEMENTS[j++]}"
 
 HOST=`get_destination_host`
 
@@ -61,7 +64,7 @@ fi
 # ------------ Compute datastore usage -------------
 
 MONITOR_SCRIPT=$(cat <<EOF
-$RADOS df | $AWK '{
+$RADOS df -p ${POOL_NAME} --id ${CEPH_USER}| $AWK '{
     if (\$1 == "total") {
 
         space = int(\$3/1024)


### PR DESCRIPTION
Modified 2 lines and rados command to take into account the pool name and Ceph user from the datastore template.
