### PR TITLE
Update Ceph remotes to take into account CEPH_USER att

### DIFF
--- a/src/datastore_mad/remotes/ceph/cp
+++ b/src/datastore_mad/remotes/ceph/cp
@@ -60,7 +60,8 @@ done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/BASE_PATH \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/MD5 \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/SHA1 \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/NO_DECOMPRESS \
-                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/LIMIT_TRANSFER_BW)
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/LIMIT_TRANSFER_BW \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/CEPH_USER)
 
 unset i
 
@@ -77,6 +78,7 @@ MD5="${XPATH_ELEMENTS[i++]}"
 SHA1="${XPATH_ELEMENTS[i++]}"
 NO_DECOMPRESS="${XPATH_ELEMENTS[i++]}"
 LIMIT_TRANSFER_BW="${XPATH_ELEMENTS[i++]}"
+CEPH_USER="${XPATH_ELEMENTS[i++]}"
 
 DST_HOST=`get_destination_host $ID`
 
@@ -131,9 +133,9 @@ REGISTER_CMD=$(cat <<EOF
             mv $TMP_DST.raw $TMP_DST
         fi
 
-        $RBD import --format 2 $TMP_DST $RBD_SOURCE
+        $RBD import --format 2 $TMP_DST $RBD_SOURCE --id ${CEPH_USER}
     else
-        $QEMU_IMG convert $QEMU_IMG_CONVERT_ARGS $TMP_DST rbd:$RBD_SOURCE
+        $QEMU_IMG convert $QEMU_IMG_CONVERT_ARGS $TMP_DST rbd:$RBD_SOURCE:id=${CEPH_USER}
     fi
 
     # remove original
@@ -142,6 +144,6 @@ EOF
 )
 
 ssh_exec_and_log    "$DST_HOST" "$REGISTER_CMD" \
-                    "Error registering $RBD_SOURCE in $DST_HOST"
+                    "Error registering $RBD_SOURCE:id=${CEPH_USER} in $DST_HOST"
 
 echo "$RBD_SOURCE"


### PR DESCRIPTION
At this moment all Ceph remotes are using Ceph admin privileges. This could be a sec. issue, CEPH_USER should be a mandatory param into Ceph datastores and it should be used by Ceph remotes by default.
