### PR TITLE
F5484 Enhance StorageDRS allowing VM deployment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -992,6 +992,7 @@ TM_VCENTER_FILES="src/tm_mad/vcenter/clone \
                  src/tm_mad/vcenter/snap_delete \
                  src/tm_mad/vcenter/snap_revert \
                  src/tm_mad/vcenter/failmigrate \
+                 src/datastore_mad/remotes/vcenter/monitor \
                  src/tm_mad/vcenter/delete"
 
 TM_ISCSI_FILES="src/tm_mad/iscsi_libvirt/clone \

--- a/src/cli/onevcenter
+++ b/src/cli/onevcenter
@@ -203,7 +203,7 @@ cmd=CommandParser::CmdParser.new(ARGV) do
 
                     answer =  STDIN.gets.strip.downcase
 
-                    case answer 
+                    case answer
                     when 'd'
                       ds_split     = t[:ds].split("|")
                       list_of_ds   = ds_split[-2]
@@ -269,7 +269,7 @@ cmd=CommandParser::CmdParser.new(ARGV) do
 
                     answer =  STDIN.gets.strip.downcase
 
-                    case answer 
+                    case answer
                     when 'd'
                        list_of_rp   = rp_split[-2]
                        default_rp   = rp_split[-1]

--- a/src/datastore_mad/remotes/vcenter_downloader.rb
+++ b/src/datastore_mad/remotes/vcenter_downloader.rb
@@ -49,6 +49,12 @@ begin
 
     ds = vi_client.get_datastore(ds_name)
 
+    if ds.is_a? RbVmomi::VIM::StoragePod
+        STDERR.puts "Cannot download images from StoragePod #{ds_name} on #{hostname}."\
+                    "Reason: Not supported"
+        exit(-1)
+    end
+
     if ds.is_descriptor? img_src
         descriptor_name = File.basename u.path
         temp_folder = VAR_LOCATION + "/vcenter/" + descriptor_name + "/"

--- a/src/datastore_mad/remotes/vcenter_uploader.rb
+++ b/src/datastore_mad/remotes/vcenter_uploader.rb
@@ -40,6 +40,12 @@ begin
 
     ds = vi_client.get_datastore(ds_name)
 
+    if ds.is_a? RbVmomi::VIM::StoragePod
+        STDERR.puts "Cannot upload image to StoragePod #{ds_name} on #{hostname}."\
+                    "Reason: Not supported"
+        exit(-1)
+    end
+
     # Monkey path datastore objects. Can not be done patching the class
     # as the library redefines it when a new object is created. Using both
     # the database vmodl.db and the Datastore.rb


### PR DESCRIPTION
Now the StorageDRS cluster can be used to deploy (clone) a VM. StorageDRS is imported as SYSTEM DS so images can't be uploaded to it.