### PR TITLE
Fix authentication for users with non-ascii chars in their names

### DIFF
--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -155,10 +155,11 @@ class OpenNebula::LdapAuth
     end
 
     def is_in_group?(user, group)
+        username = user.first.force_encoding(Encoding::UTF_8)
         result=@ldap.search(
                     :base   => group,
                     :attributes => [@options[:group_field]],
-                    :filter => "(#{@options[:group_field]}=#{user.first})")
+                    :filter => "(#{@options[:group_field]}=#{username})")
 
         if result && result.first
             true
@@ -228,4 +229,3 @@ private
       string.gsub(FILTER_ESCAPE_RE) { |char| "\\" + FILTER_ESCAPES[char] }
     end
 end
-


### PR DESCRIPTION
ldap uses base64 encoding iff there are non-ascii chars.
For some reason the query seems to then return the user_group_name
(src/authm_mad/remotes/ldap/authenticate) as ascii-encoded.
This is only relevant when a group is set in ldap_auth.conf, in which
case ldap.is_in_group is called.
By forcing the encoding to utf-8 the authentication succeeds.

Before this error was encountered:
Exception raised authenticating to LDAP
(UTF-8 regexp with ASCII-8BIT string)>
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:755:in `scan'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:755:in
`parse_filter_branch'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:737:in
`parse_paren_expression'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:682:in `parse'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:673:in `initialize'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:667:in `new'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:667:in `parse'
/usr/lib/ruby/vendor_ruby/net/ldap/filter.rb:341:in `construct'
/usr/lib/ruby/vendor_ruby/net/ldap/connection.rb:322:in `search'
/usr/lib/ruby/vendor_ruby/net/ldap.rb:753:in `block (2 levels) in
search'
/usr/lib/ruby/vendor_ruby/net/ldap.rb:1228:in `use_connection'
/usr/lib/ruby/vendor_ruby/net/ldap.rb:752:in `block in search'
/usr/lib/ruby/vendor_ruby/net/ldap/instrumentation.rb:19:in `instrument'
/usr/lib/ruby/vendor_ruby/net/ldap.rb:751:in `search'
/usr/lib/one/ruby/opennebula/ldap_auth.rb:163:in `is_in_group?'
authenticate:85:in `block in <main>'
authenticate:59:in `each'
authenticate:59:in `<main>'
Could not authenticate user tavestbo