### PR TITLE
Fix output of `econe-describe-addresses`

### DIFF
--- a/src/cloud/ec2/bin/econe-describe-addresses
+++ b/src/cloud/ec2/bin/econe-describe-addresses
@@ -34,7 +34,7 @@ require 'econe/EC2QueryClient'
 include CloudCLI
 
 TABLE = CLIHelper::ShowTable.new(nil, self) do
-    column :publicIp, "publicIp", :size=>10 do |d|
+    column :publicIp, "publicIp", :size=>15 do |d|
         d["publicIp"]
     end
 


### PR DESCRIPTION
The current with of the IP address column is too small: The IP address "192.168.1.64", for instance, is 12 characters long, and gets truncated to "192.168.1.". Reserving 15 should do:

    irb(main):001:0> "XXX.XXX.XXX.XXX".length
    => 15
    irb(main):002:0>