### PR TITLE
im/monitor_ds.sh skip broken symlinks

### DIFF
--- a/src/im_mad/remotes/common.d/monitor_ds.sh
+++ b/src/im_mad/remotes/common.d/monitor_ds.sh
@@ -44,6 +44,8 @@ for ds in $dirs; do
 
     dir=$DATASTORE_LOCATION/$ds
 
+    test -d "$dir" || continue
+
     USED_MB=$(df -B1M -P $dir 2>/dev/null | tail -n 1 | awk '{print $3}')
     TOTAL_MB=$(df -B1M -P $dir 2>/dev/null | tail -n 1 | awk '{print $2}')
     FREE_MB=$(df -B1M -P $dir 2>/dev/null | tail -n 1 | awk '{print $4}')


### PR DESCRIPTION
Most probably my test setup is too weird but if you have
_/var/lib/one/datastores_ shared on all hosts and want to have 
SYSTEM datastore with TM_MAD on one of the hosts, I am doing the following:

```
mkdir -p /var/lib/one-local/102
ln -s /var/lib/one-local/102 /var/lib/one/datastores/102
```

This way I have "local" datastore nested in "shared" filesystem.

In the above scenario on all other hosts the symlink is dead.

The proposed patch test the is the $dir directory and continue only if it is indeed directory.