### PR TITLE
Bug 5194

### DIFF
--- a/share/install_gems/Debian9/Gemfile.lock
+++ b/share/install_gems/Debian9/Gemfile.lock
@@ -1,0 +1,112 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    amazon-ec2 (0.9.17)
+      xml-simple (>= 1.0.12)
+    aws-sdk (2.9.39)
+      aws-sdk-resources (= 2.9.39)
+    aws-sdk-core (2.9.39)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.9.39)
+      aws-sdk-core (= 2.9.39)
+    aws-sigv4 (1.0.0)
+    azure (0.7.9)
+      addressable (~> 2.3)
+      azure-core (~> 0.1)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      mime-types (>= 1, < 4.0)
+      nokogiri (~> 1.7)
+      systemu (~> 2.6)
+      thor (~> 0.19)
+    azure-core (0.1.8)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      nokogiri (~> 1.7)
+    builder (3.2.3)
+    configparser (0.1.6)
+    curb (0.9.3)
+    daemons (1.2.4)
+    eventmachine (1.2.3)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
+    hashie (3.5.5)
+    inflection (1.0.0)
+    jmespath (1.3.1)
+    memcache-client (1.8.5)
+    mime-types (2.99.3)
+    mini_portile2 (2.2.0)
+    multipart-post (2.0.0)
+    mustermann (1.0.0)
+    mysql2 (0.4.6)
+    net-ldap (0.12.1)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
+    ox (2.5.0)
+    parse-cron (0.1.4)
+    polyglot (0.3.5)
+    public_suffix (2.0.5)
+    rack (2.0.3)
+    rack-protection (2.0.0)
+      rack
+    scrub_rb (1.0.1)
+    sequel (4.47.0)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    sqlite3 (1.3.13)
+    systemu (2.6.5)
+    thin (1.7.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    thor (0.19.4)
+    tilt (2.0.7)
+    treetop (1.6.8)
+      polyglot (~> 0.3)
+    trollop (2.1.2)
+    uuidtools (2.1.5)
+    xml-simple (1.1.5)
+    zendesk_api (1.13.4)
+      faraday (~> 0.9)
+      hashie (>= 1.2, < 4.0, != 3.3.0)
+      inflection
+      mime-types (~> 2.99)
+      multipart-post (~> 2.0)
+      scrub_rb (~> 1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  amazon-ec2
+  aws-sdk (~> 2.5)
+  azure
+  builder
+  configparser
+  curb
+  memcache-client
+  mysql2
+  net-ldap (< 0.13)
+  nokogiri
+  ox
+  parse-cron
+  rack
+  sequel
+  sinatra
+  sqlite3
+  thin
+  treetop (>= 1.6.3)
+  trollop
+  uuidtools
+  zendesk_api (< 1.14.0)
+
+BUNDLED WITH
+   1.15.1

--- a/share/install_gems/Ubuntu1704/Gemfile.lock
+++ b/share/install_gems/Ubuntu1704/Gemfile.lock
@@ -1,0 +1,112 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    amazon-ec2 (0.9.17)
+      xml-simple (>= 1.0.12)
+    aws-sdk (2.9.39)
+      aws-sdk-resources (= 2.9.39)
+    aws-sdk-core (2.9.39)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.9.39)
+      aws-sdk-core (= 2.9.39)
+    aws-sigv4 (1.0.0)
+    azure (0.7.9)
+      addressable (~> 2.3)
+      azure-core (~> 0.1)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      mime-types (>= 1, < 4.0)
+      nokogiri (~> 1.7)
+      systemu (~> 2.6)
+      thor (~> 0.19)
+    azure-core (0.1.8)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      nokogiri (~> 1.7)
+    builder (3.2.3)
+    configparser (0.1.6)
+    curb (0.9.3)
+    daemons (1.2.4)
+    eventmachine (1.2.3)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
+    hashie (3.5.5)
+    inflection (1.0.0)
+    jmespath (1.3.1)
+    memcache-client (1.8.5)
+    mime-types (2.99.3)
+    mini_portile2 (2.2.0)
+    multipart-post (2.0.0)
+    mustermann (1.0.0)
+    mysql2 (0.4.6)
+    net-ldap (0.12.1)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
+    ox (2.5.0)
+    parse-cron (0.1.4)
+    polyglot (0.3.5)
+    public_suffix (2.0.5)
+    rack (2.0.3)
+    rack-protection (2.0.0)
+      rack
+    scrub_rb (1.0.1)
+    sequel (4.47.0)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    sqlite3 (1.3.13)
+    systemu (2.6.5)
+    thin (1.7.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    thor (0.19.4)
+    tilt (2.0.7)
+    treetop (1.6.8)
+      polyglot (~> 0.3)
+    trollop (2.1.2)
+    uuidtools (2.1.5)
+    xml-simple (1.1.5)
+    zendesk_api (1.13.4)
+      faraday (~> 0.9)
+      hashie (>= 1.2, < 4.0, != 3.3.0)
+      inflection
+      mime-types (~> 2.99)
+      multipart-post (~> 2.0)
+      scrub_rb (~> 1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  amazon-ec2
+  aws-sdk (~> 2.5)
+  azure
+  builder
+  configparser
+  curb
+  memcache-client
+  mysql2
+  net-ldap (< 0.13)
+  nokogiri
+  ox
+  parse-cron
+  rack
+  sequel
+  sinatra
+  sqlite3
+  thin
+  treetop (>= 1.6.3)
+  trollop
+  uuidtools
+  zendesk_api (< 1.14.0)
+
+BUNDLED WITH
+   1.15.1

--- a/share/install_gems/install_gems
+++ b/share/install_gems/install_gems
@@ -62,7 +62,7 @@ DISTRIBUTIONS={
         :dependencies_common => ['ruby-dev', 'make'],
         :dependencies => {
             SQLITE      => ['gcc', 'libsqlite3-dev'],
-            'mysql2'     => ['gcc', 'libmysqlclient-dev'],
+            'mysql2'     => ['gcc', ['default-libmysqlclient-dev', 'libmysqlclient-dev']],
             'curb'      => ['gcc', 'libcurl4-openssl-dev'],
             $nokogiri   => %w{gcc rake libxml2-dev libxslt1-dev patch},
             'xmlparser' => ['gcc', 'libexpat1-dev'],
@@ -71,6 +71,7 @@ DISTRIBUTIONS={
         },
         :install_command_interactive => 'apt-get install',
         :install_command => 'apt-get -y install',
+        :check_command => 'apt-cache show',
         :gem_env    => {
             'rake'      => '/usr/bin/rake'
         }
@@ -88,7 +89,8 @@ DISTRIBUTIONS={
             'json'      => ['gcc']
         },
         :install_command_interactive => 'yum install',
-        :install_command => 'yum -y install'
+        :install_command => 'yum -y install',
+        :check_command => 'yum info',
     }
 }
 
@@ -256,14 +258,14 @@ end
 
 def get_gems(packages)
     ([$nokogiri]+packages.map do |package|
-	GROUPS[package.to_sym]
+        GROUPS[package.to_sym]
     end).flatten.uniq-installed_gems
 end
 
 
 def detect_distro
     begin
-        lsb_info=`lsb_release -a`
+        lsb_info=`lsb_release -a 2>/dev/null`
     rescue
     end
 
@@ -293,11 +295,36 @@ EOT
     end
 end
 
-def get_dependencies(gems, dependencies)
+def get_dependencies(gems, dependencies, check_command)
     deps=[]
 
     gems.each do |gem_name|
-        deps<<dependencies[gem_name]
+        next unless dependencies.has_key?(gem_name)
+
+        dependencies[gem_name].each do |pkg|
+            if pkg.is_a? Array
+                alt_pkg = nil
+
+                pkg.each do |p|
+                    `#{check_command} #{p} 2>/dev/null`
+
+                    if $?.exitstatus==0
+                        alt_pkg = p
+                        break
+                    end
+                end
+
+                if alt_pkg
+                    deps << alt_pkg
+                else
+                    puts "Could not find any suitable package from candidates:"
+                    puts pkg.join(", ")
+                    exit(-1)
+                end
+            else
+                deps << pkg
+            end
+        end
     end
 
     deps.flatten!
@@ -319,7 +346,8 @@ def install_dependencies(gems, distro)
         STDIN.readline
     else
         puts "Distribution \"#{distro.first}\" detected."
-        deps=get_dependencies(gems, distro.last[:dependencies])
+        deps=get_dependencies(gems, distro.last[:dependencies],
+                              distro.last[:check_command])
         deps+=distro.last[:dependencies_common]
 
         if deps.length==0
@@ -466,7 +494,8 @@ def show_allpackages(packages)
         distro=select_distribution
     end
 
-    deps=get_dependencies(gems, distro.last[:dependencies])
+    deps=get_dependencies(gems, distro.last[:dependencies],
+                          distro.last[:check_command])
     deps+=distro.last[:dependencies_common]
 
     if deps.length==0


### PR DESCRIPTION
- support package alternatives in install_gems
- have primary default-libmysqlclient-dev and secondary libmysqlclient-dev dependency on Debian-like
- add Gemfile.locks for D9 and Ubuntu 17.04