### PR TITLE
Fix for http://dev.opennebula.org/issues/4656

### DIFF
--- a/src/cloud/ec2/lib/EC2QueryServer.rb
+++ b/src/cloud/ec2/lib/EC2QueryServer.rb
@@ -241,7 +241,7 @@ class EC2QueryServer < CloudServer
     private
 
     def render_launch_time(vm)
-        return "<launchTime>#{Time.at(vm["STIME"].to_i).xmlschema}</launchTime>"
+        return "<launchTime>#{Time.at(vm["STIME"].to_i).utc.xmlschema}</launchTime>"
     end
 end
 


### PR DESCRIPTION
By forcing the date to utc the xmlscheme function will return the date format expected by aws java sdk.
This works in my tests but i am not sure if it has impact to any other integration. As aws uses utc/zulu time stamps in every case it should be fine but i do not have enough insight into other integrations.
