### PR TITLE
sunstone-server.conf session length parameter

### DIFF
--- a/src/sunstone/etc/sunstone-server.conf
+++ b/src/sunstone/etc/sunstone-server.conf
@@ -105,6 +105,8 @@
 :vnc_proxy_ipv6: false
 :vnc_request_password: false
 
+# Login Session Length in seconds, defaults to 1 hour.
+#:session_expire_time: 3600
 
 # Default language setting
 :lang: en_US

--- a/src/sunstone/sunstone-server.rb
+++ b/src/sunstone/sunstone-server.rb
@@ -47,8 +47,6 @@ $: << RUBY_LIB_LOCATION+'/cloud'
 $: << SUNSTONE_ROOT_DIR
 $: << SUNSTONE_ROOT_DIR+'/models'
 
-SESSION_EXPIRE_TIME = 60*60
-
 DISPLAY_NAME_XPATH = 'TEMPLATE/SUNSTONE/DISPLAY_NAME'
 TABLE_ORDER_XPATH = 'TEMPLATE/SUNSTONE/TABLE_ORDER'
 DEFAULT_VIEW_XPATH = 'TEMPLATE/SUNSTONE/DEFAULT_VIEW'
@@ -90,6 +88,9 @@ rescue Exception => e
 end
 
 $conf[:debug_level] ||= 3
+
+# Set Sunstone Session Timeout
+$conf[:session_expire_time] ||= 3600
 
 # Set the TMPDIR environment variable for uploaded images
 ENV['TMPDIR']=$conf[:tmpdir] if $conf[:tmpdir]
@@ -362,7 +363,7 @@ after do
             if params[:timeout] == "true"
                 env['rack.session.options'][:defer] = true
             else
-                env['rack.session.options'][:expire_after] = SESSION_EXPIRE_TIME
+                env['rack.session.options'][:expire_after] = $conf[:session_expire_time]
             end
         end
     end


### PR DESCRIPTION
exposed the sunstone session timeout so that it can be set in sunstone-server.conf