### PR TITLE
Exception-Prevention in src/oca/ruby/opennebula/client.rb

### DIFF
--- a/src/oca/ruby/opennebula/client.rb
+++ b/src/oca/ruby/opennebula/client.rb
@@ -113,8 +113,10 @@ module OpenNebula
             elsif ENV["ONE_AUTH"] and !ENV["ONE_AUTH"].empty? and
                     File.file?(ENV["ONE_AUTH"])
                 @one_auth = File.read(ENV["ONE_AUTH"])
-            elsif File.file?(ENV["HOME"]+"/.one/one_auth")
+            elsif ENV["HOME"] and File.file?(ENV["HOME"]+"/.one/one_auth")
                 @one_auth = File.read(ENV["HOME"]+"/.one/one_auth")
+            elsif File.file?("/var/lib/one/.one/one_auth")
+                @one_auth = File.read("/var/lib/one/.one/one_auth")
             else
                 raise "ONE_AUTH file not present"
             end
@@ -125,8 +127,10 @@ module OpenNebula
                 @one_endpoint = endpoint
             elsif ENV["ONE_XMLRPC"]
                 @one_endpoint = ENV["ONE_XMLRPC"]
-            elsif File.exists?(ENV['HOME']+"/.one/one_endpoint")
+            elsif ENV['HOME'] and File.exists?(ENV['HOME']+"/.one/one_endpoint")
                 @one_endpoint = File.read(ENV['HOME']+"/.one/one_endpoint")
+            elsif File.exists?("/var/lib/one/.one/one_endpoint")
+                @one_endpoint = File.read("/var/lib/one/.one/one_endpoint")
             else
                 @one_endpoint = "http://localhost:2633/RPC2"
             end


### PR DESCRIPTION
- Add validation of ENV['HOME'] before trying to use it in string-concat to prevent nil:NilClass-Exception
- Add default-path check "/var/lib/one/.one" if ENV['HOME'] is not defined

When the ENV-variable 'HOME' is unset (happened e.g. in my puppet rollout), the usage results in an nil:NilClass-Exception, as client.rb tries to concatenate ENV['HOME']  and a string. To prevent this, I patched client.rb to validate if ENV['HOME'] is set. Additionally, I added checking if the looked-up files exist in Default-Installation-Path (/var/lib/one/), if ENV['HOME'] does not exist, or the files don't exist there.
