### PR TITLE
fix for FT action when host is in ERROR state

### DIFF
--- a/src/tm_mad/ssh/mv
+++ b/src/tm_mad/ssh/mv
@@ -71,6 +71,11 @@ log "Moving $SRC to $DST"
 ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
     "Error removing target path to prevent overwrite errors"
 
+if [ `lcm_state` -eq 60 ]; then
+    log "Not moving files from $SRC_HOST in FT mode"
+    exit 0
+fi
+
 TAR_COPY="$SSH $SRC_HOST '$TAR -C $SRC_DS_DIR --sparse -cf - $SRC_VM_DIR'"
 TAR_COPY="$TAR_COPY | $SSH $DST_HOST '$TAR -C $DST_DIR --sparse -xf -'"
 


### PR DESCRIPTION
Following https://forum.opennebula.org/t/vm-fails-to-ha-reschedule-on-host-error-opennebula-5-0-1/2566

Skip access to the source host when called in LCM_STATE=PROLOG_MIGRATE_UNKNOWN because the source host is not reachable.

It is used in CEPH's TM_MAD but I think it is OK for SSH too.