### PR TITLE
Bug #4125: Probes cleaned by systemd-tmpfiles

### DIFF
--- a/share/pkgs/CentOS7/opennebula-node.conf
+++ b/share/pkgs/CentOS7/opennebula-node.conf
@@ -1,0 +1,1 @@
+x /var/tmp/one/*


### PR DESCRIPTION
Add systemd-tmpfiles exemption for /var/tmp/one to prevent tmpfiles from cleaning the probes.  This was tested by reducing the timer on /usr/lib/tmpfiles.d/tmp.conf and adding this exclusion to some nodes but not all.

The idea was to include this in the opennebula-node-kvm package.