### PR TITLE
fix for bug #4593

### DIFF
--- a/src/lcm/LifeCycleStates.cc
+++ b/src/lcm/LifeCycleStates.cc
@@ -682,10 +682,14 @@ void LifeCycleManager::prolog_success_action(int vid)
                     vm->set_state(VirtualMachine::BOOT_MIGRATE);
                     break;
 
-                case VirtualMachine::PROLOG:
-                case VirtualMachine::PROLOG_FAILURE: //recover success
                 case VirtualMachine::PROLOG_MIGRATE_UNKNOWN:
                 case VirtualMachine::PROLOG_MIGRATE_UNKNOWN_FAILURE: //recover success
+                    vm->set_previous_reason(History::USER);
+                    vm->set_previous_action(History::MIGRATE_ACTION);
+                    vmpool->update_previous_history(vm);
+
+                case VirtualMachine::PROLOG:
+                case VirtualMachine::PROLOG_FAILURE: //recover success
                     action = VirtualMachineManager::DEPLOY;
                     vm->set_state(VirtualMachine::BOOT);
                     break;


### PR DESCRIPTION
Hi Developers,
http://dev.opennebula.org/issues/4593
When VM in UNKNOWN state is rescheduled it can not be migrated anymore because a check in VirtualMachineMigrate::request_execute is not satisfied due to previous history record not closed properly.
https://github.com/OpenNebula/one/blob/master/src/rm/RequestManagerVirtualMachine.cc#L1097

The suggested patch updates(closes) previous history record properly (I hope) and the VM is in proper state then.

Kind Regards,
Anton Todorov