### PR TITLE
Fixed create support ticket severity custom field

### DIFF
--- a/src/sunstone/routes/support.rb
+++ b/src/sunstone/routes/support.rb
@@ -171,7 +171,8 @@ post '/support/request' do
             :custom_fields => [
               {:id => SUPPORT[:custom_field_severity], :value => body_hash['severity']},
               {:id => SUPPORT[:custom_field_version], :value => body_hash['opennebula_version']}
-            ]
+            ],
+            :tags => [body_hash['severity']]
           })
 
     if zrequest.save


### PR DESCRIPTION
Tested today towards zendesk and severity was not submitted correctly. I figure out, that we need to add severity value to tags also, because dropdown custom field use tags at the background.

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>