### PR TITLE
add LISTEN_ADDRESS config for oned XMLRPC

### DIFF
--- a/include/RequestManager.h
+++ b/include/RequestManager.h
@@ -51,6 +51,7 @@ public:
             int _timeout,
             const string _xml_log_file,
             const string call_log_format,
+            const string _listen_address,
             int message_size);
 
     ~RequestManager(){};
@@ -140,6 +141,11 @@ private:
      *  Filename for the log of the xmlrpc server that listens
      */
     string xml_log_file;
+
+    /**
+     *  Specifies the address xmlrpc server will bind to
+     */
+    string listen_address;
 
     /**
      *  Action engine for the Manager

--- a/share/etc/oned.conf
+++ b/share/etc/oned.conf
@@ -28,6 +28,7 @@
 #  scripts.
 #
 #  PORT: Port where oned will listen for xmlrpc calls.
+#  LISTEN_ADDRESS: Host IP to listen on for xmlrpc calls (default: all IPs).
 #
 #  DB: Configuration attributes for the database backend
 #   backend : can be sqlite or mysql (default is sqlite)
@@ -71,6 +72,8 @@ MONITORING_THREADS  = 50
 SCRIPTS_REMOTE_DIR=/var/tmp/one
 
 PORT = 2633
+
+LISTEN_ADDRESS = "0.0.0.0"
 
 DB = [ backend = "sqlite" ]
 

--- a/src/nebula/Nebula.cc
+++ b/src/nebula/Nebula.cc
@@ -871,8 +871,10 @@ void Nebula::start(bool bootstrap_only)
         string log_call_format;
         string rpc_filename = "";
         int  message_size;
+        string rm_listen_address = "0.0.0.0";
 
         nebula_configuration->get("PORT", rm_port);
+        nebula_configuration->get("LISTEN_ADDRESS", rm_listen_address);
         nebula_configuration->get("MAX_CONN", max_conn);
         nebula_configuration->get("MAX_CONN_BACKLOG", max_conn_backlog);
         nebula_configuration->get("KEEPALIVE_TIMEOUT", keepalive_timeout);
@@ -889,7 +891,7 @@ void Nebula::start(bool bootstrap_only)
 
         rm = new RequestManager(rm_port, max_conn, max_conn_backlog,
             keepalive_timeout, keepalive_max_conn, timeout, rpc_filename,
-            log_call_format, message_size);
+            log_call_format, rm_listen_address, message_size);
     }
     catch (bad_alloc&)
     {

--- a/src/nebula/NebulaTemplate.cc
+++ b/src/nebula/NebulaTemplate.cc
@@ -105,6 +105,7 @@ void OpenNebulaTemplate::set_conf_default()
 #  VM_INDIVIDUAL_MONITORING
 #  VM_PER_INTERVAL
 #  VM_MONITORING_EXPIRATION_TIME
+#  LISTEN_ADDRESS
 #  PORT
 #  DB
 #  VNC_BASE_PORT
@@ -158,6 +159,12 @@ void OpenNebulaTemplate::set_conf_default()
     value = "2633";
 
     attribute = new SingleAttribute("PORT",value);
+    conf_default.insert(make_pair(attribute->name(),attribute));
+
+    //XML-RPC Server listen address
+    value = "0.0.0.0";
+
+    attribute = new SingleAttribute("LISTEN_ADDRESS",value);
     conf_default.insert(make_pair(attribute->name(),attribute));
 
     //DB CONFIGURATION


### PR DESCRIPTION
This allows oned's XMLRPC server to listen on specific interfaces instead of all interfaces. This is useful for binding oned to localhost and using an HTTPS proxy to secure XMLRPC without requiring iptables to restrict unsecured public access. The new `LISTEN_ADDRESS` config defaults to `0.0.0.0` (ie `INADDR_ANY`) for backwards compatibility.