### PR TITLE
Sunstone kerberos support

### DIFF
--- a/src/cloud/common/CloudAuth.rb
+++ b/src/cloud/common/CloudAuth.rb
@@ -23,6 +23,7 @@ class CloudAuth
         "sunstone"   => 'SunstoneCloudAuth' ,
         "ec2"        => 'EC2CloudAuth',
         "x509"       => 'X509CloudAuth',
+        "remote"     => 'RemoteCloudAuth',
         "opennebula" => 'OpenNebulaCloudAuth',
         "onegate"    => 'OneGateCloudAuth'
     }

--- a/src/cloud/common/CloudAuth/RemoteCloudAuth.rb
+++ b/src/cloud/common/CloudAuth/RemoteCloudAuth.rb
@@ -14,7 +14,6 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
-require 'opennebula/x509_auth'
 
 module RemoteCloudAuth
     def do_auth(env, params={})

--- a/src/cloud/common/CloudAuth/RemoteCloudAuth.rb
+++ b/src/cloud/common/CloudAuth/RemoteCloudAuth.rb
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2015, OpenNebula Project (OpenNebula.org), C12G Labs        #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+require 'opennebula/x509_auth'
+
+module RemoteCloudAuth
+    def do_auth(env, params={})
+        # For Kerberos, the web service should be set to include the remote_user in the environment.
+        remote_user   = env['REMOTE_USER']
+        remote_user   = nil if remote_user == '(null)'
+
+        # Use the https credentials for authentication
+        unless remote_user.nil?
+            # Password should be REMOTE_USER itself.
+            username = get_username(remote_user)
+            if username
+                return username
+            else
+                raise "Username not found in local database: " + remote_user
+            end
+        else
+            raise "REMOTE_USER not found in local environment"
+        end
+
+        return nil
+    end
+end

--- a/src/sunstone/views/login.erb
+++ b/src/sunstone/views/login.erb
@@ -19,7 +19,7 @@
 
   <body>
 
-    <% if settings.config[:auth] == "x509" %>
+    <% if (settings.config[:auth] == "x509") || (settings.config[:auth] == "remote") %>
     <%= erb :_login_x509 %>
     <% else %>
     <%= erb :_login_standard %>


### PR DESCRIPTION
This PR includes a new sunstone auth script called `remote` to support Kerberos/freeip. It's similar to X509 auth, the auth work is still done by apache. Kerberos users should be included using x509 auth using username@DOMAIN instead of certificate DNs.