### PR TITLE
Install all Gems deps when using bundler. Ubuntu 16.10 Gemfile.lock

### DIFF
--- a/share/install_gems/Ubuntu1610/Gemfile.lock
+++ b/share/install_gems/Ubuntu1610/Gemfile.lock
@@ -1,0 +1,110 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    amazon-ec2 (0.9.17)
+      xml-simple (>= 1.0.12)
+    aws-sdk (2.7.5)
+      aws-sdk-resources (= 2.7.5)
+    aws-sdk-core (2.7.5)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.7.5)
+      aws-sdk-core (= 2.7.5)
+    aws-sigv4 (1.0.0)
+    azure (0.7.7)
+      addressable (~> 2.3)
+      azure-core (~> 0.1)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      mime-types (>= 1, < 4.0)
+      nokogiri (~> 1.6)
+      systemu (~> 2.6)
+      thor (~> 0.19)
+    azure-core (0.1.7)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      nokogiri (~> 1.6)
+    builder (3.2.3)
+    configparser (0.1.6)
+    curb (0.9.3)
+    daemons (1.2.4)
+    eventmachine (1.2.2)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
+    hashie (3.5.1)
+    inflection (1.0.0)
+    jmespath (1.3.1)
+    memcache-client (1.8.5)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
+    multipart-post (2.0.0)
+    mysql (2.9.1)
+    net-ldap (0.12.1)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
+    ox (2.4.9)
+    parse-cron (0.1.4)
+    polyglot (0.3.5)
+    public_suffix (2.0.5)
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
+    scrub_rb (1.0.1)
+    sequel (4.43.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sqlite3 (1.3.13)
+    systemu (2.6.5)
+    thin (1.7.0)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    thor (0.19.4)
+    tilt (2.0.6)
+    treetop (1.6.8)
+      polyglot (~> 0.3)
+    trollop (2.1.2)
+    uuidtools (2.1.5)
+    xml-simple (1.1.5)
+    zendesk_api (1.13.4)
+      faraday (~> 0.9)
+      hashie (>= 1.2, < 4.0, != 3.3.0)
+      inflection
+      mime-types (~> 2.99)
+      multipart-post (~> 2.0)
+      scrub_rb (~> 1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  amazon-ec2
+  aws-sdk (~> 2.5)
+  azure
+  builder
+  configparser
+  curb
+  memcache-client
+  mysql
+  net-ldap (< 0.13)
+  nokogiri
+  ox
+  parse-cron
+  rack
+  sequel
+  sinatra
+  sqlite3
+  thin
+  treetop (>= 1.6.3)
+  trollop
+  uuidtools
+  zendesk_api (< 1.14.0)
+
+BUNDLED WITH
+   1.14.3

--- a/share/install_gems/install_gems
+++ b/share/install_gems/install_gems
@@ -385,7 +385,11 @@ def install_bundler_gem
 end
 
 def install_gems(packages, bundler = false)
-    gems_list=get_gems(packages)
+    if bundler
+        gems_list=which_gems(packages)
+    else
+        gems_list=get_gems(packages)
+    end
 
     if gems_list.empty?
         puts "Gems already installed"


### PR DESCRIPTION
Changes:
* Install all Gems dependencies when using bundler (cc: @jfontan)
* New Gemfile.lock for Ubuntu 16.10