### PR TITLE
Nokogiri fails to install for Ruby 2.0.0

### DIFF
--- a/share/install_gems/Gemfile
+++ b/share/install_gems/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-if RUBY_VERSION < '1.9.0'
+if RUBY_VERSION < '1.9.2'
     gem 'nokogiri', '< 1.6.0'
     gem 'net-ldap', '< 0.9'
     gem 'zendesk_api', '< 1.5'
 else
-    gem 'nokogiri'
+    gem 'nokogiri', '< 1.7.0'
     gem 'net-ldap', '< 0.13'
     gem 'zendesk_api', '< 1.14.0'
 end


### PR DESCRIPTION
When compiling OpenNebula from source code in CentOS 7, /usr/share/one/install_gems fails installing nokogiri.

```
Gem::InstallError: nokogiri requires Ruby version >= 2.1.0.
An error occurred while installing nokogiri (1.7.0.1), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.7.0.1'` succeeds before bundling.
```

CentOS 7 provides Ruby 2.0.0p648 which makes the script to install latest nokogiri (1.7.0.1). Nokogiri 1.7.0 requires Ruby >= 2.1 while latest Nokogiri in 1.6.X version (1.6.8.1) requires Ruby >= 1.9.2 so I propose using nokogiri < 1.7.0 if Ruby version is higher than 1.9.2. This allows the install_gems script to finish succesfully.