### PR TITLE
fix deleting qcow2 images

### DIFF
--- a/src/tm_mad/common/delete
+++ b/src/tm_mad/common/delete
@@ -48,7 +48,7 @@ delete_file=$(cat <<EOF
 [ -e "$DST_PATH" ] || exit 0
 
 times=10
-function="rm -rf $DST_PATH"
+function="rm -rf $DST_PATH{,.snap}"
 
 count=1
 


### PR DESCRIPTION
following this forum thread

https://forum.opennebula.org/t/opennebula-5-0-2-attach-detach-images-datastore-folder-not-cleaned-up/3111