### PR TITLE
allow block devices for SYSTEM_DS images

### DIFF
--- a/src/datastore/Datastore.cc
+++ b/src/datastore/Datastore.cc
@@ -344,12 +344,12 @@ int Datastore::set_ds_disk_type(string& s_dt, string& error)
             {
                 //Valid disk types for System DS
                 case Image::FILE:
+                case Image::BLOCK:
                 case Image::RBD:
                     break;
 
                 case Image::GLUSTER:
                 case Image::SHEEPDOG:
-                case Image::BLOCK:
                 case Image::CD_ROM:
                 case Image::RBD_CDROM:
                 case Image::SHEEPDOG_CDROM:


### PR DESCRIPTION
There are block devices that can be used as system datastore like:

CLVM
iSCSI
StorPool

This patch is in need to test and develop our addon against the 'master' branch.
Probably better solution is to have the list of supported devices as list in the configuration files.