### PR TITLE
Check if an given image is readable in oneimage.

### DIFF
--- a/src/cli/one_helper/oneimage_helper.rb
+++ b/src/cli/one_helper/oneimage_helper.rb
@@ -86,10 +86,10 @@ class OneImageHelper < OpenNebulaHelper::OneHelper
                     path=Dir.pwd+"/"+o
                 end
 
-                if File.exist?(path)
+                if File.readable?(path)
                     [0, path]
                 else
-                    [-1, "File '#{path}' does not exist."]
+                    [-1, "File '#{path}' does not exist or is not readable."]
                 end
             end
         },


### PR DESCRIPTION
When running "oneimage create --path .." the tool should check not only
for the existence but also for the readability of the given image.
If the image is unreadable (one user create the image an other tries to
upload it) the image will be created in ERROR state in the datastore.

Best wishes,
Matthias