### PR TITLE
B #5393: Prefix libvirt snapshot name with snap-

### DIFF
--- a/src/vmm_mad/remotes/kvm/snapshot_create
+++ b/src/vmm_mad/remotes/kvm/snapshot_create
@@ -22,7 +22,7 @@ source $(dirname $0)/../../scripts_common.sh
 DOMAIN="$1"
 SNAP_ID="$2"
 
-data=`virsh --connect $LIBVIRT_URI snapshot-create-as $DOMAIN --name $SNAP_ID`
+data=`virsh --connect $LIBVIRT_URI snapshot-create-as $DOMAIN --name "snap-${SNAP_ID}"`
 
 if [ "$?" = "0" ]; then
     echo "$data" | awk '{print $3}'


### PR DESCRIPTION
libvirt/QEMU has problem with simple numberic names,
it's confused with the internal snapshot IDs:
https://bugzilla.redhat.com/show_bug.cgi?id=733143