### PR TITLE
Bug #4337: IP spoofing filters DHCP communication

### DIFF
--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -271,6 +271,7 @@ module SGIPTables
 
         # IP-spofing
         if nic[:filter_ip_spoofing] == "YES"
+            commands.add :iptables, "-A #{chain_out} -p udp --source 0.0.0.0/32 --sport 68 --destination 255.255.255.255/32 --dport 67 -j ACCEPT"
             commands.add :iptables, "-A #{chain_out} ! --source #{nic[:ip]} -j DROP"
         end
 


### PR DESCRIPTION
Don't filter UDP DHCP traffic from 0.0.0.0/32 port 68 to
255.255.255.255/32 port 67.