### PR TITLE
Update vcenter mkfs - fix #4872

### DIFF
--- a/src/datastore_mad/remotes/vcenter/mkfs
+++ b/src/datastore_mad/remotes/vcenter/mkfs
@@ -48,12 +48,22 @@ img_name      = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/NAME"]
 
 if ds_name.nil? ||
    hostname.nil? ||
-   adapter_type.nil? ||
-   disk_type.nil? ||
    size.nil? ||
    img_name.nil?
     STDERR.puts "Not enough information to create the image."
     exit -1
+end
+
+# If no disk type disk it was chosen on Sunstone GUI
+# Default will be thin
+if disk_type.nil? or disk_type.empty?
+    disk_type = "thin"
+end
+
+# If no adpter it was chosen on Sunstone GUI
+# Default will be lsiLogic
+if adapter_type.nil? or adapter_type.empty?
+    adapter_type = "lsiLogic"
 end
 
 begin


### PR DESCRIPTION
Proposed fix to http://dev.opennebula.org/issues/4872#

Using Sunstone or CLI is not mandatory choose the **disk type** or **adpter type**. If not choose these params, this error happen.

> Tue Oct 18 17:07:34 2016 [Z0][ImM][I]: Not enough information to create the image.
> Tue Oct 18 17:07:34 2016 [Z0][ImM][I]: ExitCode: 255
> Tue Oct 18 17:07:34 2016 [Z0][ImM][E]: Error creating datablock
