### PR TITLE
rstrip! the endpoint as well

### DIFF
--- a/src/oca/ruby/opennebula/client.rb
+++ b/src/oca/ruby/opennebula/client.rb
@@ -143,6 +143,8 @@ module OpenNebula
             else
                 @one_endpoint = "http://localhost:2633/RPC2"
             end
+            
+            @one_endpoint.rstrip!
 
             @async = !options[:sync]
 


### PR DESCRIPTION
I kept getting bad URI error when loading the endpoint from a file because there was a trailing newline. This fixes that problem.