### PR TITLE
ability to monitor ABSOLUTE_PATH instead of auto-generated BASE_PATH

### DIFF
--- a/src/datastore_mad/remotes/vmfs/monitor
+++ b/src/datastore_mad/remotes/vmfs/monitor
@@ -45,16 +45,23 @@ unset i XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/BASE_PATH \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/ABSOLUTE_PATH \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST)
 
 BASE_PATH="${XPATH_ELEMENTS[0]}"
-BRIDGE_LIST="${XPATH_ELEMENTS[1]}"
+ABSOLUTE_PATH="${XPATH_ELEMENTS[1]}"
+BRIDGE_LIST="${XPATH_ELEMENTS[2]}"
 
 HOST=`get_destination_host`
 
 if [ -z "$HOST" ]; then
     error_message "Datastore template missing 'BRIDGE_LIST' attribute."
     exit -1
+fi
+
+# if ABSOLUTE_PATH is defined in the database template use it instead of auto-generated BASE_PATH
+if [ ! -z "$ABSOLUTE_PATH" ]; then
+  BASE_PATH=$ABSOLUTE_PATH
 fi
 
 # ------------ Compute datastore usage -------------


### PR DESCRIPTION
$> onedatastore show 1
DATASTORE 1 INFORMATION  
ID             : 1  
[...]
BASE PATH      : /vmfs/volumes/ds1/1
[...]
DATASTORE TEMPLATE  
BASE_PATH="/vmfs/volumes/ds1/"
BRIDGE_LIST="esxi_host1 esxi_host2"
CLONE_TARGET="SYSTEM"
DISK_TYPE="FILE"
DS_MAD="vmfs"
LN_TARGET="NONE"
TM_MAD="vmfs"
TYPE="IMAGE_DS"

above settings doesn't work because:

/vmfs/volumes/ds1 had already been mounted by esxi host (not to /vmfs/volumes/1). Setting BASE_PATH to /vmfs/volumes/ds1 means vmfs/monitor monitors /vmfs/volumes/ds1/1 which doesn't show in "df" output, hence capacity is unknown which results in not being able to download an image from the marketplace -- which by the way the import process returns no disk space available error (something in that nature) which is not true.

setting ABSOLUTE_PATH to /vmfs/volumes/ds1 and this change fix this inability to calculate the capacity issue.

this change enables users to use premounted esxi datastores.
