### PR TITLE
Apply fix for "Requested VNC port already assgined to a VM" for undeployed VM

### DIFF
--- a/src/onedb/fsck/vm.rb
+++ b/src/onedb/fsck/vm.rb
@@ -19,7 +19,7 @@ module OneDBFsck
             port = vm_doc.root.at_xpath('TEMPLATE/GRAPHICS[translate(TYPE,"vnc","VNC")="VNC"]/PORT').text.to_i rescue nil
             # DATA: TODO: get also spice port
 
-            if cid && port
+            if cid && port && state == 3
                 cluster_vnc[cid] ||= Set.new
                 cluster_vnc[cid] << port
             end


### PR DESCRIPTION
As discussed in this forum thread [1], if the onedb fsck tool is run while there is a VM in state UNDEPLOYED, the fsck script mislabels the corresponding VNC port as being used which blocks resuming the VM later. The proposed fix to block only ports of VM in state RUNNING works for me (and others in the forum). Feel free to add further states that should block a VNC port (maybe SUSPENDED?).

[1] https://forum.opennebula.org/t/requested-vnc-port-already-assgined-to-a-vm/3194