### PR TITLE
Add OpenNebula systemd service dependency on MySQL

### DIFF
--- a/share/pkgs/CentOS7/opennebula.service
+++ b/share/pkgs/CentOS7/opennebula.service
@@ -3,7 +3,7 @@ Description=OpenNebula Cloud Controller Daemon
 After=syslog.target
 After=network.target
 After=remote-fs.target
-After=mariadb.service
+After=mariadb.service mysql.service
 Before=opennebula-scheduler.service
 BindTo=opennebula-scheduler.service
 


### PR DESCRIPTION
References https://github.com/OpenNebula/docs/pull/93

On Debian-like systems, the MariaDB service name is still **mysql**. This small change adds soft dependency also on *mysql.service* into the systemd service script.