### PR TITLE
Add CEPH_KEY to snap_revert driver operation

### DIFF
--- a/src/tm_mad/ceph/snap_revert
+++ b/src/tm_mad/ceph/snap_revert
@@ -107,6 +107,10 @@ if [ -n "$CEPH_USER" ]; then
     RBD="$RBD --id ${CEPH_USER}"
 fi
 
+if [ -n "$CEPH_KEY" ]; then
+    RBD="$RBD --keyfile ${CEPH_KEY}"
+fi
+
 if [ -n "$CEPH_CONF" ]; then
     RBD="$RBD --conf ${CEPH_CONF}"
 fi


### PR DESCRIPTION
For setups with multiple Ceph clusters we introduced the "CEPH_KEY" variable a while ago. All CEPH drivers have this CEPH_KEY, but snap_revert did not use it yet. This PR to fix that.