### PR TITLE
fix parsing of Authorization header

### DIFF
--- a/src/cloud/common/CloudAuth/EC2CloudAuth.rb
+++ b/src/cloud/common/CloudAuth/EC2CloudAuth.rb
@@ -22,7 +22,7 @@ module EC2CloudAuth
             abstract_request = Rack::Auth::AbstractRequest.new(req_env)
             auth_attrs = {}
             if abstract_request.scheme == "aws4-hmac-sha256"
-                abstract_request.params.split(', ').each { |attr|
+                abstract_request.params.gsub(', ', ',').split(',').each { |attr|
                     key, value = attr.split('=')
                     auth_attrs[key] = value
                 }


### PR DESCRIPTION
Econe server fails with 
```
<NoMethodError: undefined method `split' for nil:NilClass>
```
when using some clients (ec2 Ansible modules for example). The problem
lies in parsing Authentication header format.

Euca sends:
```
Credential=tom/20160425/undefined-19606/ec2/aws4_request, SignedHeaders=accept;accept-encoding;connection;content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=fsomehash8cda2
```

Ansible EC2 module sends:
```
Credential=tom/20160425/servers/one/aws4_request,SignedHeaders=host;x-amz-date,Signature=6b2ccdsomehash39f2fc555
```

Previous implementation fails when fields are separated with "," (without space). Documentation [1] for AWS API says "are separated by a comma" so there should be just comma, but I'd prefer to maintain compatibility with euca and convert headers (remove spaces after comma).

[1] http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html