### PR TITLE
Ruby 2.4.0 raises an error if the cipher key is > 32 bytes.

### DIFF
--- a/src/authm_mad/remotes/server_cipher/server_cipher_auth.rb
+++ b/src/authm_mad/remotes/server_cipher/server_cipher_auth.rb
@@ -39,12 +39,12 @@ class OpenNebula::ServerCipherAuth
         @srv_passwd = srv_passwd
 
         if !srv_passwd.empty?
-            @key = Digest::SHA1.hexdigest(@srv_passwd)
+            @key = Digest::SHA1.hexdigest(@srv_passwd)[0,32]
         else
             @key = ""
         end
 
-        @cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
+        @cipher = OpenSSL::Cipher.new(CIPHER)
     end
 
     ###########################################################################

--- a/src/cloud/common/CloudAuth/OneGateCloudAuth.rb
+++ b/src/cloud/common/CloudAuth/OneGateCloudAuth.rb
@@ -25,7 +25,7 @@ module OneGateCloudAuth
     #
     def initialize_auth
         @conf[:use_user_pool_cache] = false
-        @cipher = OpenSSL::Cipher::Cipher.new(CIPHER)
+        @cipher = OpenSSL::Cipher.new(CIPHER)
     end
 
     def do_auth(env, params={})

--- a/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
+++ b/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
@@ -171,7 +171,7 @@ class VIClient
 
         if !@token.nil?
             begin
-                cipher = OpenSSL::Cipher::Cipher.new("aes-256-cbc")
+                cipher = OpenSSL::Cipher.new("aes-256-cbc")
 
                 cipher.decrypt
                 cipher.key = @token
@@ -2753,7 +2753,7 @@ private
                         return nil
                     end
 
-                    cipher = OpenSSL::Cipher::Cipher.new("aes-256-cbc")
+                    cipher = OpenSSL::Cipher.new("aes-256-cbc")
                     cipher.encrypt
                     cipher.key = token_password
                     onegate_token = cipher.update(str_to_encrypt)


### PR DESCRIPTION
Previous versions silently truncate this value to the first 32 bytes.

Also, OpenSSL::Cipher::Cipher has been deprecated in favor of OpenSSL::Cipher.

I've tested this changes ruby-1.8.7, ruby-2.0.0 and ruby-2.4.0