### PR TITLE
fix ISO symlink for VMware CDROMs

### DIFF
--- a/src/tm_mad/common/context
+++ b/src/tm_mad/common/context
@@ -101,7 +101,8 @@ exec_and_set_error "$SCP $ISO_FILE $DST" "Error copying context ISO to $DST"
 [ -n "$ERROR" ] && exit_error
 
 # Creates symbolic link to add a .iso suffix, needed for VMware CDROMs
-ssh_exec_and_log $DST_HOST "$LN -sf $DST_PATH $DST_PATH.iso" "Error creating ISO symbolic link"
+DST_FILE=${DST_PATH##*/}
+ssh_exec_and_log $DST_HOST "cd $DST_DIR && $LN -sf $DST_FILE $DST_FILE.iso" "Error creating ISO symbolic link"
 
 rm -rf $ISO_DIR > /dev/null 2>&1
 


### PR DESCRIPTION
While digging another issue, I've spot that when there is SYSTEM_DS migration (at least on the shared TM_MAD) the symlink became broken because it is pointing to the absolute path, which is not available after the migration.

The proposed patch is creating the symlink relative so there is no issue when the absolute path is changed.

The patch is against current master branch but the issue exists in the current stable (4.14.2) too.