### PR TITLE
bug #4276: Fix snap_create for qcow2

### DIFF
--- a/src/tm_mad/qcow2/snap_create
+++ b/src/tm_mad/qcow2/snap_create
@@ -76,7 +76,7 @@ set -ex
 
 mkdir -p "${SNAP_DIR}"
 
-PREVIOUS_SNAP=$(readlink $SYSTEM_DS_DISK_PATH)
+PREVIOUS_SNAP=\$(readlink $SYSTEM_DS_DISK_PATH)
 
 qemu-img create -f qcow2 -b "\${PREVIOUS_SNAP}" "${SNAP_PATH}"
 ln -sf $SNAP_PATH $SYSTEM_DS_DISK_PATH


### PR DESCRIPTION
Previous snapshots should be looked up on the remote host.