### PR TITLE
Fix vxlan device creation

### DIFF
--- a/src/vnm_mad/remotes/vxlan/vxlan_driver.rb
+++ b/src/vnm_mad/remotes/vxlan/vxlan_driver.rb
@@ -51,7 +51,7 @@ class VXLANDriver < VNMMAD::VLANDriver
         end
 
         mc  = ipaddr.to_i + @nic[:vlan_id].to_i
-        mcs = VNMMAD::VNMNetwork::IPv4.to_s(mc)
+        mcs = IPAddr.new(mc, Socket::AF_INET).to_s
 
         mtu = @nic[:mtu] ? "mtu #{@nic[:mtu]}" : "mtu #{@nic[:conf][:vxlan_mtu]}"
         ttl = @nic[:conf][:vxlan_ttl] ? "ttl #{@nic[:conf][:vxlan_ttl]}" : ""


### PR DESCRIPTION
Since the upgrade to opennebula 5.4, the creation of vxlan doesn't work.
In the commit fe84d376acb079c1c1a357e9e69834fcbba2502d the module `VNMMAD::VNMNetwork::IPv4` has been removed and `IPAddr` class used.
But on merge 1b28fbe354f84177ac46065d7fb22c880e288127 `VNMMAD::VNMNetwork::IPv4` is used again but without the module declaration in `lib/address.rb`