### PR TITLE
B #5035: Specify QCOW2 backing file formats

### DIFF
--- a/src/datastore_mad/remotes/fs/snap_revert
+++ b/src/datastore_mad/remotes/fs/snap_revert
@@ -79,7 +79,7 @@ EOF
         ssh_exec_and_log "$DST_HOST" "rm $ACTIVE_SNAP_PATH" \
             "Error deleting $ACTIVE_SNAP_PATH"
 
-        ssh_exec_and_log "$DST_HOST" "qemu-img create -f qcow2 -b $SNAP_PATH $ACTIVE_SNAP_PATH" \
+        ssh_exec_and_log "$DST_HOST" "qemu-img create -f qcow2 -o backing_fmt=qcow2 -b $SNAP_PATH $ACTIVE_SNAP_PATH" \
             "Error reverting snapshot to $SNAP_PATH"
     else
         ACTIVE_SNAP_ID=$(monitor_and_log "$SNAP_ID_SCRIPT" "Error get active snapshot ID" 2>&1)
@@ -88,7 +88,7 @@ EOF
         exec_and_log "rm ${ACTIVE_SNAP_PATH}" \
             "Error deleting $ACTIVE_SNAP_PATH"
 
-        exec_and_log "qemu-img create -f qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}" \
+        exec_and_log "qemu-img create -f qcow2 -o backing_fmt=qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}" \
             "Error reverting snapshot to $SNAP_PATH"
     fi
 else

--- a/src/tm_mad/qcow2/clone
+++ b/src/tm_mad/qcow2/clone
@@ -109,7 +109,8 @@ rm -rf "${DST_PATH}.snap"
 
 mkdir -p "${DST_PATH}.snap"
 
-$QEMU_IMG create -b $SRC_PATH -f qcow2 $QCOW2_OPTIONS ${DST_PATH}.snap/0
+B_FORMAT=\$($QEMU_IMG info $SRC_PATH | grep "^file format:" | awk '{print \$3}' || :)
+$QEMU_IMG create -o backing_fmt=\${B_FORMAT:-raw} -b $SRC_PATH -f qcow2 $QCOW2_OPTIONS ${DST_PATH}.snap/0
 
 rm -f "${DST_PATH}"
 

--- a/src/tm_mad/qcow2/snap_create
+++ b/src/tm_mad/qcow2/snap_create
@@ -86,7 +86,7 @@ mkdir -p "${SNAP_DIR}"
 PREVIOUS_SNAP=\$(readlink $SYSTEM_DS_DISK_PATH)
 
 cd "${SNAP_DIR}"
-qemu-img create -f qcow2 -b "\${PREVIOUS_SNAP}" "${SNAP_PATH}"
+qemu-img create -f qcow2 -o backing_fmt=qcow2 -b "\${PREVIOUS_SNAP}" "${SNAP_PATH}"
 ln -sf $SNAP_PATH_SHORT $SYSTEM_DS_DISK_PATH
 EOT
 )

--- a/src/tm_mad/qcow2/snap_create_live
+++ b/src/tm_mad/qcow2/snap_create_live
@@ -131,24 +131,31 @@ mkdir -p "${SNAP_DIR}"
 
 PREVIOUS_SNAP=\$(readlink $SYSTEM_DS_DISK_PATH)
 
-# The file must be created beforehand or libvirt complains with
-# "permission denied"
-touch $SNAP_PATH
-
 # Temporary xml file
 FILENAME="/tmp/snapshot-$VMID-$DISK_ID-$SNAP_ID"
 echo "$DOC" > \$FILENAME
 
 if virsh -c $LIBVIRT_URI domfsfreeze $DEPLOY_ID ; then
     trap "virsh -c $LIBVIRT_URI domfsthaw $DEPLOY_ID" EXIT TERM INT HUP
+elif virsh -c $LIBVIRT_URI suspend $DEPLOY_ID; then
+    trap "virsh -c $LIBVIRT_URI resume $DEPLOY_ID" EXIT TERM INT HUP
+else
+    error_message "Could not domfsfreeze or suspend domain"
+    exit 1
 fi
 
+# older qemu-img requires relative backing file paths
+# to be resolvable from the current directory
+cd "${SNAP_DIR}"
+
+$QEMU_IMG create -o backing_fmt=qcow2 -b "\${PREVIOUS_SNAP}" \
+    -f qcow2 ${QCOW2_OPTIONS} "${SNAP_PATH}"
+
 virsh -c $LIBVIRT_URI snapshot-create $DEPLOY_ID --disk-only --atomic --no-metadata \
-    --xmlfile \$FILENAME
+    --reuse-external --xmlfile \$FILENAME
 
 rm \${FILENAME}
 
-qemu-img rebase -u -b "\${PREVIOUS_SNAP}" "${SNAP_PATH}"
 ln -sf $SNAP_PATH_SHORT $SYSTEM_DS_DISK_PATH
 EOT
 )

--- a/src/tm_mad/qcow2/snap_revert
+++ b/src/tm_mad/qcow2/snap_revert
@@ -73,7 +73,7 @@ fi
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 SNAP_PATH_SHORT="${SNAP_DIR_SHORT}/${SNAP_ID}"
 
-SNAP_CMD="cd "${SNAP_DIR}" ; qemu-img create -f qcow2 -b \"${SNAP_PATH_SHORT}\" \"\$(readlink -f ${DISK_PATH})\""
+SNAP_CMD="cd "${SNAP_DIR}" ; qemu-img create -f qcow2 -o backing_fmt=qcow2 -b \"${SNAP_PATH_SHORT}\" \"\$(readlink -f ${DISK_PATH})\""
 
 ssh_exec_and_log "${SRC_HOST}" "${SNAP_CMD}" \
                  "Error reverting snapshot to ${SNAP_PATH}"


### PR DESCRIPTION
Fixes the AppArmor file access denies in most cases, except hot-attach of the nonpersistent disk (https://bugzilla.redhat.com/show_bug.cgi?id=1361592).