### PR TITLE
fix ceph tm_mad to allow resizing persistent disk

### DIFF
--- a/src/tm_mad/ceph/resize
+++ b/src/tm_mad/ceph/resize
@@ -61,13 +61,19 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VM_ID| $XPATH \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
                     /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CEPH_USER \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CEPH_CONF)
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/CEPH_CONF \
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT)
 
 RBD_SRC="${XPATH_ELEMENTS[j++]}"
 CEPH_USER="${XPATH_ELEMENTS[j++]}"
 CEPH_CONF="${XPATH_ELEMENTS[j++]}"
+PERSISTENT="${XPATH_ELEMENTS[j++]}"
 
-RBD_DST="${RBD_SRC}-${VM_ID}-${DISK_ID}"
+if [[ $PERSISTENT == "YES" ]] ; then \
+  RBD_DST=$RBD_SRC
+else
+  RBD_DST="${RBD_SRC}-${VM_ID}-${DISK_ID}"
+fi
 
 #-------------------------------------------------------------------------------
 # Resize disk


### PR DESCRIPTION
This allows to resize a ceph persistent disk by getting its name from
the SOURCE parameter on the disk in the VM template. (If PERSISTENT is
not YES, the behavior is as before.)