### PR TITLE
Do not override global sudo configuration

### DIFF
--- a/share/pkgs/CentOS/opennebula.sudoers
+++ b/share/pkgs/CentOS/opennebula.sudoers
@@ -1,5 +1,5 @@
-Defaults !requiretty
-Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+Defaults:oneadmin !requiretty
+Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /usr/sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip
@@ -9,4 +9,3 @@ Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm
 
 oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN
-

--- a/share/pkgs/Debian/opennebula.sudoers
+++ b/share/pkgs/Debian/opennebula.sudoers
@@ -1,5 +1,5 @@
-Defaults !requiretty
-Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+Defaults:oneadmin !requiretty
+Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip

--- a/share/pkgs/Ubuntu/opennebula.sudoers
+++ b/share/pkgs/Ubuntu/opennebula.sudoers
@@ -1,5 +1,5 @@
-Defaults !requiretty
-Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+Defaults:oneadmin !requiretty
+Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip

--- a/share/pkgs/openSUSE/opennebula.sudoers
+++ b/share/pkgs/openSUSE/opennebula.sudoers
@@ -1,5 +1,5 @@
-Defaults !requiretty
-Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+Defaults:oneadmin !requiretty
+Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /usr/bin/dd, /sbin/mkfs, /usr/bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /usr/sbin/ebtables, /usr/sbin/iptables, /sbin/ip


### PR DESCRIPTION
The actual sudo configuration apply globally and can conflict with
system configuration.

* share/pkgs/CentOS/opennebula.sudoers: Limit the “!requiretty” and
  “secure_path” to user oneadmin.

* share/pkgs/Debian/opennebula.sudoers: Ditoo.

* share/pkgs/Ubuntu/opennebula.sudoers: Ditoo.

* share/pkgs/openSUSE/opennebula.sudoers: Ditoo.