### PR TITLE
[ceph] contextualization disk on rbd

### DIFF
--- a/src/datastore_mad/remotes/ceph/context
+++ b/src/datastore_mad/remotes/ceph/context
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2014, OpenNebula Project (OpenNebula.org), C12G Labs        #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# context context.sh file1 file2 ... fileN host:remote_system_ds/disk.i vmid 0
+#   - context.sh file are the contents of the context ISO
+#   - host is the target host to deploy the VM
+#   - remote_system_ds is the path for the system datastore in the host
+#   - vmid is the id of the VM
+#   - 0 is the target datastore (system)
+
+ARGV=("$@")
+
+DS_ID="${ARGV[$(($#-1))]}"
+VM_ID="${ARGV[$(($#-2))]}"
+DST="${ARGV[$(($#-3))]}"
+SRC=("${ARGV[@]:0:$(($#-3))}")
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+fi
+
+. $TMCOMMON
+
+function exit_error
+{
+    error_message "$ERROR"
+    rm -rf $ISO_DIR > /dev/null 2>&1
+    exit -1
+}
+
+#-------------------------------------------------------------------------------
+# Set dst path and dirs
+#-------------------------------------------------------------------------------
+DST_PATH=`arg_path $DST`
+DST_HOST=`arg_host $DST`
+DST_DIR=`dirname $DST_PATH`
+
+#-------------------------------------------------------------------------------
+# Create DST path
+#-------------------------------------------------------------------------------
+
+ssh_make_path $DST_HOST $DST_DIR
+
+#-------------------------------------------------------------------------------
+# Build the Context Block device (locally) and copy it remotely
+#-------------------------------------------------------------------------------
+log "Generating context block device at $DST"
+
+VM_ID=`basename $DST_DIR`
+ISO_DIR="$DS_DIR/.isofiles/$VM_ID"
+ISO_FILE="$ISO_DIR/$VM_ID.iso"
+
+exec_and_set_error "mkdir -p $ISO_DIR" \
+    "Could not create tmp dir to make context dev"
+[ -n "$ERROR" ] && exit_error
+
+for f in "${SRC[@]}"; do
+    case "$f" in
+    http://*)
+        exec_and_set_error "$WGET -P $ISO_DIR $f" "Error downloading $f"
+        ;;
+    *)
+        if echo "$f" | grep -q ':'; then
+            target=$(echo "$f"|cut -d':' -f2-)
+            target="'$target'"
+            f=$(echo "$f"|cut -d':' -f1)
+        else
+            target=""
+        fi
+
+        exec_and_set_error "cp -R $f $ISO_DIR/$target" \
+            "Error copying $f to $ISO_DIR"
+        ;;
+    esac
+
+    [ -n "$ERROR" ] && exit_error
+done
+
+exec_and_set_error "$MKISOFS -o $ISO_FILE -V CONTEXT -J -R $ISO_DIR" \
+    "Error creating iso fs"
+[ -n "$ERROR" ] && exit_error
+
+exec_and_set_error "rbd create -p one -s 2048 $VM_ID-context" "Error creating rbd $VM_ID-context"
+[ -n "$ERROR" ] && exit_error
+
+exec_and_set_error "sudo rbd map -p one $VM_ID-context" "Error mapping rbd $VM_ID-context"
+[ -n "$ERROR" ] && exit_error
+
+exec_and_set_error "sudo dd if=$ISO_FILE of=`sudo rbd showmapped |grep $VM_ID-context| awk {'print $5'}`" "Error dd'ing temporary iso on $VM_ID-context"
+[ -n "$ERROR" ] && exit_error
+
+exec_and_set_error "sudo rbd unmap `sudo rbd showmapped |grep $VM_ID-context| awk {'print $5'}`" "Error unmapping $VM_ID-context"
+[ -n "$ERROR" ] && exit_error
+
+#exec_and_set_error "$SCP $ISO_FILE $DST" "Error copying context ISO to $DST"
+#[ -n "$ERROR" ] && exit_error
+
+# Creates symbolic link to add a .iso suffix, needed for VMware CDROMs
+ssh_exec_and_log $DST_HOST "$LN -sf $DST_PATH $DST_PATH.iso" "Error creating ISO symbolic link"
+
+
+
+rm -rf $ISO_DIR > /dev/null 2>&1
+
+exit 0

--- a/src/datastore_mad/remotes/ceph/delete
+++ b/src/datastore_mad/remotes/ceph/delete
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2014, OpenNebula Project (OpenNebula.org), C12G Labs        #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# DELETE <host:remote_system_ds/disk.i|host:remote_system_ds/>
+#   - host is the target host to deploy the VM
+#   - remote_system_ds is the path for the system datastore in the host
+
+DST=$1
+VM_ID=$2
+DS_ID=$3
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+fi
+
+DRIVER_PATH=$(dirname $0)
+
+source $TMCOMMON
+source ${DRIVER_PATH}/../../datastore/ceph/ceph.conf
+
+#-------------------------------------------------------------------------------
+# Process destination
+#-------------------------------------------------------------------------------
+
+DST_PATH=`arg_path $DST`
+DST_HOST=`arg_host $DST`
+
+#-------------------------------------------------------------------------------
+# Delete and exit if directory
+#-------------------------------------------------------------------------------
+
+if [ `is_disk $DST_PATH` -eq 0 ]; then
+    # Directory
+    log "Deleting $DST_PATH"
+    ssh_exec_and_log "$DST_HOST" "rm -rf $DST_PATH" "Error deleting $DST_PATH"
+    exit 0
+fi
+
+#-------------------------------------------------------------------------------
+# Get Image information
+#-------------------------------------------------------------------------------
+
+DISK_ID=$(echo "$DST_PATH" | $AWK -F. '{print $NF}')
+
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+unset i j XPATH_ELEMENTS
+
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onevm show -x $VM_ID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE)
+
+SRC="${XPATH_ELEMENTS[j++]}"
+CLONE="${XPATH_ELEMENTS[j++]}"
+
+# No need to delete no cloned images
+if [ "$CLONE" = "NO" ]; then
+    exit 0
+fi
+
+# cloned, so the name will be "<pool>/one-<imageid>-<vmid>-<diskid>"
+RBD_SRC="${SRC}-${VM_ID}-${DISK_ID}"
+RBD_SNAP="${VM_ID}-${DISK_ID}"
+RBD_CONTEXT="one/${VM_ID}-context"
+
+#-------------------------------------------------------------------------------
+# Delete the device
+#-------------------------------------------------------------------------------
+
+log "Deleting $DST_PATH"
+
+# Note that this command, as opposed to the rest of $RBD commands in this set of
+# drivers, is executed in the worker node and not in the CEPH frontend.
+
+DELETE_CMD=$(cat <<EOF
+    set -e
+
+    RBD_FORMAT=\$(rbd info $RBD_SRC | sed -n 's/.*format: // p')
+
+    $RBD rm $RBD_SRC
+    $RBD rm $RBD_CONTEXT
+
+    if [ "\$RBD_FORMAT" = "2" ]; then
+        $RBD snap unprotect $SRC@$RBD_SNAP
+        $RBD snap rm $SRC@$RBD_SNAP
+    fi
+EOF
+)
+
+ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" \
+                 "Error deleting $RBD_SRC in $DST_HOST"
+
+exit 0
+

--- a/src/tm_mad/ceph/clone
+++ b/src/tm_mad/ceph/clone
@@ -38,6 +38,7 @@ DRIVER_PATH=$(dirname $0)
 source $TMCOMMON
 
 DST_HOST=`arg_host $DST`
+DST_PATH=`arg_path $DST`
 
 #-------------------------------------------------------------------------------
 # Compute the destination image name
@@ -50,33 +51,13 @@ RBD_DST="${SRC_PATH}-${VM_ID}-${DISK_ID}"
 RBD_SNAP="${VM_ID}-${DISK_ID}"
 
 #-------------------------------------------------------------------------------
-# Get Image information
-#-------------------------------------------------------------------------------
-
-XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
-
-unset i j XPATH_ELEMENTS
-
-while IFS= read -r -d '' element; do
-        XPATH_ELEMENTS[i++]="$element"
-        done < <(onevm show -x $VM_ID| $XPATH  \
-                            /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CEPH_USER)
-
-CEPH_USER="${XPATH_ELEMENTS[j++]}"
-
-
-#-------------------------------------------------------------------------------
 # Clone the image
 #-------------------------------------------------------------------------------
 
-if [ -n "$CEPH_USER" ]; then
-    RBD="$RBD --id ${CEPH_USER}"
-fi
- 
 CLONE_CMD=$(cat <<EOF
     set -e
 
-    RBD_FORMAT=\$($RBD info $SRC_PATH | sed -n 's/.*format: // p')   
+    RBD_FORMAT=\$(rbd info $SRC_PATH | sed -n 's/.*format: // p')
 
     if [ "\$RBD_FORMAT" = "2" ]; then
         $RBD snap create "$SRC_PATH@$RBD_SNAP"
@@ -88,6 +69,30 @@ CLONE_CMD=$(cat <<EOF
 EOF
 )
 
+if [ "$DST_HOST" == "fras008" ] || [ "$DST_HOST" == "fras009" ]; then
+
+CLONE_CMD=$(cat <<EOF
+    set -e
+
+    RBD_FORMAT=\$(rbd info $SRC_PATH | sed -n 's/.*format: // p')
+
+    if [ "\$RBD_FORMAT" = "2" ]; then
+        $RBD snap create "$SRC_PATH@$RBD_SNAP"
+        $RBD snap protect "$SRC_PATH@$RBD_SNAP"
+        $RBD clone "$SRC_PATH@$RBD_SNAP" $RBD_DST
+    else
+        $RBD copy $SRC_PATH $RBD_DST
+    fi
+    mkdir -p `dirname $DST_PATH`
+    qemu-img convert -O raw "rbd:$SRC_PATH@$RBD_SNAP" "$DST_PATH" 
+EOF
+)
+
+fi
+
+
+
 ssh_exec_and_log "$DST_HOST" "$CLONE_CMD" \
                  "Error cloning $SRC_PATH to $RBD_DST in $DST_HOST"
 exit 0
+

--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -682,6 +682,27 @@ int LibVirtDriver::deployment_description_kvm(
 
         if ( !target.empty() )
         {
+          if ( context->vector_value("CEPH_CONTEXT") == "true" )
+          {
+            file << "\t\t<disk type='network' device='cdrom'>" << endl;
+            file << "\t\t\t<source protocol='rbd' name='one/" << vm->get_oid() << "-context";
+            do_network_hosts(file, ceph_host, "");
+
+            if ( !ceph_secret.empty() && !ceph_user.empty())
+            {
+              file << "\t\t\t<auth username='"<< ceph_user <<"'>" << endl
+              << "\t\t\t\t<secret type='ceph' uuid='"
+              << ceph_secret <<"'/>" << endl
+              << "\t\t\t</auth>" << endl;
+            }
+
+            file << "\t\t\t<target dev='" << target << "'/>" << endl;
+            file << "\t\t\t<readonly/>" << endl;
+            file << "\t\t\t<driver name='qemu' type='raw'/>" << endl;
+            file << "\t\t</disk>" << endl;
+          }
+          else
+          {
             file << "\t\t<disk type='file' device='cdrom'>" << endl;
 
             file << "\t\t\t<source file='" << vm->get_remote_system_dir()
@@ -693,6 +714,7 @@ int LibVirtDriver::deployment_description_kvm(
             file << "\t\t\t<driver name='qemu' type='raw'/>" << endl;
 
             file << "\t\t</disk>" << endl;
+          }
         }
         else
         {

--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -117,6 +117,7 @@ int LibVirtDriver::deployment_description_kvm(
     string  ceph_user       = "";
     string  gluster_host    = "";
     string  gluster_volume  = "";
+    string  local_storage   = "";
 
     string  total_bytes_sec = "";
     string  read_bytes_sec  = "";
@@ -494,7 +495,7 @@ int LibVirtDriver::deployment_description_kvm(
 
         one_util::toupper(type);
 
-        if ( type == "BLOCK" )
+        if ( type == "BLOCK" || local_storage == "TRUE" )
         {
             file << "\t\t<disk type='block' device='disk'>" << endl
                  << "\t\t\t<source dev='" << vm->get_remote_system_dir()


### PR DESCRIPTION
If you use ceph as the only datastore (image) without having a classical shared system datastore and use contextualization you will struggle by using livemigration. The contextualization disk is created on the default system datastore on the target host (local). If you dont have a NFS or other shared file system, you cannot live migrate even if you have a distributed filesystem like ceph, which is shared on all nodes if configured properly.

The fix works and is tested for 4.8 and should also work for 4.10 and creates contextualization disks on rbd named "$VM_ID-context" and deletes the disk as soon the vm gets destroyed. You have to set CEPH_CONTEXT=true to your template context section and configure a custom system datastore using the ceph tm.

Regards,

Sebastian
