### PR TITLE
tm/qcow2/ln fix cleanup before attach

### DIFF
--- a/src/tm_mad/qcow2/ln
+++ b/src/tm_mad/qcow2/ln
@@ -111,7 +111,7 @@ fi
 
 ln -sf "$SNAP_DIR/\$SNAP" "$DST_PATH"
 
-$RM -f "${DST_PATH}.snap"
+$RM -rf "${DST_PATH}.snap"
 ln -sf "$SNAP_DIR" "${DST_PATH}.snap"
 EOT
 )


### PR DESCRIPTION
Following this forum thread
https://forum.opennebula.org/t/opennebula-5-0-2-attach-detach-images-datastore-folder-not-cleaned-up/3111