### PR TITLE
Fix typo. Networks should be Templates

### DIFF
--- a/src/sunstone/public/app/utils/vcenter/templates.js
+++ b/src/sunstone/public/app/utils/vcenter/templates.js
@@ -140,8 +140,8 @@ define(function(require) {
 
             VCenterCommon.setupTable({
               context : newdiv,
-              allSelected : Locale.tr("All %1$s Networks selected."),
-              selected: Locale.tr("%1$s Networks selected.")
+              allSelected : Locale.tr("All %1$s Templates selected."),
+              selected: Locale.tr("%1$s Templates selected.")
             });
 
             context.off('click', '.clear_imported');


### PR DESCRIPTION
WARNING: "All %1$s Templates selected." and "%1$s Templates selected." should be added to messages so they can be translated in Transifex. I'm not sure how to do that so I won't be editing that locale files.