### PR TITLE
Bug #4969: Ceph driver for system datastore ignores SHARED=YES

### DIFF
--- a/src/tm_mad/ceph/postmigrate
+++ b/src/tm_mad/ceph/postmigrate
@@ -61,6 +61,12 @@ source $TMCOMMON
 
 #--------------------------------------------------------------------------------
 
+if [ "$SHARED" = "YES" ]; then
+    exit 0
+fi
+
+#--------------------------------------------------------------------------------
+
 if [ "$SRC_HOST" == "$DST_HOST" ]; then
     log "Not moving $SRC_HOST to $DST_HOST, they are the same host"
     exit 0
@@ -70,8 +76,6 @@ fi
 
 migrate_other "$@"
 
-if [ "$SHARED" != "YES" ]; then
-    exec_and_log "$SSH $SRC_HOST rm -rf $DST_PATH"
-fi
+exec_and_log "$SSH $SRC_HOST rm -rf $DST_PATH"
 
 exit 0

--- a/src/tm_mad/ceph/postmigrate
+++ b/src/tm_mad/ceph/postmigrate
@@ -36,6 +36,21 @@ TEMPLATE_64=$6
 
 #--------------------------------------------------------------------------------
 
+# Get custom datastore values
+DRIVER_PATH=$(dirname "$0")
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+unset XPATH_ELEMENTS i j
+
+while IFS= read -r -d '' element; do
+  XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x "$DSID" | $XPATH \
+  /DATASTORE/TEMPLATE/SHARED)
+
+SHARED="${XPATH_ELEMENTS[j++]:-$SHARED}"
+
+#--------------------------------------------------------------------------------
+
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
 else
@@ -55,6 +70,8 @@ fi
 
 migrate_other "$@"
 
-exec_and_log "$SSH $SRC_HOST rm -rf $DST_PATH"
+if [ "$SHARED" != "YES" ]; then
+    exec_and_log "$SSH $SRC_HOST rm -rf $DST_PATH"
+fi
 
 exit 0

--- a/src/tm_mad/ceph/postmigrate
+++ b/src/tm_mad/ceph/postmigrate
@@ -47,7 +47,7 @@ while IFS= read -r -d '' element; do
 done < <(onedatastore show -x "$DSID" | $XPATH \
   /DATASTORE/TEMPLATE/SHARED)
 
-SHARED="${XPATH_ELEMENTS[j++]:-$SHARED}"
+SHARED="${XPATH_ELEMENTS[j++]}"
 
 #--------------------------------------------------------------------------------
 

--- a/src/tm_mad/ceph/premigrate
+++ b/src/tm_mad/ceph/premigrate
@@ -47,7 +47,7 @@ while IFS= read -r -d '' element; do
 done < <(onedatastore show -x "$DSID" | $XPATH \
   /DATASTORE/TEMPLATE/SHARED)
 
-SHARED="${XPATH_ELEMENTS[j++]:-$SHARED}"
+SHARED="${XPATH_ELEMENTS[i++]}"
 
 #--------------------------------------------------------------------------------
 

--- a/src/tm_mad/ceph/premigrate
+++ b/src/tm_mad/ceph/premigrate
@@ -36,6 +36,21 @@ TEMPLATE_64=$6
 
 #--------------------------------------------------------------------------------
 
+# Get custom datastore values
+DRIVER_PATH=$(dirname "$0")
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+unset XPATH_ELEMENTS i j
+
+while IFS= read -r -d '' element; do
+  XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x "$DSID" | $XPATH \
+  /DATASTORE/TEMPLATE/SHARED)
+
+SHARED="${XPATH_ELEMENTS[j++]:-$SHARED}"
+
+#--------------------------------------------------------------------------------
+
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
 else
@@ -56,17 +71,19 @@ fi
 DST_PATH_DIRNAME=`dirname $DST_PATH`
 DST_PATH_BASENAME=`basename $DST_PATH`
 
-ssh_make_path "$DST_HOST" "$DST_PATH"
-
-log "Moving $SRC_HOST:$DST_PATH to $DST_HOST:$DST_PATH"
-
-ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
-    "Error removing target path to prevent overwrite errors"
-
-TAR_COPY="$SSH $SRC_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -cf - $DST_PATH_BASENAME'"
-TAR_COPY="$TAR_COPY | $SSH $DST_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -xf -'"
-
-exec_and_log "eval $TAR_COPY" "Error copying disk directory to target host"
+if [ "$SHARED" != "YES" ]; then
+    ssh_make_path "$DST_HOST" "$DST_PATH"
+    
+    log "Moving $SRC_HOST:$DST_PATH to $DST_HOST:$DST_PATH"
+    
+    ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
+        "Error removing target path to prevent overwrite errors"
+    
+    TAR_COPY="$SSH $SRC_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -cf - $DST_PATH_BASENAME'"
+    TAR_COPY="$TAR_COPY | $SSH $DST_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -xf -'"
+    
+    exec_and_log "eval $TAR_COPY" "Error copying disk directory to target host"
+fi
 
 migrate_other "$@"
 

--- a/src/tm_mad/ceph/premigrate
+++ b/src/tm_mad/ceph/premigrate
@@ -61,6 +61,12 @@ source $TMCOMMON
 
 #--------------------------------------------------------------------------------
 
+if [ "$SHARED" = "YES" ]; then
+    exit 0
+fi
+
+#--------------------------------------------------------------------------------
+
 if [ "$SRC_HOST" == "$DST_HOST" ]; then
     log "Not moving $SRC_HOST to $DST_HOST, they are the same host"
     exit 0
@@ -71,19 +77,17 @@ fi
 DST_PATH_DIRNAME=`dirname $DST_PATH`
 DST_PATH_BASENAME=`basename $DST_PATH`
 
-if [ "$SHARED" != "YES" ]; then
-    ssh_make_path "$DST_HOST" "$DST_PATH"
-    
-    log "Moving $SRC_HOST:$DST_PATH to $DST_HOST:$DST_PATH"
-    
-    ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
-        "Error removing target path to prevent overwrite errors"
-    
-    TAR_COPY="$SSH $SRC_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -cf - $DST_PATH_BASENAME'"
-    TAR_COPY="$TAR_COPY | $SSH $DST_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -xf -'"
-    
-    exec_and_log "eval $TAR_COPY" "Error copying disk directory to target host"
-fi
+ssh_make_path "$DST_HOST" "$DST_PATH"
+
+log "Moving $SRC_HOST:$DST_PATH to $DST_HOST:$DST_PATH"
+
+ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
+    "Error removing target path to prevent overwrite errors"
+
+TAR_COPY="$SSH $SRC_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -cf - $DST_PATH_BASENAME'"
+TAR_COPY="$TAR_COPY | $SSH $DST_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -xf -'"
+
+exec_and_log "eval $TAR_COPY" "Error copying disk directory to target host"
 
 migrate_other "$@"
 

--- a/src/tm_mad/ceph/premigrate
+++ b/src/tm_mad/ceph/premigrate
@@ -47,7 +47,7 @@ while IFS= read -r -d '' element; do
 done < <(onedatastore show -x "$DSID" | $XPATH \
   /DATASTORE/TEMPLATE/SHARED)
 
-SHARED="${XPATH_ELEMENTS[i++]}"
+SHARED="${XPATH_ELEMENTS[j++]}"
 
 #--------------------------------------------------------------------------------
 

--- a/src/tm_mad/ssh/mv
+++ b/src/tm_mad/ssh/mv
@@ -72,6 +72,10 @@ DST_DIR=`dirname $DST_PATH`
 SRC_DS_DIR=`dirname  $SRC_PATH`
 SRC_VM_DIR=`basename $SRC_PATH`
 
+if [ "$SHARED" = "YES" ]; then
+    exit 0
+fi
+
 if [ `is_disk $DST_PATH` -eq 1 ]; then
     exit 0
 fi
@@ -86,23 +90,21 @@ if [ `lcm_state` -eq 60 ]; then
     exit 0
 fi
 
-if [ "$SHARED" != "YES" ]; then
-    ssh_make_path "$DST_HOST" "$DST_DIR" "ssh"
-    
-    log "Moving $SRC to $DST"
-    
-    ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
-        "Error removing target path to prevent overwrite errors"
-    
-    TAR_SSH=$(cat <<EOF
-    set -e -o pipefail
-    
-    $TAR -C $SRC_DS_DIR --sparse -cf - $SRC_VM_DIR | $SSH $DST_HOST '$TAR -C $DST_DIR --sparse -xf -'
-    rm -rf $SRC_PATH
-    EOF
-    )
-    
-    ssh_exec_and_log "$SRC_HOST" "$TAR_SSH" "Error copying disk directory to target host"
-fi
+ssh_make_path "$DST_HOST" "$DST_DIR" "ssh"
+
+log "Moving $SRC to $DST"
+
+ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
+    "Error removing target path to prevent overwrite errors"
+
+TAR_SSH=$(cat <<EOF
+set -e -o pipefail
+
+$TAR -C $SRC_DS_DIR --sparse -cf - $SRC_VM_DIR | $SSH $DST_HOST '$TAR -C $DST_DIR --sparse -xf -'
+rm -rf $SRC_PATH
+EOF
+)
+
+ssh_exec_and_log "$SRC_HOST" "$TAR_SSH" "Error copying disk directory to target host"
 
 exit 0

--- a/src/tm_mad/ssh/mv
+++ b/src/tm_mad/ssh/mv
@@ -42,7 +42,7 @@ while IFS= read -r -d '' element; do
 done < <(onedatastore show -x "$DSID" | $XPATH \
   /DATASTORE/TEMPLATE/SHARED)
 
-SHARED="${XPATH_ELEMENTS[j++]:-$SHARED}"
+SHARED="${XPATH_ELEMENTS[j++]}"
 
 #--------------------------------------------------------------------------------
 

--- a/src/tm_mad/ssh/mv
+++ b/src/tm_mad/ssh/mv
@@ -29,6 +29,23 @@ DST=$2
 VMID=$3
 DSID=$4
 
+#--------------------------------------------------------------------------------
+
+# Get custom datastore values
+DRIVER_PATH=$(dirname "$0")
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+unset XPATH_ELEMENTS i j
+
+while IFS= read -r -d '' element; do
+  XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x "$DSID" | $XPATH \
+  /DATASTORE/TEMPLATE/SHARED)
+
+SHARED="${XPATH_ELEMENTS[j++]:-$SHARED}"
+
+#--------------------------------------------------------------------------------
+
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
 else
@@ -69,21 +86,23 @@ if [ `lcm_state` -eq 60 ]; then
     exit 0
 fi
 
-ssh_make_path "$DST_HOST" "$DST_DIR" "ssh"
-
-log "Moving $SRC to $DST"
-
-ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
-    "Error removing target path to prevent overwrite errors"
-
-TAR_SSH=$(cat <<EOF
-set -e -o pipefail
-
-$TAR -C $SRC_DS_DIR --sparse -cf - $SRC_VM_DIR | $SSH $DST_HOST '$TAR -C $DST_DIR --sparse -xf -'
-rm -rf $SRC_PATH
-EOF
-)
-
-ssh_exec_and_log "$SRC_HOST" "$TAR_SSH" "Error copying disk directory to target host"
+if [ "$SHARED" != "YES" ]; then
+    ssh_make_path "$DST_HOST" "$DST_DIR" "ssh"
+    
+    log "Moving $SRC to $DST"
+    
+    ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
+        "Error removing target path to prevent overwrite errors"
+    
+    TAR_SSH=$(cat <<EOF
+    set -e -o pipefail
+    
+    $TAR -C $SRC_DS_DIR --sparse -cf - $SRC_VM_DIR | $SSH $DST_HOST '$TAR -C $DST_DIR --sparse -xf -'
+    rm -rf $SRC_PATH
+    EOF
+    )
+    
+    ssh_exec_and_log "$SRC_HOST" "$TAR_SSH" "Error copying disk directory to target host"
+fi
 
 exit 0


### PR DESCRIPTION
https://dev.opennebula.org/issues/4969

If you use ceph as system datastore and if your /var/lib/one is shared between your nodes.
Then `premigrate`, `postmigrate` and `mv` scripts from ceph tm driver removes vm folder: /var/lib/one/datastores/{datastoreid}/{vmid} with files like `deployment.0`, `disk.1`, `checkpoint`
This entails the error when `save` vm for `suspend` or `migrate`.
```
Command execution fail: cat << EOT | /var/tmp/one/vmm/kvm/migrate 'one-48' 'c13n1' 'c15n1' 48 c15n1
migrate: Command "virsh --connect qemu:///system migrate --live one-48 qemu+ssh://c13n1/system" failed: error: Cannot access storage file '/var/lib/one//datastores/100/48/disk.1' (as uid:9869, gid:9869): No such file or directory
Could not migrate one-48 to c13n1
ExitCode: 1
```