### PR TITLE
fix default group bug in get_groups()

### DIFF
--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -180,8 +180,6 @@ class OpenNebula::LdapAuth
         [@user['memberOf']].flatten.each do |group|
             if @mapping[group]
                 groups << @mapping[group]
-            else
-                groups << @options[:mapping_default]
             end
         end
 


### PR DESCRIPTION
Users should only be added to the default group if it's defined and the user's groups aren't mapped (ie get_groups() is empty). This is correctly handled by the `remotes/auth/ldap/authenticate` script by checking whether or not get_groups returns an empty list.