### PR TITLE
B #5145: Drop domain snapshots before live-migrate

### DIFF
--- a/src/vmm_mad/remotes/kvm/migrate
+++ b/src/vmm_mad/remotes/kvm/migrate
@@ -22,5 +22,16 @@ source $(dirname $0)/../../scripts_common.sh
 deploy_id=$1
 dest_host=$2
 
+# migration can't be done with domain snapshots, drop them first
+snaps=$(monitor_and_log \
+   "virsh --connect $LIBVIRT_URI snapshot-list $deploy_id --name 2>/dev/null" \
+   "Failed to get snapshots for $deploy_id")
+
+for snap in $snaps; do
+    exec_and_log \
+        "virsh --connect $LIBVIRT_URI snapshot-delete $deploy_id --snapshotname $snap --metadata" \
+        "Failed to delete snapshot $snap from $deploy_id"
+done
+
 exec_and_log "virsh --connect $LIBVIRT_URI migrate --live $MIGRATE_OPTIONS $deploy_id $QEMU_PROTOCOL://$dest_host/system" \
     "Could not migrate $deploy_id to $dest_host"

--- a/src/vmm_mad/remotes/kvm/migrate_local
+++ b/src/vmm_mad/remotes/kvm/migrate_local
@@ -17,10 +17,22 @@
 #--------------------------------------------------------------------------- #
 
 source $(dirname $0)/kvmrc
+source $(dirname $0)/../../scripts_common.sh
 
 deploy_id=$1
 dest_host=$2
 src_host=$3
+
+# migration can't be done with domain snapshots, drop them first
+snaps=$(monitor_and_log \
+   "virsh --connect $QEMU_PROTOCOL://$src_host/system snapshot-list $deploy_id --name 2>/dev/null" \
+   "Failed to get snapshots for $deploy_id")
+
+for snap in $snaps; do
+    exec_and_log \
+        "virsh --connect $QEMU_PROTOCOL://$src_host/system snapshot-delete $deploy_id --snapshotname $snap --metadata" \
+        "Failed to delete snapshot $snap from $deploy_id"
+done
 
 virsh --connect $QEMU_PROTOCOL://$src_host/system \
     migrate --live $deploy_id $MIGRATE_OPTIONS $QEMU_PROTOCOL://$dest_host/system


### PR DESCRIPTION
Otherwise the migration fails on existing snapshots:
"error: Requested operation is not valid: cannot migrate domain with 3 snapshots"