### PR TITLE
fix issue when cloning qcow2 images

### DIFF
--- a/src/tm_mad/qcow2/clone
+++ b/src/tm_mad/qcow2/clone
@@ -104,8 +104,8 @@ else
 
     CLONE_CMD=$(cat <<EOF
 cd $DST_DIR
+rm -rf $DST_PATH{,.snap}
 mkdir -p ${DST_PATH}.snap
-rm -f $DST_PATH
 $QEMU_IMG create -b $SRC_PATH -f qcow2 $QCOW2_OPTIONS ${DST_PATH}.snap/0
 ln -s ${DST_FILE}.snap/0 ${DST_PATH}
 cd ${DST_PATH}.snap


### PR DESCRIPTION
Following this forum thread
https://forum.opennebula.org/t/opennebula-5-0-2-attach-detach-images-datastore-folder-not-cleaned-up/3111

Please let me know if you need it backported to 5.0.2 too