### PR TITLE
Fix performance issue in sunstone / mysql

### DIFF
--- a/src/onedb/database_schema.rb
+++ b/src/onedb/database_schema.rb
@@ -57,7 +57,7 @@ class OneDBBacKEnd
             vm_pool: "oid INTEGER PRIMARY KEY, name VARCHAR(128), " <<
                 "body MEDIUMTEXT, uid INTEGER, gid INTEGER, " <<
                 "last_poll INTEGER, state INTEGER, lcm_state INTEGER, " <<
-                "owner_u INTEGER, group_u INTEGER, other_u INTEGER",
+                "owner_u INTEGER, group_u INTEGER, other_u INTEGER, index(state)",
             logdb: "log_index INTEGER PRIMARY KEY, term INTEGER, " <<
                 "sqlcmd MEDIUMTEXT, timestamp INTEGER, fed_index INTEGER",
             history: "vid INTEGER, seq INTEGER, body MEDIUMTEXT, " <<

--- a/src/vm/VirtualMachine.cc
+++ b/src/vm/VirtualMachine.cc
@@ -461,7 +461,7 @@ const char * VirtualMachine::db_names =
 const char * VirtualMachine::db_bootstrap = "CREATE TABLE IF NOT EXISTS "
     "vm_pool (oid INTEGER PRIMARY KEY, name VARCHAR(128), body MEDIUMTEXT, uid INTEGER, "
     "gid INTEGER, last_poll INTEGER, state INTEGER, lcm_state INTEGER, "
-    "owner_u INTEGER, group_u INTEGER, other_u INTEGER)";
+    "owner_u INTEGER, group_u INTEGER, other_u INTEGER, index(state))";
 
 
 const char * VirtualMachine::monit_table = "vm_monitoring";


### PR DESCRIPTION
Sunstone often queries for running VMs. Over time the query became
quite expensive because it scans for all VMs that were ever created.
For our case in which we had more then 600k done machines, the query
time was longer then 25s, causing sunstone to start pondering about
it's db connection and freezing.

This patch tries to mitigate the problem by installing an index on
vm_pool.state column, so running VMs could be found in almost no
time.