### PR TITLE
Fix duplicated NICs issue

### DIFF
--- a/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
+++ b/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
@@ -2589,8 +2589,7 @@ private
             vm.config.hardware.device.each{ |dv|
                 if is_nic?(dv)
                    nics.each{|nic|
-                      if nic.elements["MAC"].text == dv.macAddress and
-                         nic.elements["BRIDGE"].text == dv.deviceInfo.summary
+                      if nic.elements["MAC"].text == dv.macAddress
                          nics.delete(nic)
                       end
                    }


### PR DESCRIPTION
Remove the problematic nic.elements["BRIDGE"].text == dv.deviceInfo.summary which could duplicate NICs in certain circumstances.