### PR TITLE
tm/shared/clone cleanup artefacts before copy

### DIFF
--- a/src/tm_mad/shared/clone
+++ b/src/tm_mad/shared/clone
@@ -98,6 +98,7 @@ fi
 log "Cloning $SRC_PATH in $DST"
 
 CLONE_CMD="cd ${DST_DIR}; \
+    rm -rf ${DST_PATH}; \
     cp ${SRC_PATH} ${DST_PATH} \
     ${RESIZE_CMD}"
 


### PR DESCRIPTION
Following https://forum.opennebula.org/t/opennebula-5-0-2-attach-detach-images-datastore-folder-not-cleaned-up/3111

I count this fix as safeguard. IMO the _mvds_ script needs to be extended to cleanup the symlinks when persistent volume is detached.
