### PR TITLE
Feature 5136 && Bug 5012

### DIFF
--- a/src/cli/one_helper.rb
+++ b/src/cli/one_helper.rb
@@ -494,18 +494,13 @@ EOT
 
         # receive a object key => value format
         # returns hashed values
-        def encrypt(opts)
-
+        def encrypt(opts, token)
             res = {}
-            key_one= File.read(VAR_LOCATION+'/.one/one_key')
-
             opts.each do |key, value|
                 cipher = OpenSSL::Cipher::AES.new(256,:CBC)
-                cipher.encrypt.key = key_one
-                puts "cifrando #{key}"                
+                cipher.encrypt.key = token[0..31]
                 encrypted = cipher.update(value) + cipher.final
                 res[key] = Base64::encode64(encrypted) 
-                puts "encriptado es: "+encrypted
             end
             
             return res

--- a/src/cli/one_helper.rb
+++ b/src/cli/one_helper.rb
@@ -504,33 +504,12 @@ EOT
                 cipher.encrypt.key = key_one
                 puts "cifrando #{key}"                
                 encrypted = cipher.update(value) + cipher.final
-                #res.merge!({key => value})
                 res[key] = Base64::encode64(encrypted) 
                 puts "encriptado es: "+encrypted
             end
             
             return res
         end
-
-        def decrypt(res)
-            opts = {}
-            key_one= File.read(VAR_LOCATION+'/.one/one_key')
-
-            res.each do |key, encrypted_value|
-                decipher = OpenSSL::Cipher::AES.new(256,:CBC)
-                decipher.decrypt
-                decipher.key = key_one
-                puts "desencriptando #{key}"
-                plain = decipher.update(Base64::decode64(encrypted_value)) + decipher.final
-                puts "una vez desencriptado es "+plain
-                opts[key] = plain
-            end
-
-            return opts
-
-        end
-
-
 
         def list_pool(options, top=false, filter_flag=nil)
             if options[:describe]

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -32,6 +32,7 @@ $: << RUBY_LIB_LOCATION+"/cli"
 require 'command_parser'
 require 'one_helper/onehost_helper'
 require 'one_helper/onecluster_helper'
+require 'ec2_driver'
 
 cmd=CommandParser::CmdParser.new(ARGV) do
     usage "`onehost` <command> [<args>] [<options>]"
@@ -124,12 +125,7 @@ cmd=CommandParser::CmdParser.new(ARGV) do
             exit -1
         end
 
-        if !options[:ec2access].nil? && !options[:ec2secret].nil?
-            puts "madafakaaa"
-            puts "el acceso es "+options[:ec2access]
-            puts "la key es "+options[:ec2secret]
-            exit (-1)
-        end
+        encrypt(options) 
 
         cid = options[:cluster] || ClusterPool::NONE_CLUSTER_ID
 

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -32,7 +32,6 @@ $: << RUBY_LIB_LOCATION+"/cli"
 require 'command_parser'
 require 'one_helper/onehost_helper'
 require 'one_helper/onecluster_helper'
-require 'ec2_driver'
 
 cmd=CommandParser::CmdParser.new(ARGV) do
     usage "`onehost` <command> [<args>] [<options>]"
@@ -124,16 +123,37 @@ cmd=CommandParser::CmdParser.new(ARGV) do
             STDERR.puts "\t -v hypervisor driver"
             exit -1
         end
+        
+        ec2_host = !options[:ec2access].nil? && !options[:ec2secret].nil?
 
-        encrypt(options) 
+        if ec2_host
+            ec2_opts = {
+                :access => options[:ec2access],
+                :secret => options[:ec2secret]
+            }
+
+            encrypt_opts = helper.encrypt(ec2_opts) 
+            helper.decrypt(encrypt_opts)
+
+        end
 
         cid = options[:cluster] || ClusterPool::NONE_CLUSTER_ID
-
         helper.create_resource(options) do |host|
                 host.allocate(args[0],
                               options[:im],
                               options[:vm],
                               cid)
+				#template=""
+				#encrypt_opts.each do |key, value|
+           		#	template << "#{key}=\"+value\"\n"\
+				#end
+
+               	template = "EC2_ACCESS=\"#{encrypt_opts[:access]}\"\n"\
+               		"EC2_SECRET=\"#{encrypt_opts[:secret]}\"\n"\
+
+                host.update(template, true)
+
+
         end
     end
 

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -79,7 +79,21 @@ cmd=CommandParser::CmdParser.new(ARGV) do
             " rsync command must be installed in the frontend and nodes."
     }
 
-    CREAT_OPTIONS = [ IM, VMM, OneClusterHelper::CLUSTER ]
+    EC2_ACCESS = {
+        :name   => "ec2access",
+        :large  => "--ec2access id",
+        :description => "Set the id access for EC2 Driver",
+        :format => String
+    }
+
+    EC2_SECRET = {
+        :name   => "ec2secret",
+        :large  => "--ec2secret key",
+        :description => "Set the secret key for EC2 Driver",
+        :format => String
+    }
+
+    CREAT_OPTIONS = [ IM, VMM, OneClusterHelper::CLUSTER, EC2_ACCESS, EC2_SECRET ]
     SYNC_OPTIONS  = [ OneClusterHelper::CLUSTER, FORCE, RSYNC ]
 
     ########################################################################
@@ -108,6 +122,13 @@ cmd=CommandParser::CmdParser.new(ARGV) do
             STDERR.puts "\t -i information driver"
             STDERR.puts "\t -v hypervisor driver"
             exit -1
+        end
+
+        if !options[:ec2access].nil? && !options[:ec2secret].nil?
+            puts "madafakaaa"
+            puts "el acceso es "+options[:ec2access]
+            puts "la key es "+options[:ec2secret]
+            exit (-1)
         end
 
         cid = options[:cluster] || ClusterPool::NONE_CLUSTER_ID

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -126,16 +126,6 @@ cmd=CommandParser::CmdParser.new(ARGV) do
         
         ec2_host = !options[:ec2access].nil? && !options[:ec2secret].nil?
 
-        if ec2_host
-            ec2_opts = {
-                :access => options[:ec2access],
-                :secret => options[:ec2secret]
-            }
-
-            encrypt_opts = helper.encrypt(ec2_opts) 
-            helper.decrypt(encrypt_opts)
-
-        end
 
         cid = options[:cluster] || ClusterPool::NONE_CLUSTER_ID
         helper.create_resource(options) do |host|
@@ -143,12 +133,19 @@ cmd=CommandParser::CmdParser.new(ARGV) do
                               options[:im],
                               options[:vm],
                               cid)
+                if ec2_host
+                    ec2_opts = {
+                        :access => options[:ec2access],
+                        :secret => options[:ec2secret]
+                    }
 
-               	template = "EC2_ACCESS=\"#{encrypt_opts[:access]}\"\n"\
-               		"EC2_SECRET=\"#{encrypt_opts[:secret]}\"\n"\
+                    encrypt_opts = helper.encrypt(ec2_opts) 
+               	    template = "EC2_ACCESS=\"#{encrypt_opts[:access]}\"\n"\
+               		    "EC2_SECRET=\"#{encrypt_opts[:secret]}\"\n"\
 
-                host.update(template, true)
+                    host.update(template, true)
 
+                end
 
         end
     end

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -126,7 +126,6 @@ cmd=CommandParser::CmdParser.new(ARGV) do
         
         ec2_host = !options[:ec2access].nil? && !options[:ec2secret].nil?
 
-
         cid = options[:cluster] || ClusterPool::NONE_CLUSTER_ID
         helper.create_resource(options) do |host|
                 host.allocate(args[0],
@@ -134,17 +133,10 @@ cmd=CommandParser::CmdParser.new(ARGV) do
                               options[:vm],
                               cid)
                 if ec2_host
-                    ec2_opts = {
-                        :access => options[:ec2access],
-                        :secret => options[:ec2secret]
-                    }
-
-                    encrypt_opts = helper.encrypt(ec2_opts) 
-               	    template = "EC2_ACCESS=\"#{encrypt_opts[:access]}\"\n"\
-               		    "EC2_SECRET=\"#{encrypt_opts[:secret]}\"\n"\
+               	    template = "EC2_ACCESS=\"#{options[:ec2access]}\"\n"\
+               		    "EC2_SECRET=\"#{options[:ec2secret]}\"\n"\
 
                     host.update(template, true)
-
                 end
 
         end

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -143,10 +143,6 @@ cmd=CommandParser::CmdParser.new(ARGV) do
                               options[:im],
                               options[:vm],
                               cid)
-				#template=""
-				#encrypt_opts.each do |key, value|
-           		#	template << "#{key}=\"+value\"\n"\
-				#end
 
                	template = "EC2_ACCESS=\"#{encrypt_opts[:access]}\"\n"\
                		"EC2_SECRET=\"#{encrypt_opts[:secret]}\"\n"\

--- a/src/vmm_mad/remotes/ec2/ec2_driver.rb
+++ b/src/vmm_mad/remotes/ec2/ec2_driver.rb
@@ -254,7 +254,7 @@ class EC2Driver
             :secret_access_key  => @region['secret_access_key'],
             :region             => @region['region_name']
         })
-        getHost(host)
+        get_connect_info(host)
 
         if (proxy_uri = PUBLIC_CLOUD_EC2_CONF['proxy_uri'])
             Aws.config(:proxy_uri => proxy_uri)
@@ -263,16 +263,24 @@ class EC2Driver
         @ec2 = Aws::EC2::Resource.new
     end
 
-    def getHost(host)
+    def get_connect_info(host)
+
+        conn_opts={}
 
         client   = OpenNebula::Client.new
         pool = OpenNebula::HostPool.new(client)
         pool.info
         objects=pool.select {|object| object.name==host }
-        access = objects.first["TEMPLATE/EC2_ACCESS"]
-        secret = objects.first["TEMPLATE/EC2_SECRET"]
-        File.open("/home/semedi/prueba", 'w') {|f| f << "el secreto esta en #{secret}\n" }
-        File.open("/home/semedi/prueba", 'w') {|f| f << "el acceso esta en #{access}\n" }
+        xmlhost = objects.first
+
+        access = xmlhost["TEMPLATE/EC2_ACCESS"]
+        secret = xmlhost["TEMPLATE/EC2_SECRET"]
+
+
+        File.open("/home/semedi/prueba_secret", 'w') {|f| f << "el secreto esta en #{secret}\n" }
+        File.open("/home/semedi/prueba_acces", 'w') {|f| f << "el acceso esta en #{access}\n" }
+
+        
     end
 
     # DEPLOY action, also sets ports and ip if needed

--- a/src/vmm_mad/remotes/ec2/ec2_driver.rb
+++ b/src/vmm_mad/remotes/ec2/ec2_driver.rb
@@ -58,7 +58,16 @@ def handle_exception(action, ex, host, did, id = nil, file = nil)
     exit (-1)
 end
 
+def encrypt(opts)
+      if !opts[:ec2access].nil? && !opts[:ec2secret].nil?
+        puts "el accesoas es "+opts[:ec2access]
+        puts "la key es "+opts[:ec2secret]
+        cipher = OpenSSL::Cipher.new("aes-256-cbc")
+        cipher.encrypt
+        exit (-1)
+      end
 
+end
 
 
 begin


### PR DESCRIPTION

#### HEAD^1
* Bug 5012
it's possible to see live mem values

* Tags_bug
ec2 drivers was failing when you try to get instantiate a template without any tags, now is solved.


#### HEAD~x 
Feature 5136:

Now it's mandatory to add authentication ec2 options in --ec2access --ec2secret parameters instead of ec2_driver.conf
```
$  onehost create ec2-test --im ec2 --vm ec2 --ec2access accessloginhash --ec2secret ec2secrethash
```
