### PR TITLE
Update kvm.rb to fix localization bug

### DIFF
--- a/src/im_mad/remotes/kvm-probes.d/kvm.rb
+++ b/src/im_mad/remotes/kvm-probes.d/kvm.rb
@@ -27,6 +27,7 @@ end
 ######
 
 ENV['LANG'] = 'C'
+ENV['LC_ALL'] = 'C'
 
 nodeinfo_text = `virsh -c qemu:///system nodeinfo`
 exit(-1) if $?.exitstatus != 0


### PR DESCRIPTION
The LANG environment variable does not work as expected with virsh -c qemu:///system nodeinfo. But LC_ALL=C works fine.
Without LC_ALL=C monitoring fails with a "Error monitoring Host hostname (0): ./kvm.rb:49: undefined method `*' for nil:NilClass (NoMethodError)".

Server configuration:
OS: CentOS 6.2
OpenNebula: 4.14.2
Default language: ru_RU.UTF-8

Bug example:
LANG=C virsh -c qemu:///system nodeinfo
Модель процессора: x86_64
CPU:                 16
Частота процессора: 1600 MHz
Сокеты:        1
Ядер на сокет: 4
Потоков на ядро: 2
Ячейки NUMA:   2
Объём памяти: 74237932 KiB

Correct behavior:
LC_ALL=C virsh -c qemu:///system nodeinfo
CPU model:           x86_64
CPU(s):              16
CPU frequency:       1600 MHz
CPU socket(s):       1
Core(s) per socket:  4
Thread(s) per core:  2
NUMA cell(s):        2
Memory size:         74237932 KiB