### PR TITLE
B #4994: Ignore logrotate exit status on opennebula(-sunstone) start

### DIFF
--- a/share/pkgs/CentOS7/opennebula-sunstone.service
+++ b/share/pkgs/CentOS7/opennebula-sunstone.service
@@ -12,7 +12,7 @@ Group=oneadmin
 User=oneadmin
 
 ExecStart=/usr/bin/ruby /usr/lib/one/sunstone/sunstone-server.rb
-ExecStartPre=/usr/sbin/logrotate -s /tmp/logrotate.state -f /etc/logrotate.d/opennebula
+ExecStartPre=-/usr/sbin/logrotate -s /tmp/logrotate.state -f /etc/logrotate.d/opennebula
 PIDFile=/var/run/one/sunstone.pid
 
 [Install]

--- a/share/pkgs/CentOS7/opennebula.service
+++ b/share/pkgs/CentOS7/opennebula.service
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/oned -f
 # Log file location must exist
 ExecStartPre=/bin/mkdir -p /var/log/one
 ExecStartPre=/bin/chown oneadmin:oneadmin /var/log/one
-ExecStartPre=/usr/sbin/logrotate -s /tmp/logrotate.state -f /etc/logrotate.d/opennebula
+ExecStartPre=-/usr/sbin/logrotate -s /tmp/logrotate.state -f /etc/logrotate.d/opennebula
 ExecStop=/bin/kill -TERM $MAINPID
 PIDFile=/var/run/one/oned.pid
 


### PR DESCRIPTION
Ignores logrotate exit status as this is not critical requirement for the service.