### PR TITLE
Fix user login via LDAP (refs #1489)

### DIFF
--- a/src/authm_mad/remotes/ldap/authenticate
+++ b/src/authm_mad/remotes/ldap/authenticate
@@ -76,7 +76,7 @@ begin
     end
 
     if server_conf[:group]
-        if !ldap.is_in_group?(user_group_name, server_conf[:group])
+        if !ldap.is_in_group?(user, server_conf[:group])
             STDERR.puts "User #{user} is not in group #{server_conf[:group]}"
             next
         end

--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -155,7 +155,7 @@ class OpenNebula::LdapAuth
     end
 
     def is_in_group?(user, group)
-        username = user.first.force_encoding(Encoding::UTF_8)
+        username = user.force_encoding(Encoding::UTF_8)
         result=@ldap.search(
                     :base   => group,
                     :attributes => [@options[:group_field]],


### PR DESCRIPTION
User parameter was not a table anymore, and first parameter of 'is_in_group' should be the user's dn