### PR TITLE
remotes kvm.rb probe improvement

### DIFF
--- a/src/im_mad/remotes/kvm-probes.d/kvm.rb
+++ b/src/im_mad/remotes/kvm-probes.d/kvm.rb
@@ -43,7 +43,7 @@ nodeinfo_text.split(/\n/).each{|line|
 #   for everything else, top & proc
 #####
 
-NETINTERFACE = "eth|bond|em|enp2|p[0-9]+p[0-9]+"
+NETINTERFACE = "eth|bond|em|enp|p[0-9]+p[0-9]+"
 
 stat = `cat /proc/stat`
 

--- a/src/im_mad/remotes/kvm-probes.d/kvm.rb
+++ b/src/im_mad/remotes/kvm-probes.d/kvm.rb
@@ -50,7 +50,7 @@ stat = `cat /proc/stat`
 stat.each_line do |line|
   if /\Acpu (.*)\Z/.match(line)
     stat_cpu = Regexp.last_match[1].to_s.split
-    stat_total_cpu = stat_cpu.inject(0) {|s,sum| sum.to_i+s.to_i}.to_i
+    stat_total_cpu = stat_cpu.inject(0) {|sum,s| sum.to_i+s.to_i}.to_i
     $free_cpu = $total_cpu * stat_cpu[3].to_f / stat_total_cpu
     $used_cpu = $total_cpu - $free_cpu
   end

--- a/src/im_mad/remotes/kvm-probes.d/kvm.rb
+++ b/src/im_mad/remotes/kvm-probes.d/kvm.rb
@@ -26,7 +26,9 @@ end
 #  TODO : use virsh freecell when available
 ######
 
-nodeinfo_text = `LANG=C virsh -c qemu:///system nodeinfo`
+ENV['LANG'] = 'C'
+
+nodeinfo_text = `virsh -c qemu:///system nodeinfo`
 exit(-1) if $?.exitstatus != 0
 
 nodeinfo_text.split(/\n/).each{|line|

--- a/src/im_mad/remotes/kvm-probes.d/kvm.rb
+++ b/src/im_mad/remotes/kvm-probes.d/kvm.rb
@@ -40,22 +40,15 @@ nodeinfo_text.split(/\n/).each{|line|
 }
 
 ######
-#   for everything else, top & proc
-#####
+#  CPU
+######
+vmstat = `vmstat 1 2`
+$free_cpu = $total_cpu * ((vmstat.split("\n").to_a.last.split)[14].to_i)/100
+$used_cpu = $total_cpu - $free_cpu
 
-NETINTERFACE = "eth|bond|em|enp|p[0-9]+p[0-9]+"
-
-stat = `cat /proc/stat`
-
-stat.each_line do |line|
-  if /\Acpu (.*)\Z/.match(line)
-    stat_cpu = Regexp.last_match[1].to_s.split
-    stat_total_cpu = stat_cpu.inject(0) {|sum,s| sum.to_i+s.to_i}.to_i
-    $free_cpu = $total_cpu * stat_cpu[3].to_f / stat_total_cpu
-    $used_cpu = $total_cpu - $free_cpu
-  end
-end
-
+######
+#  MEMORY
+######
 memory = `cat /proc/meminfo`
 meminfo = Hash.new()
 memory.each_line do |line|
@@ -67,6 +60,11 @@ $total_memory = meminfo['MemTotal']
 
 $used_memory = meminfo['MemTotal'] - meminfo['MemFree'] - meminfo['Buffers'] - meminfo['Cached']
 $free_memory = $total_memory - $used_memory
+
+######
+#  INTERFACE
+######
+NETINTERFACE = "eth|bond|em|enp|p[0-9]+p[0-9]+"
 
 net_text=`cat /proc/net/dev`
 exit(-1) if $?.exitstatus != 0


### PR DESCRIPTION
Arch Linux have enp* interfaces.
`free -k` have different output on Arch Linux system, that's why i rewrite memory collecting to /proc/meminfo.
<pre>
free -k
              total        used        free      shared  buff/cache   available
Mem:       32804976    23918256      425892      965480     8460828     7586596
Swap:             0           0           0
</pre>
And in current code calculating cpu usage from `top -bin2` output parsed wrong when system locale set to something else than en_EN. Commas instead of dots when `LANG=ru_RU.UTF-8`:
<pre>
%Cpu(s):  1,3 us,  0,5 sy,  0,0 ni, 98,1 id,  0,0 wa,  0,0 hi,  0,0 si,  0,0 st
</pre>
There are all this values in `/proc/stat`.