### PR TITLE
Bug 5144 - fs/snap_* BRIDGE_LIST, fixes

### DIFF
--- a/src/datastore_mad/remotes/fs/snap_delete
+++ b/src/datastore_mad/remotes/fs/snap_delete
@@ -20,16 +20,19 @@ DRV_ACTION=$1
 ID=$2
 
 if [ -z "${ONE_LOCATION}" ]; then
-    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
-    DATASTORES=/var/lib/one/datastores
+    LIB_LOCATION=/usr/lib/one
 else
-    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
-    DATASTORES=$ONE_LOCATION/var/datastores
+    LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
+TMCOMMON=$LIB_LOCATION/var/remotes/tm/tm_common.sh
+DATASTORES=$LIB_LOCATION/var/datastores
+
 . $TMCOMMON
+. $LIB_LOCATION/sh/scripts_common.sh
 
 DRIVER_PATH=$(dirname $0)
+source ${DRIVER_PATH}/../libfs.sh
 
 # -------- Get image and datastore arguments from OpenNebula core ------------
 
@@ -42,9 +45,11 @@ unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT)
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 SNAP_ID="${XPATH_ELEMENTS[j++]}"
 
@@ -55,5 +60,11 @@ SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 SNAP_DIR="${DISK_SRC}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
-rm ${SNAP_PATH}
-
+if [ -n "$BRIDGE_LIST" ]; then
+    log "Delete remote snapshot $SNAP_PATH"
+    DST_HOST=`get_destination_host $ID`
+    ssh_exec_and_log "$DST_HOST" "rm -f $SNAP_PATH" "Error deleting snapshot $SNAP_PATH"
+else
+    log "Delete local snapshot $SNAP_PATH"
+    rm -f ${SNAP_PATH}
+fi

--- a/src/datastore_mad/remotes/fs/snap_delete
+++ b/src/datastore_mad/remotes/fs/snap_delete
@@ -20,15 +20,17 @@ DRV_ACTION=$1
 ID=$2
 
 if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+    DATASTORES=/var/lib/one/datastores
     LIB_LOCATION=/usr/lib/one
 else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+    DATASTORES=$ONE_LOCATION/var/datastores
     LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
-TMCOMMON=$LIB_LOCATION/var/remotes/tm/tm_common.sh
-DATASTORES=$LIB_LOCATION/var/datastores
-
 . $TMCOMMON
+
 . $LIB_LOCATION/sh/scripts_common.sh
 
 DRIVER_PATH=$(dirname $0)
@@ -63,8 +65,12 @@ SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 if [ -n "$BRIDGE_LIST" ]; then
     log "Delete remote snapshot $SNAP_PATH"
     DST_HOST=`get_destination_host $ID`
-    ssh_exec_and_log "$DST_HOST" "rm -f $SNAP_PATH" "Error deleting snapshot $SNAP_PATH"
+
+    ssh_exec_and_log "$DST_HOST" "rm $SNAP_PATH" \
+        "Error deleting snapshot $SNAP_PATH"
 else
     log "Delete local snapshot $SNAP_PATH"
-    rm -f ${SNAP_PATH}
+
+    exec_and_log "rm ${SNAP_PATH}" \
+        "Error deleting snapshot $SNAP_PATH"
 fi

--- a/src/datastore_mad/remotes/fs/snap_flatten
+++ b/src/datastore_mad/remotes/fs/snap_flatten
@@ -20,16 +20,19 @@ DRV_ACTION=$1
 ID=$2
 
 if [ -z "${ONE_LOCATION}" ]; then
-    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
-    DATASTORES=/var/lib/one/datastores
+    LIB_LOCATION=/usr/lib/one
 else
-    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
-    DATASTORES=$ONE_LOCATION/var/datastores
+    LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
+TMCOMMON=$LIB_LOCATION/var/remotes/tm/tm_common.sh
+DATASTORES=$LIB_LOCATION/var/datastores
+
 . $TMCOMMON
+. $LIB_LOCATION/sh/scripts_common.sh
 
 DRIVER_PATH=$(dirname $0)
+source ${DRIVER_PATH}/../libfs.sh
 
 # -------- Get image and datastore arguments from OpenNebula core ------------
 
@@ -42,10 +45,12 @@ unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TM_MAD )
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 SNAP_ID="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
@@ -60,11 +65,22 @@ DISK_PATH="${DISK_SRC}"
 SNAP_DIR="${DISK_PATH}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
-if [ "$TM_MAD" = "qcow2" ]; then
-    qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp
-    mv "${DISK_PATH}.tmp" "${DISK_PATH}"
+if [ -n "$BRIDGE_LIST" ]; then
+    log "Flatten remote image $DISK_ID"
+    DST_HOST=`get_destination_host $ID`
+    if [ "$TM_MAD" = "qcow2" ]; then
+        ssh_exec_and_log "$DST_HOST" "qemu-img convert -O qcow2 $SNAP_PATH $DISK_PATH.tmp; mv -f $DISK_PATH.tmp $DISK_PATH; rm -rf $SNAP_DIR" "Error flattening image $SNAP_PATH to $DISK_PATH"
+    else
+        ssh_exec_and_log "$DST_HOST" "mv -f $SNAP_PATH $DISK_PATH; rm -rf $SNAP_DIR" "Error flattening image $SNAP_PATH to $DISK_PATH"
+    fi
 else
-    mv ${SNAP_PATH} ${DISK_PATH}
-fi
+    log "Flatten local image $DISK_ID"
+    if [ "$TM_MAD" = "qcow2" ]; then
+        qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp
+        mv "${DISK_PATH}.tmp" "${DISK_PATH}"
+    else
+        mv ${SNAP_PATH} ${DISK_PATH}
+    fi
 
-rm -rf ${SNAP_DIR}
+    rm -rf ${SNAP_DIR}
+fi

--- a/src/datastore_mad/remotes/fs/snap_flatten
+++ b/src/datastore_mad/remotes/fs/snap_flatten
@@ -20,15 +20,17 @@ DRV_ACTION=$1
 ID=$2
 
 if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+    DATASTORES=/var/lib/one/datastores
     LIB_LOCATION=/usr/lib/one
 else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+    DATASTORES=$ONE_LOCATION/var/datastores
     LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
-TMCOMMON=$LIB_LOCATION/var/remotes/tm/tm_common.sh
-DATASTORES=$LIB_LOCATION/var/datastores
-
 . $TMCOMMON
+
 . $LIB_LOCATION/sh/scripts_common.sh
 
 DRIVER_PATH=$(dirname $0)
@@ -65,22 +67,43 @@ DISK_PATH="${DISK_SRC}"
 SNAP_DIR="${DISK_PATH}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
-if [ -n "$BRIDGE_LIST" ]; then
-    log "Flatten remote image $DISK_ID"
-    DST_HOST=`get_destination_host $ID`
-    if [ "$TM_MAD" = "qcow2" ]; then
-        ssh_exec_and_log "$DST_HOST" "qemu-img convert -O qcow2 $SNAP_PATH $DISK_PATH.tmp; mv -f $DISK_PATH.tmp $DISK_PATH; rm -rf $SNAP_DIR" "Error flattening image $SNAP_PATH to $DISK_PATH"
+if [ "$TM_MAD" = "qcow2" ]; then
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
+
+        ssh_exec_and_log "$DST_HOST" "qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp" \
+            "Error flattening ${SNAP_PATH}"
+
+        ssh_exec_and_log "$DST_HOST" "mv ${DISK_PATH}.tmp ${DISK_PATH}" \
+            "Error moving to ${DISK_PATH}"
+
+        ssh_exec_and_log "$DST_HOST" "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
     else
-        ssh_exec_and_log "$DST_HOST" "mv -f $SNAP_PATH $DISK_PATH; rm -rf $SNAP_DIR" "Error flattening image $SNAP_PATH to $DISK_PATH"
-    fi
-else
-    log "Flatten local image $DISK_ID"
-    if [ "$TM_MAD" = "qcow2" ]; then
-        qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp
-        mv "${DISK_PATH}.tmp" "${DISK_PATH}"
-    else
-        mv ${SNAP_PATH} ${DISK_PATH}
+        exec_and_log "qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp" \
+            "Error flattening ${SNAP_PATH}"
+
+        exec_and_log "mv ${DISK_PATH}.tmp ${DISK_PATH}" \
+            "Error moving to ${DISK_PATH}"
+
+        exec_and_log "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
     fi
 
-    rm -rf ${SNAP_DIR}
+else
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
+
+        ssh_exec_and_log "$DST_HOST" "mv ${SNAP_PATH} ${DISK_PATH}" \
+            "Error moving snapshot ${SNAP_PATH}"
+
+        ssh_exec_and_log "$DST_HOST" "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
+    else
+        exec_and_log "mv ${SNAP_PATH} ${DISK_PATH}" \
+            "Error moving snapshot ${SNAP_PATH}"
+
+        exec_and_log "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
+    fi
 fi

--- a/src/datastore_mad/remotes/fs/snap_revert
+++ b/src/datastore_mad/remotes/fs/snap_revert
@@ -20,15 +20,17 @@ DRV_ACTION=$1
 ID=$2
 
 if [ -z "${ONE_LOCATION}" ]; then
+    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
+    DATASTORES=/var/lib/one/datastores
     LIB_LOCATION=/usr/lib/one
 else
+    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
+    DATASTORES=$ONE_LOCATION/var/datastores
     LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
-TMCOMMON=$LIB_LOCATION/var/remotes/tm/tm_common.sh
-DATASTORES=$LIB_LOCATION/var/datastores
-
 . $TMCOMMON
+
 . $LIB_LOCATION/sh/scripts_common.sh
 
 DRIVER_PATH=$(dirname $0)
@@ -62,25 +64,47 @@ SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 SNAP_DIR="${DISK_SRC}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
-if [ -n "$BRIDGE_LIST" ]; then
-    log "Revert remote snapshot $SNAP_PATH"
-    DST_HOST=`get_destination_host $ID`
-    if [ "$TM_MAD" = "qcow2" ]; then
-        ACTIVE_SNAP_ID=$(ssh_monitor_and_log "$DST_HOST" "ls $SNAP_DIR | grep '^[[:digit:]]*$' | sort -n | tail -n 1" "Get active snapshot id" 2>&1)
+if [ "$TM_MAD" = "qcow2" ]; then
+    SNAP_ID_SCRIPT=$(cat <<EOF
+set -e -o pipefail
+ls $SNAP_DIR | grep '^[[:digit:]]*\$' | sort -n | tail -n 1
+EOF
+)
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
+
+        ACTIVE_SNAP_ID=$(ssh_monitor_and_log "$DST_HOST" "$SNAP_ID_SCRIPT" "Error get active snapshot ID" 2>&1)
         ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
 
-        ssh_exec_and_log "$DST_HOST" "rm -f $ACTIVE_SNAP_PATH; qemu-img create -f qcow2 -b $SNAP_PATH $ACTIVE_SNAP_PATH" "Error reverting snapshot to $SNAP_PATH"
+        ssh_exec_and_log "$DST_HOST" "rm $ACTIVE_SNAP_PATH" \
+            "Error deleting $ACTIVE_SNAP_PATH"
+
+        ssh_exec_and_log "$DST_HOST" "qemu-img create -f qcow2 -b $SNAP_PATH $ACTIVE_SNAP_PATH" \
+            "Error reverting snapshot to $SNAP_PATH"
     else
-        ssh_exec_and_log "$DST_HOST" "mv -f $SNAP_PATH $DISK_SRC" "Error reverting snapshot to $SNAP_PATH"
+        ACTIVE_SNAP_ID=$(monitor_and_log "$SNAP_ID_SCRIPT" "Error get active snapshot ID" 2>&1)
+        ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
+
+        exec_and_log "rm ${ACTIVE_SNAP_PATH}" \
+            "Error deleting $ACTIVE_SNAP_PATH"
+
+        exec_and_log "qemu-img create -f qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}" \
+            "Error reverting snapshot to $SNAP_PATH"
     fi
 else
-    if [ "$TM_MAD" = "qcow2" ]; then
-        ACTIVE_SNAP_ID=$(ls ${SNAP_DIR} | grep '^[[:digit:]]*$' | sort -n | tail -n 1)
-        ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
 
-        rm ${ACTIVE_SNAP_PATH}
-        qemu-img create -f qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}
+        ssh_exec_and_log "$DST_HOST" "cp -f ${SNAP_PATH} ${DISK_SRC}.tmp" \
+            "Error copying snapshot $SNAP_PATH"
+
+        ssh_exec_and_log "$DST_HOST" "mv ${DISK_SRC}.tmp ${DISK_SRC}" \
+            "Error moving to $DISK_SRC"
     else
-        mv -f ${SNAP_PATH} ${DISK_SRC}
+        exec_and_log "cp -f ${SNAP_PATH} ${DISK_SRC}.tmp" \
+            "Error copying snapshot $SNAP_PATH"
+
+        exec_and_log "mv ${DISK_SRC}.tmp ${DISK_SRC}" \
+            "Error moving to $DISK_SRC"
     fi
 fi

--- a/src/datastore_mad/remotes/fs/snap_revert
+++ b/src/datastore_mad/remotes/fs/snap_revert
@@ -20,16 +20,19 @@ DRV_ACTION=$1
 ID=$2
 
 if [ -z "${ONE_LOCATION}" ]; then
-    TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
-    DATASTORES=/var/lib/one/datastores
+    LIB_LOCATION=/usr/lib/one
 else
-    TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
-    DATASTORES=$ONE_LOCATION/var/datastores
+    LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
+TMCOMMON=$LIB_LOCATION/var/remotes/tm/tm_common.sh
+DATASTORES=$LIB_LOCATION/var/datastores
+
 . $TMCOMMON
+. $LIB_LOCATION/sh/scripts_common.sh
 
 DRIVER_PATH=$(dirname $0)
+source ${DRIVER_PATH}/../libfs.sh
 
 # -------- Get image and datastore arguments from OpenNebula core ------------
 
@@ -42,10 +45,12 @@ unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TM_MAD )
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 SNAP_ID="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
@@ -57,13 +62,25 @@ SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 SNAP_DIR="${DISK_SRC}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
-if [ "$TM_MAD" = "qcow2" ]; then
-    ACTIVE_SNAP_ID=$(ls ${SNAP_DIR} | sort -n | tail -n 1)
-    ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
+if [ -n "$BRIDGE_LIST" ]; then
+    log "Revert remote snapshot $SNAP_PATH"
+    DST_HOST=`get_destination_host $ID`
+    if [ "$TM_MAD" = "qcow2" ]; then
+        ACTIVE_SNAP_ID=$(ssh_monitor_and_log "$DST_HOST" "ls $SNAP_DIR | grep '^[[:digit:]]*$' | sort -n | tail -n 1" "Get active snapshot id" 2>&1)
+        ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
 
-    rm ${ACTIVE_SNAP_PATH}
-    qemu-img create -f qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}
+        ssh_exec_and_log "$DST_HOST" "rm -f $ACTIVE_SNAP_PATH; qemu-img create -f qcow2 -b $SNAP_PATH $ACTIVE_SNAP_PATH" "Error reverting snapshot to $SNAP_PATH"
+    else
+        ssh_exec_and_log "$DST_HOST" "mv -f $SNAP_PATH $DISK_SRC" "Error reverting snapshot to $SNAP_PATH"
+    fi
 else
-    mv ${SNAP_PATH} ${DISK_SRC}
-fi
+    if [ "$TM_MAD" = "qcow2" ]; then
+        ACTIVE_SNAP_ID=$(ls ${SNAP_DIR} | grep '^[[:digit:]]*$' | sort -n | tail -n 1)
+        ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
 
+        rm ${ACTIVE_SNAP_PATH}
+        qemu-img create -f qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}
+    else
+        mv -f ${SNAP_PATH} ${DISK_SRC}
+    fi
+fi


### PR DESCRIPTION
The PR includes also changes from PR #298 (by @feldsam). Fixes fs/snap_* for:
1. BRIDGE_LIST, support was missing
2. loss of the particular snapshot on revert (both qcow2/non-qcow2)