### PR TITLE
Add support for Ceph DS with shared TM (Bug #4944)

### DIFF
--- a/src/tm_mad/shared/clone
+++ b/src/tm_mad/shared/clone
@@ -67,10 +67,12 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VMID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SIZE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/ORIGINAL_SIZE \
                     /VM/HISTORY_RECORDS/HISTORY[last\(\)]/TM_MAD)
 
+DISK_TYPE="${XPATH_ELEMENTS[j++]}"
 SIZE="${XPATH_ELEMENTS[j++]}"
 ORIGINAL_SIZE="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
@@ -86,6 +88,15 @@ fi
 #-------------------------------------------------------------------------------
 
 ssh_make_path $DST_HOST $DST_DIR $MONITOR
+
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ "$DISK_TYPE" = "RBD" ]; then
+    ${DRIVER_PATH}/../ceph/clone "$1" "$2" "$3" "$4"
+    exit 0
+fi
 
 #-------------------------------------------------------------------------------
 # Clone (cp) SRC into DST

--- a/src/tm_mad/shared/cpds
+++ b/src/tm_mad/shared/cpds
@@ -54,9 +54,11 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VMID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE)
 
+DISK_TYPE="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
@@ -77,6 +79,15 @@ DST_PATH="${SRC_DS_PATH}${DST_ARG_PATH##$DST_DS_PATH}"
 if [ "$SNAP_ID" != "-1" ]; then
     [ "$CLONE" != "YES" ] && SRC_PATH="$DISK_SRC"
     SRC_PATH="$SRC_PATH.snap/$SNAP_ID"
+fi
+
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ "$DISK_TYPE" = "RBD" ]; then
+    ${DRIVER_PATH}/../ceph/cpds "$1" "$2" "$3" "$4" "$5"
+    exit 0
 fi
 
 #-------------------------------------------------------------------------------

--- a/src/tm_mad/shared/delete
+++ b/src/tm_mad/shared/delete
@@ -49,7 +49,7 @@ DST_HOST=`arg_host $DST`
 #-------------------------------------------------------------------------------
 
 if [ `is_disk $DST_PATH` -eq 1 ]; then
-    DISK_ID=$(basename ${SRC} | cut -d. -f2)
+    DISK_ID=$(basename ${DST} | cut -d. -f2)
 
     XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
 

--- a/src/tm_mad/shared/delete
+++ b/src/tm_mad/shared/delete
@@ -1,1 +1,101 @@
-../common/delete
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# DELETE <host:remote_system_ds/disk.i|host:remote_system_ds/> vmid dsid
+#   - host is the target host to deploy the VM
+#   - remote_system_ds is the path for the system datastore in the host
+#   - vmid is the id of the VM
+#   - dsid is the target datastore (0 is the system datastore)
+
+DST=$1
+
+VMID=$2
+DSID=$3
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+fi
+
+. $TMCOMMON
+
+DRIVER_PATH=$(dirname $0)
+
+#-------------------------------------------------------------------------------
+# Set dst path and dir
+#-------------------------------------------------------------------------------
+
+DST_PATH=`arg_path $DST`
+DST_HOST=`arg_host $DST`
+
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ `is_disk $DST_PATH` -eq 1 ]; then
+    DISK_ID=$(basename ${SRC} | cut -d. -f2)
+
+    XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+    unset i j XPATH_ELEMENTS
+
+    while IFS= read -r -d '' element; do
+        XPATH_ELEMENTS[i++]="$element"
+    done < <(onevm show -x $VMID | $XPATH \
+                        /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE)
+
+    DISK_TYPE="${XPATH_ELEMENTS[j++]}"
+
+    if [ "$DISK_TYPE" = "RBD" ]; then
+        ${DRIVER_PATH}/../ceph/delete "$1" "$2" "$3"
+        exit 0
+    fi
+fi
+
+#-------------------------------------------------------------------------------
+# Return if deleting a disk, we will delete them when removing the
+# remote_system_ds directory for the VM (remotely)
+#-------------------------------------------------------------------------------
+
+log "Deleting $DST_PATH"
+
+delete_file=$(cat <<EOF
+[ -e "$DST_PATH" ] || exit 0
+
+times=10
+function="rm -rf $DST_PATH"
+
+count=1
+
+ret=\$(\$function)
+error=\$?
+
+while [ \$count -lt \$times -a "\$error" != "0" ]; do
+    sleep 1
+    count=\$(( \$count + 1 ))
+    ret=\$(\$function)
+    error=\$?
+done
+
+[ "x\$error" = "x0" ]
+EOF
+)
+
+ssh_exec_and_log $DST_HOST "$delete_file" "Error deleting $DST_PATH"
+

--- a/src/tm_mad/shared/snap_create
+++ b/src/tm_mad/shared/snap_create
@@ -51,12 +51,26 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VMID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE)
 
+DISK_TYPE="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ "$DISK_TYPE" = "RBD" ]; then
+    ${DRIVER_PATH}/../ceph/snap_create "$1" "$2" "$3" "$4"
+    exit 0
+fi
+
+#-------------------------------------------------------------------------------
+# Create snapshots
+#-------------------------------------------------------------------------------
 
 SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 IMAGE_DS_PATH=$(dirname ${DISK_SRC})

--- a/src/tm_mad/shared/snap_create_live
+++ b/src/tm_mad/shared/snap_create_live
@@ -1,1 +1,72 @@
-../common/not_supported.sh
+#!/bin/bash
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# snap_create host:parent_image snap_id vmid ds_id
+
+SRC=$1
+SNAP_ID=$2
+VMID=$3
+DSID=$4
+
+if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+    DATASTORES=/var/lib/one/datastores
+else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+    DATASTORES=$ONE_LOCATION/var/datastores
+fi
+
+DRIVER_PATH=$(dirname $0)
+
+. $TMCOMMON
+
+script_name=$(basename $0)
+
+SRC_PATH=$(arg_path $SRC)
+SRC_HOST=$(arg_host $SRC)
+
+#-------------------------------------------------------------------------------
+# Get Image information
+#-------------------------------------------------------------------------------
+
+DISK_ID=$(basename ${SRC} | cut -d. -f2)
+
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+
+unset i j XPATH_ELEMENTS
+
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onevm show -x $VMID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE) 
+
+DISK_TYPE="${XPATH_ELEMENTS[j++]}"
+
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ "$DISK_TYPE" = "RBD" ]; then
+    ${DRIVER_PATH}/../ceph/snap_create_live "$1" "$2" "$3" "$4"
+    exit 0
+fi
+
+error_message "$script_name: Operation not supported"
+
+exit 1
+

--- a/src/tm_mad/shared/snap_delete
+++ b/src/tm_mad/shared/snap_delete
@@ -51,12 +51,26 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VMID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE)
 
+DISK_TYPE="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ "$DISK_TYPE" = "RBD" ]; then
+    ${DRIVER_PATH}/../ceph/snap_delete "$1" "$2" "$3" "$4"
+    exit 0
+fi
+
+#-------------------------------------------------------------------------------
+# Delete snapshot
+#-------------------------------------------------------------------------------
 
 SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 IMAGE_DS_PATH=$(dirname ${DISK_SRC})

--- a/src/tm_mad/shared/snap_revert
+++ b/src/tm_mad/shared/snap_revert
@@ -51,12 +51,26 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VMID| $XPATH \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/DISK_TYPE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CLONE)
 
+DISK_TYPE="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 CLONE="${XPATH_ELEMENTS[j++]}"
 
+#-------------------------------------------------------------------------------
+# Handle Ceph image
+#-------------------------------------------------------------------------------
+
+if [ "$DISK_TYPE" = "RBD" ]; then
+    ${DRIVER_PATH}/../ceph/snap_revert "$1" "$2" "$3" "$4"
+    exit 0
+fi
+
+#-------------------------------------------------------------------------------
+# Revert to snapshot
+#-------------------------------------------------------------------------------
 
 SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 IMAGE_DS_PATH=$(dirname ${DISK_SRC})


### PR DESCRIPTION
Hi,

This pull request intends to fix
[Bug #4944: tm/shared/clone: ceph disk clone is failing with shared system ds
](https://dev.opennebula.org/issues/4944) and more.

The pull request #160 from Anton Todorov (StorPool)  is required, otherwise ceph DS migration scripts are called resulting in total loss of VM files in shared system DS.

I also had to add "kvm-shared" to LIVE_DISK_SNAPSHOTS variable in
  /etc/one/vmm_exec/vmm_execrc
file to allow Ceph live disk snapshots while using shared system datastore.

Best regards,

Laurent
