### PR TITLE
Added support for specifying that the VNC port should be shared

### DIFF
--- a/src/sunstone/OpenNebulaVNC.rb
+++ b/src/sunstone/OpenNebulaVNC.rb
@@ -108,6 +108,7 @@ class OpenNebulaVNC
         @token_folder = File.join(VAR_LOCATION, opts[:token_folder_name])
         @proxy_path   = File.join(SHARE_LOCATION, "websockify/websocketproxy.py")
         @proxy_port   = config[:vnc_proxy_port]
+        @proxy_port_shared = config[:vnc_proxy_port_shared]
 
         @proxy_ipv6   = config[:vnc_proxy_ipv6]
 

--- a/src/sunstone/etc/sunstone-server.conf
+++ b/src/sunstone/etc/sunstone-server.conf
@@ -100,6 +100,8 @@
 ################################################################################
 # :vnc_proxy_
 #   port:           port where the vnc proxy will listen
+#   port_shared:    VNC proxy port will handled by the webserver and passed to
+#                   us
 #   support_wss:    no | yes | only. For yes and only, provide path to
 #                   cert and key. "yes" means both ws and wss connections will be
 #                   supported.
@@ -111,6 +113,7 @@
 #   Request VNC password for external windows, by default it will not be requested
 #
 :vnc_proxy_port: 29876
+:vnc_proxy_port_shared: no
 :vnc_proxy_support_wss: no
 :vnc_proxy_cert:
 :vnc_proxy_key:

--- a/src/sunstone/public/app/sunstone-config.js
+++ b/src/sunstone/public/app/sunstone-config.js
@@ -20,6 +20,28 @@ define(function(require) {
   // Clone the local config object in a private var
   var _config = $.extend(true, {}, config);
 
+  var vncProxyPort = window.location.port;
+  var vncWSS = "no";
+
+  if (_config['system_config']['vnc_proxy_port_shared'] == "yes") {
+    if (window.location.protocol.substring(0, 5) == 'http:') {
+      if (!vncProxyPort) {
+        vncProxyPort = 80;
+      }
+
+      vncWSS = "no";
+    } else if (window.location.protocol.substring(0, 6) == 'https:') {
+      if (!vncProxyPort) {
+        vncProxyPort = 443;
+      }
+
+      vncWSS = "yes";
+    }
+  } else {
+    vncProxyPort = _config['system_config']['vnc_proxy_port'];
+    vncWSS = _config['user_config']['vnc_wss'];
+  }
+
   var Config = {
     'isTabEnabled': function(tabName) {
       var enabled = _config['view']['enabled_tabs'].indexOf(tabName) != -1;
@@ -139,8 +161,8 @@ define(function(require) {
 
     'autoRefresh' : _config['view']['autorefresh'],
     'tableOrder': _config['user_config']['table_order'],
-    'vncProxyPort': _config['system_config']['vnc_proxy_port'],
-    'vncWSS': _config['user_config']['vnc_wss'],
+    'vncProxyPort': vncProxyPort,
+    'vncWSS': vncWSS,
     'requestVNCPassword': _config['system_config']['vnc_request_password'],
     'logo': (_config['view']["small_logo"] || "images/one_small_logo.png"),
     'vmLogos': (_config['vm_logos']),

--- a/src/sunstone/sunstone-server.rb
+++ b/src/sunstone/sunstone-server.rb
@@ -566,7 +566,8 @@ get '/config' do
         },
         :system_config => {
             :marketplace_url => $conf[:marketplace_url],
-            :vnc_proxy_port => $vnc.proxy_port
+            :vnc_proxy_port => $vnc.proxy_port,
+            :vnc_proxy_port_shared => $vnc.proxy_port_shared
         }
     }
 

--- a/src/sunstone/views/index.erb
+++ b/src/sunstone/views/index.erb
@@ -37,6 +37,7 @@
             'marketplace_url' : '<%= $conf[:marketplace_url] %>',
             'vnc_request_password' : <%= $conf[:vnc_request_password] || false %>,
             'vnc_proxy_port' : '<%= $vnc.proxy_port %>'
+            'vnc_proxy_port_shared' : '<%= $vnc.proxy_port_shared %>'
         },
         'view' : view,
         'available_views' : available_views,


### PR DESCRIPTION
Added support for specifying that the VNC port should be shared the webserver.

This requires some cooperation from the webserver to proxy websocket requests for the VNC/SPICE data to the OpenNebula websocket proxy.