### PR TITLE
Feature #3510: authorize “EMULATOR” in VM TEMPLATE

### DIFF
--- a/src/vm/VirtualMachine.cc
+++ b/src/vm/VirtualMachine.cc
@@ -472,6 +472,18 @@ int VirtualMachine::insert(SqlDB * db, string& error_str)
     }
 
     // ------------------------------------------------------------------------
+    // Check for EMULATOR attribute
+    // ------------------------------------------------------------------------
+
+    user_obj_template->get("EMULATOR", value);
+
+    if (!value.empty())
+    {
+        user_obj_template->erase("EMULATOR");
+        obj_template->add("EMULATOR", value);
+    }
+
+    // ------------------------------------------------------------------------
     // Check for CPU, VCPU and MEMORY attributes
     // ------------------------------------------------------------------------
 

--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -379,11 +379,15 @@ int LibVirtDriver::deployment_description_kvm(
     // ------------------------------------------------------------------------
     file << "\t<devices>" << endl;
 
-    get_default("EMULATOR",emulator_path);
-
+    vm->get_template_attribute("EMULATOR", emulator_path);
     if(emulator_path.empty())
     {
-        emulator_path = "/usr/bin/kvm";
+        get_default("EMULATOR",emulator_path);
+
+        if(emulator_path.empty())
+        {
+            emulator_path = "/usr/bin/kvm";
+        }
     }
 
     file << "\t\t<emulator>" << one_util::escape_xml(emulator_path)


### PR DESCRIPTION
* src/vm/VirtualMachine.cc (insert): Add “EMULATOR” to the list of
  VM attributes understood by opennebula.

* src/vmm/LibVirtDriverKVM.cc (deployment_description_kvm): Get
  “EMULATOR” from VM template first, then from default and finally from
  hardcoded path.

Thanks Vladislav Gorbunov for the patch