### PR TITLE
Ldap filter can use `;` character

### DIFF
--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -127,7 +127,7 @@ class OpenNebula::LdapAuth
 
     def find_user(name)
         begin
-            filter = "#{@options[:user_field]}=#{escape(name)}"
+            filter = Net::LDAP::Filter.eq(@options[:user_field], escape(name))
 
             result = @ldap.search(
                 :base       => @options[:base],


### PR DESCRIPTION
This change will allow user_field to contain characters such as `;`. This is useful because some of ldap attributes look like `login;organization`.