### PR TITLE
Remove possible copy&paste mistake

### DIFF
--- a/src/cli/oneimage
+++ b/src/cli/oneimage
@@ -97,7 +97,7 @@ cmd=CommandParser::CmdParser.new(ARGV) do
 
             oneimage create -d default centOS.tmpl
 
-          - new image "arch" using a path of type centOS:
+          - new image "arch" using a path:
 
             oneimage create -d default --name arch --path /tmp/arch.img
 


### PR DESCRIPTION
The command shows how to create a new image using a path to the image
so the comment should reflect that. I guess the removed words "of type centOS" are ether a copy & paste mistake or it should state that the default type of an image is OS. But this should better be documented whithin the "## OPTIONS" section. 
Should i open a pull-request with added documentation about the cli parameter defaults? 

best wishes,
Matthias