### PR TITLE
B #1481: Better estimate image sizes

### DIFF
--- a/src/datastore_mad/remotes/common/stat
+++ b/src/datastore_mad/remotes/common/stat
@@ -45,15 +45,21 @@ unset i XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH /DS_DRIVER_ACTION_DATA/IMAGE/PATH)
+done < <($XPATH /DS_DRIVER_ACTION_DATA/IMAGE/PATH \
+                /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/NO_DECOMPRESS \
+                /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/LIMIT_TRANSFER_BW)
 
-SRC="${XPATH_ELEMENTS[0]}"
+unset i
+
+SRC="${XPATH_ELEMENTS[i++]}"
+NO_DECOMPRESS="${XPATH_ELEMENTS[i++]}"
+LIMIT_TRANSFER_BW="${XPATH_ELEMENTS[i++]}"
 
 # ------------------------------------------------------------------------------
 #  Compute the size
 # ------------------------------------------------------------------------------
 
-SIZE=`fs_size $SRC`
+SIZE=`fs_size "${SRC}" "${NO_DECOMPRESS}" "${LIMIT_TRANSFER_BW}"`
 
 if [ "$SIZE" = "0" ]; then
     log_error "Cannot determine size for $SRC"

--- a/src/datastore_mad/remotes/libfs.sh
+++ b/src/datastore_mad/remotes/libfs.sh
@@ -221,10 +221,13 @@ function fs_size {
         exit 1
     fi
 
+    error=1
+
+    # limit only on local or remote http(s)
     if [ -d "${SRC}" ]; then
         SIZE=`du -sb "${SRC}" | cut -f1`
         error=$?
-    else
+    elif [ -f "${SRC}" ] || (echo "${SRC}" | grep -qe '^https\?://'); then
         IMAGE=$(mktemp)
 
         # try first download only a part of image

--- a/src/tm_mad/fs_lvm/clone
+++ b/src/tm_mad/fs_lvm/clone
@@ -76,7 +76,7 @@ SIZE="${XPATH_ELEMENTS[j++]}"
 ORIGINAL_SIZE="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
 
-FILE_SIZE=`fs_size $SRC_PATH`
+FILE_SIZE=`fs_size "${SRC_PATH}" YES`
 
 if [ $FILE_SIZE -gt $SIZE ]; then
     SIZE="$FILE_SIZE"


### PR DESCRIPTION
Improves support for importing of the compressed images, except the remote compressed raw images (these require complete image download to get the size). Adds XZ support.

### Supported remote (http) image formats

format / compression | no | .gz | .bz2 | .xz
------|--------|-----|------|------
raw | OK | - | - | -
qcow2 | OK | OK | OK | OK
vmdk | OK | OK | OK | OK

### Supported local image formats

format / compression | no | .gz | .bz2 | .xz
------|--------|-----|------|------
raw | OK | OK | OK | OK
qcow2 | OK | OK | OK | OK
vmdk | OK | OK | OK | OK

