### PR TITLE
Bug #3829 Memory leak in onehost update - added missing delete

### DIFF
--- a/src/pool/PoolObjectSQL.cc
+++ b/src/pool/PoolObjectSQL.cc
@@ -280,6 +280,8 @@ int PoolObjectSQL::append_template(
         return -1;
     }
 
+    delete old_tmpl;
+
     return 0;
 }
 

--- a/src/pool/PoolObjectSQL.cc
+++ b/src/pool/PoolObjectSQL.cc
@@ -223,6 +223,8 @@ int PoolObjectSQL::replace_template(
         return -1;
     }
 
+    delete old_tmpl;
+
     return 0;
 }
 


### PR DESCRIPTION
To confirm, run Michael's test script. Tested using the 4.12.0 OpenNebula sandbox.