### PR TITLE
sudo for mkfs also questionable and mkswap partly missing

### DIFF
--- a/share/pkgs/CentOS/opennebula.sudoers
+++ b/share/pkgs/CentOS/opennebula.sudoers
@@ -1,7 +1,7 @@
 Defaults:oneadmin !requiretty
 Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
-Cmnd_Alias ONE_MISC = /sbin/mkfs, /bin/sync, /sbin/mkswap
+Cmnd_Alias ONE_MISC = /bin/sync, /sbin/mkswap
 Cmnd_Alias ONE_NET = /usr/sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip6tables, /sbin/ip, /usr/sbin/ipset, /usr/sbin/arping
 Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange, /sbin/lvscan
 Cmnd_Alias ONE_ISCSI = /sbin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm

--- a/share/pkgs/Debian7/opennebula.sudoers
+++ b/share/pkgs/Debian7/opennebula.sudoers
@@ -1,7 +1,7 @@
 Defaults:oneadmin !requiretty
 Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
-Cmnd_Alias ONE_MISC = /sbin/mkfs, /bin/sync, /sbin/mkswap
+Cmnd_Alias ONE_MISC = /bin/sync, /sbin/mkswap
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip, /usr/sbin/ipset, /usr/bin/arping
 Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange, /sbin/lvscan
 Cmnd_Alias ONE_ISCSI = /usr/bin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm

--- a/share/pkgs/Debian8/opennebula.sudoers
+++ b/share/pkgs/Debian8/opennebula.sudoers
@@ -1,7 +1,7 @@
 Defaults:oneadmin !requiretty
 Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
-Cmnd_Alias ONE_MISC = /sbin/mkfs, /bin/sync, /sbin/mkswap
+Cmnd_Alias ONE_MISC = /bin/sync, /sbin/mkswap
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip6tables, /sbin/ip, /sbin/ipset, /usr/bin/arping
 Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange, /sbin/lvscan
 Cmnd_Alias ONE_ISCSI = /usr/bin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm

--- a/share/pkgs/Ubuntu/opennebula.sudoers
+++ b/share/pkgs/Ubuntu/opennebula.sudoers
@@ -1,7 +1,7 @@
 Defaults:oneadmin !requiretty
 Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
-Cmnd_Alias ONE_MISC = /sbin/mkfs, /bin/sync, /sbin/mkswap
+Cmnd_Alias ONE_MISC = /bin/sync, /sbin/mkswap
 Cmnd_Alias ONE_NET = /sbin/brctl, /sbin/ebtables, /sbin/iptables, /sbin/ip6tables, /sbin/ip, /sbin/ipset, /usr/bin/arping
 Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange, /sbin/lvscan
 Cmnd_Alias ONE_ISCSI = /usr/bin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm

--- a/share/pkgs/openSUSE/opennebula.sudoers
+++ b/share/pkgs/openSUSE/opennebula.sudoers
@@ -1,7 +1,7 @@
 Defaults:oneadmin !requiretty
 Defaults:oneadmin secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
-Cmnd_Alias ONE_MISC = /sbin/mkfs, /usr/bin/sync
+Cmnd_Alias ONE_MISC = /usr/bin/sync, /sbin/mkswap
 Cmnd_Alias ONE_NET = /sbin/brctl, /usr/sbin/ebtables, /usr/sbin/iptables, /usr/sbin/ip6tables, /sbin/ip, /usr/sbin/arping
 Cmnd_Alias ONE_LVM = /sbin/lvcreate, /sbin/lvremove, /sbin/lvs, /sbin/vgdisplay, /sbin/lvchange, /sbin/lvscan
 Cmnd_Alias ONE_ISCSI = /sbin/iscsiadm, /usr/sbin/tgt-admin, /usr/sbin/tgtadm

--- a/share/sudoers/sudo_commands.rb
+++ b/share/sudoers/sudo_commands.rb
@@ -20,7 +20,7 @@ require "erb"
 
 
 CMDS = {
-    :MISC  => %w(dd mkfs sync),
+    :MISC  => %w(mkfs sync),
     :NET   => %w(brctl ebtables iptables ip6tables ip ipset),
     :LVM   => %w(lvcreate lvremove lvs vgdisplay lvchange lvscan),
     :ISCSI => %w(iscsiadm tgt-admin tgtadm),

--- a/share/sudoers/sudo_commands.rb
+++ b/share/sudoers/sudo_commands.rb
@@ -20,7 +20,7 @@ require "erb"
 
 
 CMDS = {
-    :MISC  => %w(mkfs sync),
+    :MISC  => %w(sync mkswap),
     :NET   => %w(brctl ebtables iptables ip6tables ip ipset),
     :LVM   => %w(lvcreate lvremove lvs vgdisplay lvchange lvscan),
     :ISCSI => %w(iscsiadm tgt-admin tgtadm),


### PR DESCRIPTION
mkswap was missing in openSUSE sudoers-distributionfile and in sudo_commands.rb

Also similar to dd I was reviewing the necessity of sudo for mkfs -  wasn't able to find a line where it's called with elevated privileges. But maybe I'm misunderstanding concepts here.