### PR TITLE
Proposal: changing lvremove behavior

### DIFF
--- a/share/pkgs/CentOS/opennebula.sudoers
+++ b/share/pkgs/CentOS/opennebula.sudoers
@@ -3,7 +3,7 @@ Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /usr/sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip, /usr/sbin/ipset
-Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay
+Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange
 Cmnd_Alias ONE_ISCSI = /sbin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm

--- a/share/pkgs/Debian7/opennebula.sudoers
+++ b/share/pkgs/Debian7/opennebula.sudoers
@@ -3,7 +3,7 @@ Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip, /usr/sbin/ipset
-Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay
+Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange
 Cmnd_Alias ONE_ISCSI = /usr/bin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm

--- a/share/pkgs/Debian8/opennebula.sudoers
+++ b/share/pkgs/Debian8/opennebula.sudoers
@@ -3,7 +3,7 @@ Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip, /sbin/ipset
-Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay
+Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange
 Cmnd_Alias ONE_ISCSI = /usr/bin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm

--- a/share/pkgs/Ubuntu/opennebula.sudoers
+++ b/share/pkgs/Ubuntu/opennebula.sudoers
@@ -3,7 +3,7 @@ Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /bin/dd, /sbin/mkfs, /bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip, /sbin/ipset
-Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay
+Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange
 Cmnd_Alias ONE_ISCSI = /usr/bin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm

--- a/share/pkgs/openSUSE/opennebula.sudoers
+++ b/share/pkgs/openSUSE/opennebula.sudoers
@@ -3,7 +3,7 @@ Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 Cmnd_Alias ONE_MISC = /usr/bin/dd, /sbin/mkfs, /usr/bin/sync
 Cmnd_Alias ONE_NET = /sbin/brctl, /usr/sbin/ebtables, /usr/sbin/iptables, /sbin/ip
-Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay
+Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvrename, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange
 Cmnd_Alias ONE_ISCSI = /sbin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm

--- a/share/sudoers/sudo_commands.rb
+++ b/share/sudoers/sudo_commands.rb
@@ -22,7 +22,7 @@ require "erb"
 CMDS = {
     :MISC  => %w(dd mkfs sync),
     :NET   => %w(brctl ebtables iptables ip ipset),
-    :LVM   => %w(lvcreate lvremove lvrename lvs vgdisplay),
+    :LVM   => %w(lvcreate lvremove lvrename lvs vgdisplay lvchange),
     :ISCSI => %w(iscsiadm tgt-admin tgtadm),
     :OVS   => %w(ovs-ofctl ovs-vsctl),
     :XEN   => %w(xentop xl xm),

--- a/src/mad/sh/scripts_common.sh
+++ b/src/mad/sh/scripts_common.sh
@@ -31,6 +31,7 @@ ISCSIADM=${ISCSIADM:-iscsiadm}
 LVCREATE=${LVCREATE:-lvcreate}
 LVREMOVE=${LVREMOVE:-lvremove}
 LVRENAME=${LVRENAME:-lvrename}
+LVCHANGE=${LVCHANGE:-lvchange}
 LVS=${LVS:-lvs}
 LN=${LN:-ln}
 MD5SUM=${MD5SUM:-md5sum}

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -46,7 +46,8 @@ DELETE_CMD=$(cat <<EOF
     # remove link
     rm -f $DST_PATH
 
-    $SUDO $LVREMOVE -f \$DEV
+    $SUDO $LVCHANGE -an \$DEV
+    $SUDO $LVREMOVE \$DEV
 EOF
 )
 


### PR DESCRIPTION
PROPOSAL:
lvremove -f can lead to race conditions at udev making all the lvm commands to hang indefinitely.

Nowadays lvm defaults to retry_deactivation = 1 at lvm.conf, which lvremove uses and theoretically should mitigate this.
However I recently had issues even with retry_deactivation.

Probably a safer bet is to deactivate the volume before removing it, if the deactivation fails the removal process should fail.
This way even if the -f behavior change in the future we will be OK.

In OpenNebula's lvm use case this shouldn't have side effects, however feedback is needed on this.
