### PR TITLE
fixed typo 'shoback'=>'showback'

### DIFF
--- a/src/sunstone/etc/sunstone-views/admin.yaml
+++ b/src/sunstone/etc/sunstone-views/admin.yaml
@@ -84,7 +84,7 @@ tabs:
             group_quotas_tab: true
             group_providers_tab: true
             group_accounting_tab: true
-            group_shoback_tab: true
+            group_showback_tab: true
         table_columns:
             - 0         # Checkbox
             - 1         # ID

--- a/src/sunstone/etc/sunstone-views/admin_vcenter.yaml
+++ b/src/sunstone/etc/sunstone-views/admin_vcenter.yaml
@@ -84,7 +84,7 @@ tabs:
             group_quotas_tab: true
             group_providers_tab: true
             group_accounting_tab: true
-            group_shoback_tab: true
+            group_showback_tab: true
         table_columns:
             - 0         # Checkbox
             - 1         # ID

--- a/src/sunstone/etc/sunstone-views/user.yaml
+++ b/src/sunstone/etc/sunstone-views/user.yaml
@@ -85,7 +85,7 @@ tabs:
             group_quotas_tab: true
             group_providers_tab: true
             group_accounting_tab: true
-            group_shoback_tab: true
+            group_showback_tab: true
         table_columns:
             - 0         # Checkbox
             - 1         # ID


### PR DESCRIPTION
See Bug #3844: http://dev.opennebula.org/issues/3844

src/sunstone/public/js/plugins/groups-tab.js expects 'showback'.