### PR TITLE
vnm_mad: Use absolute instead of relative path to require scripts in vnmmad-load.d directory

### DIFF
--- a/src/vnm_mad/remotes/lib/vnmmad.rb
+++ b/src/vnm_mad/remotes/lib/vnmmad.rb
@@ -32,7 +32,7 @@ require 'sg_driver'
 require 'vlan'
 require 'scripts_common'
 
-Dir["vnmmad-load.d/*.rb"].each{ |f| require f }
+Dir[File.expand_path('vnmmad-load.d', File.dirname(__FILE__)) + "/*.rb"].each{ |f| require f }
 
 include OpenNebula
 


### PR DESCRIPTION
On hypervisor, scripts are located inside /var/tmp/one/vnm directory but executed from /var/lib/one directory and therefore, file require with relative path isn't working.