### PR TITLE
Debian init: add optional dependency on mysql

### DIFF
--- a/share/pkgs/Debian/opennebula
+++ b/share/pkgs/Debian/opennebula
@@ -3,6 +3,8 @@
 # Provides:          opennebula
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
+# Should-Start:      mysql
+# Should-Stop:       mysql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: OpenNebula init script

--- a/share/pkgs/Ubuntu/opennebula
+++ b/share/pkgs/Ubuntu/opennebula
@@ -3,6 +3,8 @@
 # Provides:          opennebula
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
+# Should-Start:      mysql
+# Should-Stop:       mysql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: OpenNebula init script


### PR DESCRIPTION
Debian with insserv use dependency based boot sequence.

“Required-Start” and “Required-Stop” can not be used because MySQL may
not be available.

* share/pkgs/Debian/opennebula: Add the “Should-Start” and “Should-Stop”
  on MySQL.

* share/pkgs/Ubuntu/opennebula: Ditoo.