### PR TITLE
shared/mvds rm the symlink to the persistent img

### DIFF
--- a/src/tm_mad/shared/mvds
+++ b/src/tm_mad/shared/mvds
@@ -16,4 +16,36 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
+# mvds host:remote_system_ds/disk.i fe:SOURCE vmid dsid
+#   - fe is the front-end hostname
+#   - SOURCE is the path of the disk image in the form DS_BASE_PATH/disk
+#   - host is the target host to deploy the VM
+#   - remote_system_ds is the path for the system datastore in the host
+#   - vmid is the id of the VM
+#   - dsid is the target datastore (0 is the system datastore)
+
+SRC=$1
+DST=$2
+
+VMID=$3
+DSID=$4
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+fi
+
+. $TMCOMMON
+
+SRC_PATH="$(arg_path $SRC)"
+SRC_HOST="$(arg_host $SRC)"
+
+#-------------------------------------------------------------------------------
+# Removing $SRC_PATH from $SRC_HOST
+#-------------------------------------------------------------------------------
+
+log "Removing $SRC_PATH from $SRC_HOST"
+ssh_exec_and_log "$SRC_HOST" "$RM -rf $SRC_PATH{,.snap}" "Error removing $SRC_PATH from $SRC_HOST"
+
 exit 0


### PR DESCRIPTION
Again, following https://forum.opennebula.org/t/opennebula-5-0-2-attach-detach-images-datastore-folder-not-cleaned-up/3111/11?u=atodorov_storpool

I think that the patch to tm/shared/clone is safeguard and this is proper fix - cleanup the symlink to the persistent image here.

Not tested, but should work. Used ssh/mvds as donor.