### PR TITLE
Update failmigrate

### DIFF
--- a/src/tm_mad/ceph/failmigrate
+++ b/src/tm_mad/ceph/failmigrate
@@ -55,6 +55,27 @@ fi
 
 migrate_other "$@"
 
+#--------------------------------------------------------------------------------
+
+# Get custom datastore values
+DRIVER_PATH=$(dirname "$0")
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+unset XPATH_ELEMENTS i j
+
+while IFS= read -r -d '' element; do
+  XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x "$DSID" | $XPATH \
+  /DATASTORE/TEMPLATE/SHARED)
+
+SHARED="${XPATH_ELEMENTS[j++]}"
+
+if [ "$SHARED" = "YES" ]; then
+    exit 0
+fi
+
+#--------------------------------------------------------------------------------
+
 ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
     "Error removing target path to prevent overwrite errors"
 

--- a/src/tm_mad/ceph/failmigrate
+++ b/src/tm_mad/ceph/failmigrate
@@ -1,1 +1,61 @@
-../common/failmigrate
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2016, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# FAILMIGRATE SOURCE DST remote_system_dir vmid dsid template
+#  - SOURCE is the host where the VM is running
+#  - DST is the host where the VM is to be migrated
+#  - remote_system_dir is the path for the VM home in the system datastore
+#  - vmid is the id of the VM
+#  - dsid is the target datastore
+#  - template is the template of the VM in XML and base64 encoded
+
+SRC_HOST=$1
+DST_HOST=$2
+
+DST_PATH=$3
+
+VMID=$4
+DSID=$5
+
+TEMPLATE_64=$6
+
+#--------------------------------------------------------------------------------
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+fi
+
+source $TMCOMMON
+
+#--------------------------------------------------------------------------------
+
+if [ "$SRC_HOST" == "$DST_HOST" ]; then
+    log "Not moving $SRC_HOST to $DST_HOST, they are the same host"
+    exit 0
+fi
+
+#--------------------------------------------------------------------------------
+
+migrate_other "$@"
+
+ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
+    "Error removing target path to prevent overwrite errors"
+
+exit 0

--- a/src/tm_mad/fs_lvm/failmigrate
+++ b/src/tm_mad/fs_lvm/failmigrate
@@ -1,1 +1,63 @@
-../common/failmigrate
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2016, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# POSTMIGRATE SOURCE DST remote_system_dir vmid dsid template
+#  - SOURCE is the host where the VM is running
+#  - DST is the host where the VM is to be migrated
+#  - remote_system_dir is the path for the VM home in the system datastore
+#  - vmid is the id of the VM
+#  - dsid is the target datastore
+#  - template is the template of the VM in XML and base64 encoded
+
+SRC_HOST=$1
+DST_HOST=$2
+
+DST_PATH=$3
+
+VMID=$4
+DSID=$5
+
+TEMPLATE_64=$6
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+fi
+
+. $TMCOMMON
+
+CMD=$(cat <<EOF
+    set -ex -o pipefail
+    $SUDO $SYNC
+    $SUDO $LVSCAN
+
+    for disk in \$(ls ${DST_PATH}/disk.*); do
+        if [ -L "\$disk" ]; then
+            DEVICE=\$(readlink "\$disk")
+
+            $SUDO $LVCHANGE -an \$DEVICE
+        fi
+    done
+EOF
+)
+
+ssh_exec_and_log $DST_HOST "$CMD" \
+    "Error running fs_lvm failmigrate"
+
+migrate_other "$@"

--- a/src/tm_mad/qcow2/failmigrate
+++ b/src/tm_mad/qcow2/failmigrate
@@ -1,1 +1,1 @@
-../common/failmigrate
+../common/prepostmigrate

--- a/src/tm_mad/shared/failmigrate
+++ b/src/tm_mad/shared/failmigrate
@@ -1,1 +1,1 @@
-../common/failmigrate
+../common/prepostmigrate

--- a/src/tm_mad/ssh/failmigrate
+++ b/src/tm_mad/ssh/failmigrate
@@ -1,1 +1,1 @@
-../common/failmigrate
+../common/prepostmigrate


### PR DESCRIPTION
It is obvious that I've totally missed the tm/failmigrate script when proposed the migrate_other function

Here are three commits:
- tm/fs_lvm - besides the call of migrate_other() I think it is good idea to deactivate the LVM volumes enabled by the  `tm/fs_lvm/premigrate` on DST_HOST
- tm/ceph/failmigrate - same as for the above commit - I believe it is good to clean up the DST_HOST if the live-migration fails
- tm/{qcow2,shared,ssh} - do migrate_other() when failmigrate

Kind Regards,
Anton Todorov
