### PR TITLE
regex match from the beginning to the end of the string in nic_deacti…

### DIFF
--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -328,7 +328,7 @@ module SGIPTables
 
         remove_chains = []
         iptables_s.lines.each do |line|
-            if line.match(/^-N #{chain}/)
+            if line.match(/^-N #{chain}$/)
                  remove_chains << line.split[1]
             end
         end
@@ -336,7 +336,7 @@ module SGIPTables
         remove_chains.each {|c| commands.add :iptables, "-X #{c}" }
 
         ipset_list.lines.each do |line|
-            if line.match(/^#{chain}/)
+            if line.match(/^#{chain}$/)
                 set = line.strip
                 commands.add :ipset, "destroy #{set}"
             end

--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -328,7 +328,7 @@ module SGIPTables
 
         remove_chains = []
         iptables_s.lines.each do |line|
-            if line.match(/^-N #{chain}$/)
+            if line.match(/^-N #{chain}(-|$)/)
                  remove_chains << line.split[1]
             end
         end
@@ -336,7 +336,7 @@ module SGIPTables
         remove_chains.each {|c| commands.add :iptables, "-X #{c}" }
 
         ipset_list.lines.each do |line|
-            if line.match(/^#{chain}$/)
+            if line.match(/^#{chain}(-|$)/)
                 set = line.strip
                 commands.add :ipset, "destroy #{set}"
             end


### PR DESCRIPTION
This fixes issue 4882. Actually, we just avoid that interface with id 10  matches lines.match(/^#{chain}/ for example. 
