### PR TITLE
Revert "Fix VM ID parsing in `associate_address()`"

### DIFF
--- a/src/cloud/ec2/lib/elastic_ip.rb
+++ b/src/cloud/ec2/lib/elastic_ip.rb
@@ -119,7 +119,8 @@ module ElasticIP
 
         user_id = retrieve_uid
         eip     = params["PublicIp"]
-        vmid    = params['InstanceId'].sub(/^i\-0*/, '')
+        vmid    = params['InstanceId']
+        vmid    = vmid.split('-')[1] if vmid[0]==?i
 
         unless vnet["TEMPLATE/EC2_ADDRESSES[IP=\"#{eip}\" and UID=\"#{retrieve_uid}\"]/IP"]
             rc = OpenNebula::Error.new("address:#{eip} does not exist")


### PR DESCRIPTION
Reverts OpenNebula/one#88 . Keeping parsing and moving id conversion to other places, as in other econe fucntions