### PR TITLE
Update: Ceph remotes to take into account CEPH_USER att

### DIFF
--- a/src/datastore_mad/remotes/ceph/clone
+++ b/src/datastore_mad/remotes/ceph/clone
@@ -48,7 +48,8 @@ done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/BASE_PATH \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/POOL_NAME \
                     /DS_DRIVER_ACTION_DATA/IMAGE/PATH \
-                    /DS_DRIVER_ACTION_DATA/IMAGE/SIZE)
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SIZE \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/CEPH_USER)
 
 unset i
 
@@ -57,6 +58,7 @@ BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
 POOL_NAME="${XPATH_ELEMENTS[i++]:-$POOL_NAME}"
 SRC="${XPATH_ELEMENTS[i++]}"
 SIZE="${XPATH_ELEMENTS[i++]}"
+CEPH_USER="${XPATH_ELEMENTS[i++]}"
 
 DST_HOST=`get_destination_host $ID`
 
@@ -65,12 +67,17 @@ if [ -z "$DST_HOST" ]; then
     exit -1
 fi
 
+if [ -z "$CEPH_USER" ]; then
+    error_message "Datastore template missing 'CEPH_USER' attribute."
+    exit -1
+fi
+
 SAFE_DIRS=""
 
 IMAGE_NAME="one-${ID}"
 RBD_DST="${POOL_NAME}/${IMAGE_NAME}"
 
-ssh_exec_and_log "$DST_HOST" "$RBD copy $SRC $RBD_DST" \
-                "Error cloning $SRC to $RBD_DST in $DST_HOST"
+ssh_exec_and_log "$DST_HOST" "$RBD copy $SRC $RBD_DST --id ${CEPH_USER}" \
+                "Error cloning $SRC to $RBD_DST --id ${CEPH_USER} in $DST_HOST"
 
 echo "$RBD_DST"


### PR DESCRIPTION
At this moment all Ceph remotes are using Ceph admin privileges. This could be a sec. issue, CEPH_USER should be a mandatory param into Ceph datastores and it should be used by Ceph remotes by default.
