### PR TITLE
Fix B4897 NIC is not removed from vCenter if you detach a NIC when in POWEROFF

### DIFF
--- a/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
+++ b/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
@@ -1815,11 +1815,6 @@ class VCenterVm
 
         vm.ReconfigVM_Task(:spec => spec).wait_for_completion
 
-        config_array << {
-                        :key    => 'opennebula.hotplugged_nics',
-                        :value  => hotplugged_nics
-                    }
-
     end
 
     ############################################################################


### PR DESCRIPTION
A new variable is used in the extraConfig section of a VM and it's called opennebula.hotplugged_nics 

That variable is used to track the mac addresses of those NICs that have been hot-plugged to that VM. If a VM has a hot-plugged NIC and goes to the POWEROFF state, if that NIC is detached in that state it's only removed from the XML file and it remains in vCenter.

To solve this issue, I check if there are MAC addresses in vCenter which are not inside the XML. I could remove all NICs from vCenter which were not in the XML but as OpenNebula can't see the NICs that are inside a template when it's imported, it could remove accidently those "invisible" NICs. The only way I've found acceptable is the use of extraConfig with the variable opennebula.hotplugged_nics. That way I can know which MAC addresses in vCenter satisfy that:
- they are not in the XML and
- they are not "invisible" nics
so they can be safely removed preventing duplicates.