### PR TITLE
xpath.rb fix crash when querying empty-element tag

### DIFF
--- a/src/datastore_mad/remotes/xpath.rb
+++ b/src/datastore_mad/remotes/xpath.rb
@@ -66,9 +66,9 @@ ARGV.each do |xpath|
         element = xml.elements[xpath.dup]
         if !element.nil?
             if element.class.method_defined?(:text)
-                values << element.text
+                values << ( element.text || '' )
             else
-                values << element.to_s
+                values << ( element.to_s || '' )
             end
         end
     end


### PR DESCRIPTION
by returning empty string.
Handling both `<test/>` and `<test></test>`
test pattern:
```
echo -e "<A>\n<B>b</B>\n<C/>\n<D></D><E>e</E></A>\n"| /var/lib/one/remotes/datastore/xpath.rb /A/B /A/C /A/D /A/E | while IFS= read -r -d '' e; do echo "'$e'"; done
```