### PR TITLE
tm/ceph/premigrate handle pipefail

### DIFF
--- a/src/tm_mad/ceph/premigrate
+++ b/src/tm_mad/ceph/premigrate
@@ -63,10 +63,13 @@ log "Moving $SRC_HOST:$DST_PATH to $DST_HOST:$DST_PATH"
 ssh_exec_and_log "$DST_HOST" "rm -rf '$DST_PATH'" \
     "Error removing target path to prevent overwrite errors"
 
-TAR_COPY="$SSH $SRC_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -cf - $DST_PATH_BASENAME'"
-TAR_COPY="$TAR_COPY | $SSH $DST_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -xf -'"
+TAR_SSH=$(cat <<EOF
+set -e -o pipefail
+$TAR -C $DST_PATH_DIRNAME --sparse -cf - $DST_PATH_BASENAME | $SSH $DST_HOST '$TAR -C $DST_PATH_DIRNAME --sparse -xf -'
+EOF
+)
 
-exec_and_log "eval $TAR_COPY" "Error copying disk directory to target host"
+ssh_exec_and_log "$SRC_HOST" "$TAR_SSH" "Error copying disk directory to target host"
 
 migrate_other "$@"
 


### PR DESCRIPTION
As we are using same code constructs, a customer managed to hit this with a network issue during live migrate. 

The change is not tested (have no ceph cluster ATM) so please test it for issues before merging(it should probably need `eval`). 

Best,
Anton
