### PR TITLE
vCenter :: Store empty block images in directory

### DIFF
--- a/src/datastore_mad/remotes/vcenter/clone
+++ b/src/datastore_mad/remotes/vcenter/clone
@@ -51,8 +51,10 @@ if ds_name.nil? || hostname.nil? || img_path.nil?
     exit -1
 end
 
-if folder_img[-1] != '/'
-    folder_img = folder_img.gsub(/$/, '/')
+if !folder_img.nil?
+    if folder_img[-1] != '/'
+        folder_img = folder_img.gsub(/$/, '/')
+    end
 end
 
 # Generate target path

--- a/src/datastore_mad/remotes/vcenter/clone
+++ b/src/datastore_mad/remotes/vcenter/clone
@@ -40,14 +40,19 @@ id             = ARGV[1]
 drv_action = OpenNebula::XMLElement.new
 drv_action.initialize_xml(Base64.decode64(drv_action_enc), 'DS_DRIVER_ACTION_DATA')
 
-ds_name  = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/NAME"]
-hostname = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/VCENTER_CLUSTER"]
-img_path = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/PATH"]
+ds_name    = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/NAME"]
+hostname   = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/VCENTER_CLUSTER"]
+img_path   = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/PATH"]
+folder_img = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/FOLDER_IMG"]
 
 if ds_name.nil? || hostname.nil? || img_path.nil?
     STDERR.puts "Not enough information to clone the image, missing datastore"\
                 " name or vcenter cluster name or image path."
     exit -1
+end
+
+if folder_img[-1] != '/'
+    folder_img = folder_img.gsub(/$/, '/')
 end
 
 # Generate target path
@@ -58,7 +63,7 @@ begin
     host_id      = VCenterDriver::VIClient.translate_hostname(hostname)
     vi_client    = VCenterDriver::VIClient.new host_id
 
-    puts vi_client.copy_virtual_disk(img_path, ds_name, target_path)
+    puts vi_client.copy_virtual_disk(img_path, ds_name, "#{folder_img}#{target_path}")
 rescue Exception => e
     STDERR.puts "Error cloning img #{img_path} size. Reason: #{e.message}"
     exit -1

--- a/src/datastore_mad/remotes/vcenter/mkfs
+++ b/src/datastore_mad/remotes/vcenter/mkfs
@@ -57,8 +57,10 @@ if ds_name.nil? ||
     exit -1
 end
 
-if folder_img[-1] != '/'
-    folder_img = folder_img.gsub(/$/, '/')
+if !folder_img.nil?
+    if folder_img[-1] != '/'
+        folder_img = folder_img.gsub(/$/, '/')
+    end
 end
 
 begin

--- a/src/datastore_mad/remotes/vcenter/mkfs
+++ b/src/datastore_mad/remotes/vcenter/mkfs
@@ -45,6 +45,7 @@ adapter_type  = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/ADAPTER_TYPE"]
 disk_type     = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/DISK_TYPE"]
 size          = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/SIZE"]
 img_name      = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/NAME"]
+folder_img    = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/FOLDER_IMG"]
 
 if ds_name.nil? ||
    hostname.nil? ||
@@ -56,17 +57,21 @@ if ds_name.nil? ||
     exit -1
 end
 
+if folder_img[-1] != '/'
+    folder_img = folder_img.gsub(/$/, '/')
+end
+
 begin
     host_id      = VCenterDriver::VIClient.translate_hostname(hostname)
     vi_client    = VCenterDriver::VIClient.new host_id
 
-    puts vi_client.create_virtual_disk(img_name,
+    puts vi_client.create_virtual_disk("#{folder_img}#{img_name}",
                                        ds_name,
                                        size,
                                        adapter_type,
                                        disk_type)
 rescue Exception => e
-    STDERR.puts "Error creating virtual disk in #{ds_name}."\
+    STDERR.puts "Error creating virtual disk #{folder_img}#{img_name} in #{ds_name}."\
                 " Reason: #{e.message}"
     exit -1
 end

--- a/src/datastore_mad/remotes/vcenter/rm
+++ b/src/datastore_mad/remotes/vcenter/rm
@@ -42,6 +42,11 @@ drv_action.initialize_xml(Base64.decode64(drv_action_enc), 'DS_DRIVER_ACTION_DAT
 ds_name       = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/NAME"]
 hostname      = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/VCENTER_CLUSTER"]
 img_src       = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/SOURCE"]
+folder_img    = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/FOLDER_IMG"]
+
+if folder_img[-1] != '/'
+    folder_img = folder_img.gsub(/$/, '/')
+end
 
 if ds_name.nil? ||
    hostname.nil? ||
@@ -54,10 +59,10 @@ begin
     host_id      = VCenterDriver::VIClient.translate_hostname(hostname)
     vi_client    = VCenterDriver::VIClient.new host_id
 
-    vi_client.delete_virtual_disk(img_src,
+    vi_client.delete_virtual_disk("#{folder_img}#{img_src}",
                                   ds_name)
 rescue Exception => e
-    STDERR.puts "Error delete virtual disk #{img_src} in #{ds_name}."\
+    STDERR.puts "Error delete virtual disk #{folder_img}#{img_src} in #{ds_name}."\
                 " Reason: #{e.message}"
     exit -1
 end

--- a/src/datastore_mad/remotes/vcenter/rm
+++ b/src/datastore_mad/remotes/vcenter/rm
@@ -42,11 +42,6 @@ drv_action.initialize_xml(Base64.decode64(drv_action_enc), 'DS_DRIVER_ACTION_DAT
 ds_name       = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/NAME"]
 hostname      = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/VCENTER_CLUSTER"]
 img_src       = drv_action["/DS_DRIVER_ACTION_DATA/IMAGE/SOURCE"]
-folder_img    = drv_action["/DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/FOLDER_IMG"]
-
-if folder_img[-1] != '/'
-    folder_img = folder_img.gsub(/$/, '/')
-end
 
 if ds_name.nil? ||
    hostname.nil? ||
@@ -59,10 +54,10 @@ begin
     host_id      = VCenterDriver::VIClient.translate_hostname(hostname)
     vi_client    = VCenterDriver::VIClient.new host_id
 
-    vi_client.delete_virtual_disk("#{folder_img}#{img_src}",
+    vi_client.delete_virtual_disk(img_src,
                                   ds_name)
 rescue Exception => e
-    STDERR.puts "Error delete virtual disk #{folder_img}#{img_src} in #{ds_name}."\
+    STDERR.puts "Error delete virtual disk #{img_src} in #{ds_name}."\
                 " Reason: #{e.message}"
     exit -1
 end


### PR DESCRIPTION
Proposed fix to add option to create empty block images on specified directory instead root directory

It is needed add FOLDER_IMG attribute on datastore.
![ds_option](https://cloud.githubusercontent.com/assets/1812609/19595391/86d9eda6-9768-11e6-9477-c504de718d57.png)
![data_store](https://cloud.githubusercontent.com/assets/1812609/19595393/86dc4eb6-9768-11e6-8cd1-8cfc0cf1ed17.png)
![image_attached](https://cloud.githubusercontent.com/assets/1812609/19595390/86d9ae72-9768-11e6-9cae-a1f481ab9f2c.png)
![images1](https://cloud.githubusercontent.com/assets/1812609/19595392/86dad518-9768-11e6-9397-f0fa99f7b3ed.png)
