### PR TITLE
Fixed restart-sched in opennebula init script

### DIFF
--- a/share/pkgs/Debian7/opennebula
+++ b/share/pkgs/Debian7/opennebula
@@ -106,7 +106,7 @@ case "$1" in
     do_stop_sched
     case "$?" in
       0|1)
-        do_start
+        do_start_sched
         case "$?" in
             0) log_end_msg 0 ;;
             1) log_end_msg 1 ;; # Old process is still running

--- a/share/pkgs/Debian8/opennebula
+++ b/share/pkgs/Debian8/opennebula
@@ -106,7 +106,7 @@ case "$1" in
     do_stop_sched
     case "$?" in
       0|1)
-        do_start
+        do_start_sched
         case "$?" in
             0) log_end_msg 0 ;;
             1) log_end_msg 1 ;; # Old process is still running

--- a/share/pkgs/Ubuntu/opennebula
+++ b/share/pkgs/Ubuntu/opennebula
@@ -106,7 +106,7 @@ case "$1" in
     do_stop_sched
     case "$?" in
       0|1)
-        do_start
+        do_start_sched
         case "$?" in
             0) log_end_msg 0 ;;
             1) log_end_msg 1 ;; # Old process is still running


### PR DESCRIPTION
Fixing wrong use of `do_start` in restart-sched routine.