### PR TITLE
Fix: Missing programname in syslog output

### DIFF
--- a/include/Log.h
+++ b/include/Log.h
@@ -211,6 +211,7 @@ public:
 
 private:
     string resource_label;
+    string label;
 };
 
 #endif /* _LOG_H_ */

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -154,7 +154,7 @@ void StdLog::log(
 /* -------------------------------------------------------------------------- */
 
 SysLog::SysLog(const MessageType level,
-               const string&     label):Log(level), resource_label("")
+               const string&     label):Log(level), resource_label(""), label(label)
 {
     static bool initialized = false;
 


### PR DESCRIPTION
For the centralized syslog project I'm working on I've noted that the program name field was missing:
> Feb  6 10:01:19 one-sandbox [4217]: [Z0][AuM][I]: #011Auth Manager loaded
> Feb  6 10:01:19 one-sandbox [4217]: [Z0][ReM][I]: Starting Request Manager...
> Feb  6 10:01:19 one-sandbox [4217]: [Z0][ReM][I]: Starting XML-RPC server, port 2633 ...
> Feb  6 10:01:19 one-sandbox [4217]: [Z0][ReM][I]: Request Manager started.
 
After my modification:
> Feb  7 06:49:05 one-sandbox oned[29752]: [Z0][AuM][I]: #011Auth Manager loaded
> Feb  7 06:49:05 one-sandbox oned[29752]: [Z0][ReM][I]: Starting Request Manager...
> Feb  7 06:49:05 one-sandbox oned[29752]: [Z0][ReM][I]: Starting XML-RPC server, port 2633 ...
> Feb  7 06:49:05 one-sandbox oned[29752]: [Z0][ReM][I]: Request Manager started.

Beware: this is my first time with C++.

Regards,
Germán.
