### PR TITLE
feature-3060: enable disk discard option for qemu-kvm

### DIFF
--- a/share/man/onevm.1
+++ b/share/man/onevm.1
@@ -67,6 +67,8 @@
  \-\-cache cache_mode        Hypervisor cache mode: default, none,
                            writethrough, writeback, directsync or unsafe\.
                            (Only KVM driver)
+ \-\-discard discard_mode    Hypervisor discard mode: ignore or unmap\.
+                           (Only KVM driver)
  \-n, \-\-network id|name     Selects the virtual network
  \-i, \-\-ip ip               IP address for the new NIC
  \-l, \-\-list x,y,z          Selects columns to display with list command
@@ -370,7 +372,7 @@ disk\-attach \fIvmid\fR Attaches a disk to a running VM\. When using \-\-file ad
 .nf
 
 States: RUNNING
-valid options: file, image, target, cache
+valid options: file, image, target, cache, discard
 .
 .fi
 .

--- a/src/cli/onevm
+++ b/src/cli/onevm
@@ -79,6 +79,14 @@ cmd=CommandParser::CmdParser.new(ARGV) do
             " writeback, directsync or unsafe. (Only KVM driver)"
     }
 
+    DISCARD={
+        :name => "discard",
+        :large => "--discard discard_mode",
+        :format => String,
+        :description => "Hypervisor discard mode: ignore or unmap."<<
+            " (Only KVM driver)"
+    }
+
     ENFORCE={
         :name  => "enforce",
         :short => "-e",
@@ -590,7 +598,7 @@ cmd=CommandParser::CmdParser.new(ARGV) do
 
     command :"disk-attach", disk_attach_desc, :vmid,
             :options => [OneVMHelper::FILE, OneVMHelper::IMAGE,
-                         TARGET, CACHE, PREFIX] do
+                         TARGET, CACHE, DISCARD, PREFIX] do
 
         if options[:file].nil? and options[:image].nil?
             STDERR.puts "Provide a template file or an image:"
@@ -616,6 +624,10 @@ cmd=CommandParser::CmdParser.new(ARGV) do
 
             if options[:cache]
                 template<<", CACHE = \"#{options[:cache]}\""
+            end
+
+            if options[:discard]
+                template<<", DISCARD = \"#{options[:discard]}\""
             end
 
             template << " ]"

--- a/src/sunstone/public/app/tabs/templates-tab/form-panels/create/wizard-tabs/storage/disk-tab/html.hbs
+++ b/src/sunstone/public/app/tabs/templates-tab/form-panels/create/wizard-tabs/storage/disk-tab/html.hbs
@@ -143,6 +143,17 @@
       </select>
     </div>
     <div class="large-6 columns hypervisor only_kvm">
+      <label for="DISCARD">
+        {{tr "DISCARD"}}
+        <span class="tip">{{tr "Set DISCARD feature."}}</span>
+      </label>
+      <select wizard_field="DISCARD" id="DISCARD" name="DISCARD">
+        <option value=""></option>
+        <option value="ignore">{{tr "ignore"}}</option>
+        <option value="unmap">{{tr "unmap"}}</option>
+      </select>
+    </div>
+    <div class="large-6 columns hypervisor only_kvm">
       <label for="TOTAL_BYTES_SEC">
         {{tr "Total Bytes Sec"}}
         <span class="tip">

--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -119,6 +119,7 @@ int LibVirtDriver::deployment_description_kvm(
     string  driver          = "";
     string  cache           = "";
     string  disk_io         = "";
+    string  discard         = "";
     string  source          = "";
     string  clone           = "";
     string  ceph_host       = "";
@@ -146,6 +147,7 @@ int LibVirtDriver::deployment_description_kvm(
     string  default_driver          = "";
     string  default_driver_cache    = "";
     string  default_driver_disk_io  = "";
+    string  default_driver_discard  = "";
     bool    readonly;
 
     const VectorAttribute * nic;
@@ -408,6 +410,9 @@ int LibVirtDriver::deployment_description_kvm(
 
     get_default("DISK", "IO", default_driver_disk_io);
 
+    get_default("DISK", "DISCARD", default_driver_discard);
+
+
     get_default("DISK", "TOTAL_BYTES_SEC", default_total_bytes_sec);
     get_default("DISK", "READ_BYTES_SEC", default_read_bytes_sec);
     get_default("DISK", "WRITE_BYTES_SEC", default_write_bytes_sec);
@@ -434,6 +439,7 @@ int LibVirtDriver::deployment_description_kvm(
         driver          = disk->vector_value("DRIVER");
         cache           = disk->vector_value("CACHE");
         disk_io         = disk->vector_value("IO");
+        discard         = disk->vector_value("DISCARD");
         source          = disk->vector_value("SOURCE");
         clone           = disk->vector_value("CLONE");
 
@@ -643,6 +649,20 @@ int LibVirtDriver::deployment_description_kvm(
         else if ( !default_driver_disk_io.empty() )
         {
             file << " io='" << default_driver_disk_io << "'";
+        }
+
+       if ( !discard.empty() || !default_driver_discard.empty() )
+       {
+            file << "' discard='";
+
+            if ( !discard.empty() )
+            {
+                file << discard << "'";
+            }
+            else
+            {
+                file << default_driver_discard << "'";
+            }
         }
 
         file << "/>" << endl;

--- a/src/vmm_mad/exec/vmm_exec_kvm.conf
+++ b/src/vmm_mad/exec/vmm_exec_kvm.conf
@@ -21,7 +21,7 @@
 #  - os [kernel,initrd,boot,root,kernel_cmd,arch,machine]
 #  - vcpu
 #  - features [acpi, pae, apic, hyperv, localtime]
-#  - disk [driver, cache, io, total_bytes_sec, total_iops_sec, read_bytes_sec, write_bytes_sec, read_iops_sec, write_iops_sec]
+#  - disk [driver, cache, io, discard, total_bytes_sec, total_iops_sec, read_bytes_sec, write_bytes_sec, read_iops_sec, write_iops_sec]
 #  - nic  [filter, model]
 #  - raw
 #  - hyperv_options: options used for FEATURES = [ HYPERV = yes ]

--- a/src/vmm_mad/remotes/kvm/attach_disk
+++ b/src/vmm_mad/remotes/kvm/attach_disk
@@ -44,6 +44,7 @@ done < <($XPATH     /VMM_DRIVER_ACTION_DATA/VM/ID \
                     $DISK_XPATH/TYPE \
                     $DISK_XPATH/READONLY \
                     $DISK_XPATH/CACHE \
+                    $DISK_XPATH/DISCARD \
                     $DISK_XPATH/SOURCE \
                     $DISK_XPATH/DISK_ID \
                     $DISK_XPATH/CLONE \
@@ -56,6 +57,7 @@ DRIVER="${XPATH_ELEMENTS[j++]:-$DEFAULT_TYPE}"
 TYPE="${XPATH_ELEMENTS[j++]}"
 READONLY="${XPATH_ELEMENTS[j++]}"
 CACHE="${XPATH_ELEMENTS[j++]}"
+DISCARD="${XPATH_ELEMENTS[j++]}"
 IMG_SRC="${XPATH_ELEMENTS[j++]}"
 DISK_ID="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
@@ -127,6 +129,10 @@ esac
     CACHE="$DEFAULT_ATTACH_CACHE"
 [ -n "$CACHE" ] && CACHE="cache='$CACHE'"
 
+[ -z "$DISCARD" ] && [ -n "$DEFAULT_ATTACH_DISCARD" ] && \
+    DISCARD="$DEFAULT_ATTACH_DISCARD"
+[ -n "$DISCARD" ] && DISCARD="discard='$DISCARD'"
+
 if [ "$READONLY" = "YES" ]; then
     READONLY="<readonly/>"
 else
@@ -135,7 +141,7 @@ fi
 
 cat <<EOF > $ATTACH_FILE
 <disk type='$TYPE_XML' device='$DEVICE'>
-  <driver name='qemu' type='$DRIVER' $CACHE/>
+  <driver name='qemu' type='$DRIVER' $CACHE $DISCARD/>
   <source $TYPE_SOURCE='$SOURCE' $SOURCE_ARGS>
   $SOURCE_HOST
   </source>

--- a/src/vmm_mad/remotes/kvm/kvmrc
+++ b/src/vmm_mad/remotes/kvm/kvmrc
@@ -37,3 +37,11 @@ export SHUTDOWN_TIMEOUT=300
 
 # Uncomment this line to set options for the virsh migrate command
 #MIGRATE_OPTIONS=--unsafe
+
+# IDE and SCSI disks always have the ability to issue "discard"
+# (aka TRIM or UNMAP) commands. However, by default "discard" commands are
+# silently ignored as they can cause performance degradation and fragmentation.
+# To enable them, the "-drive" option now supports a "discard" suboption; the
+# default value is "ignore" (or its synonym "off"), and the other valid value
+# is "unmap" (or "on").
+#DEFAULT_ATTACH_DISCARD=unmap


### PR DESCRIPTION
This is proposed solution for feature in Backlog #3060 (http://dev.opennebula.org/issues/3060)

By default this feature is not touching the xml configuration for backward compatibility.

There is global VM config in vmm/remotes/kvm/kvmrc named `DEFAULT_ATTACH_DISCARD` that if set will enforce the discard option to all VMs if there is no configuranito per template.

It is possible to enable the discard feature per VM in their template by adding
`DISCARD=unmap`
to enable and
`DISCARD=ignore`
to disable the discard