### PR TITLE
Send unsolicited ARP packet to update IP across switches

### DIFF
--- a/share/hooks/raft/vip.sh
+++ b/share/hooks/raft/vip.sh
@@ -17,7 +17,8 @@ fi
 case $ACTION in
 leader)
     sudo ip address add $IP dev $INTERFACE
-    sudo arping -c 5 -U -I $INTERFACE ${IP%%/*}
+    sudo arping -c 3 -U -I $INTERFACE ${IP%%/*}
+    sudo arping -c 3 -UA -I $INTERFACE ${IP%%/*}
     ;;
 
 follower)

--- a/share/hooks/raft/vip.sh
+++ b/share/hooks/raft/vip.sh
@@ -17,7 +17,7 @@ fi
 case $ACTION in
 leader)
     sudo ip address add $IP dev $INTERFACE
-    arping -c 5 -A -I $INTERFACE ${IP%%/*}
+    arping -c 5 -U -I $INTERFACE ${IP%%/*}
     ;;
 
 follower)

--- a/share/hooks/raft/vip.sh
+++ b/share/hooks/raft/vip.sh
@@ -17,7 +17,7 @@ fi
 case $ACTION in
 leader)
     sudo ip address add $IP dev $INTERFACE
-    arping -c 5 -U -I $INTERFACE ${IP%%/*}
+    sudo arping -c 5 -U -I $INTERFACE ${IP%%/*}
     ;;
 
 follower)


### PR DESCRIPTION
The arping parameter needs to be -U instead of -A as an unsolicited ARP packet is needed to update the ARP tables in switches. Without that the switch of the IP to a different host is not recognized and requests to the floating IP do not reach the correct node.

Bug report https://dev.opennebula.org/issues/5309