### PR TITLE
Remove orders attributes when removing boot orders

### DIFF
--- a/src/vm/VirtualMachine.cc
+++ b/src/vm/VirtualMachine.cc
@@ -282,22 +282,6 @@ error_previous_history:
 
 static void set_boot_order(Template * tmpl)
 {
-	VectorAttribute * os = tmpl->get("OS");
-
-    if ( os == 0 )
-    {
-        return;
-    }
-
-    string order = os->vector_value("BOOT");
-
-    if ( order.empty() )
-    {
-        return;
-    }
-
-	vector<string> bdevs = one_util::split(order, ',');
-
     vector<VectorAttribute *> disk;
     vector<VectorAttribute *> nic;
 
@@ -313,6 +297,22 @@ static void set_boot_order(Template * tmpl)
     {
         nic[i]->remove("ORDER");
     }
+    
+    VectorAttribute * os = tmpl->get("OS");
+
+    if ( os == 0 )
+    {
+        return;
+    }
+
+    string order = os->vector_value("BOOT");
+
+    if ( order.empty() )
+    {
+        return;
+    }
+
+    vector<string> bdevs = one_util::split(order, ',');
 
     int index = 1;
 


### PR DESCRIPTION
This is to make sure that the ORDER attribute is removed correctly for disks and nics if we remove OS = [ BOOT = "disk0,...." ] from the XML template of the VM.