### PR TITLE
MAD scripts must log command outputs

### DIFF
--- a/src/mad/ruby/scripts_common.rb
+++ b/src/mad/ruby/scripts_common.rb
@@ -59,7 +59,7 @@ module OpenNebula
     # If a second parameter is present it is used as the error message when
     # the command fails
     def self.exec_and_log(command, message=nil)
-        output=`#{command} 2>&1 1>/dev/null`
+        output=`#{command} 2>&1`
         code=$?.exitstatus
 
         if code!=0

--- a/src/mad/sh/scripts_common.sh
+++ b/src/mad/sh/scripts_common.sh
@@ -136,7 +136,7 @@ function exec_and_log
 {
     message=$2
 
-    EXEC_LOG_ERR=`$1 2>&1 1>/dev/null`
+    EXEC_LOG_ERR=`$1 2>&1`
     EXEC_LOG_RC=$?
 
     if [ $EXEC_LOG_RC -ne 0 ]; then
@@ -187,7 +187,7 @@ function multiline_exec_and_log
 {
     message=$2
 
-    EXEC_LOG_ERR=`bash -s 2>&1 1>/dev/null <<EOF
+    EXEC_LOG_ERR=`bash -s 2>&1 <<EOF
 export LANG=C
 export LC_ALL=C
 $1
@@ -212,7 +212,7 @@ function exec_and_set_error
 {
     message=$2
 
-    EXEC_LOG_ERR=$(bash -c "$1" 2>&1 1>/dev/null)
+    EXEC_LOG_ERR=$(bash -c "$1" 2>&1)
     EXEC_LOG_RC=$?
 
     export ERROR=""
@@ -333,7 +333,7 @@ function mkfs_command {
 #This function executes $2 at $1 host and report error $3
 function ssh_exec_and_log
 {
-    SSH_EXEC_ERR=`$SSH $1 bash -s 2>&1 1>/dev/null <<EOF
+    SSH_EXEC_ERR=`$SSH $1 bash -s 2>&1 <<EOF
 export LANG=C
 export LC_ALL=C
 $2
@@ -360,7 +360,7 @@ EOF`
 # $4: ERROR_REPORT
 function ssh_exec_and_log_stdin
 {
-    SSH_EXEC_ERR=`$SSH $1 bash -s 2>&1 1>/dev/null <<EOF
+    SSH_EXEC_ERR=`$SSH $1 bash -s 2>&1 <<EOF
 export LANG=C
 export LC_ALL=C
 $(cat $3)
@@ -414,7 +414,7 @@ EOF
 # file ".monitor" in the directory. Used for local disk monitoring
 function ssh_make_path
 {
-    SSH_EXEC_ERR=`$SSH $1 bash -s 2>&1 1>/dev/null <<EOF
+    SSH_EXEC_ERR=`$SSH $1 bash -s 2>&1 <<EOF
 set -e -o pipefail
 if [ ! -d $2 ]; then
    mkdir -p $2


### PR DESCRIPTION
Actually the “EXEC_LOG_ERR” variable is always empty since we redirect
stderr to stdout and then redirect stdout to /dev/null.

* src/mad/ruby/scripts_common.rb (OpenNebula.exec_and_log): Do not
  redirect stdout to /dev/null.

* src/mad/sh/scripts_common.sh (exec_and_log): Ditoo.
  (multiline_exec_and_log): Ditoo.
  (exec_and_set_error): Ditoo.
  (ssh_exec_and_log): Ditoo.
  (ssh_exec_and_log_stdin): Ditoo.
  (ssh_make_path): Ditoo.