### PR TITLE
Fix token creation handeling

### DIFF
--- a/src/rm/RequestManagerUser.cc
+++ b/src/rm/RequestManagerUser.cc
@@ -503,9 +503,18 @@ void UserLogin::request_execute(xmlrpc_c::paramList const& paramList,
     }
     else if (valid > 0 || valid == -1)
     {
-        if ( egid != -1 && !user->is_in_group(egid) )
+        if ( egid != -1 && (!user->is_in_group(egid) || att.group_ids.find(egid) == att.group_ids.end()) )
         {
             att.resp_msg = "EGID is not in user group list";
+            failure_response(XML_RPC_API,  att);
+
+            user->unlock();
+            return;
+        }
+
+        if ( egid == -1 && user->get_groups() != att.group_ids )
+        {
+            att.resp_msg = "Cannot request unscoped token from scoped token";
             failure_response(XML_RPC_API,  att);
 
             user->unlock();

--- a/src/rm/RequestManagerUser.cc
+++ b/src/rm/RequestManagerUser.cc
@@ -503,7 +503,7 @@ void UserLogin::request_execute(xmlrpc_c::paramList const& paramList,
     }
     else if (valid > 0 || valid == -1)
     {
-        if ( egid != -1 && (!user->is_in_group(egid) || att.group_ids.find(egid) == att.group_ids.end()) )
+        if ( egid != -1 && (!user->is_in_group(egid) || att.group_ids.count(egid) == 0) )
         {
             att.resp_msg = "EGID is not in user group list";
             failure_response(XML_RPC_API,  att);


### PR DESCRIPTION
Hello,
this pull request adds one more check before token creation. It checks if token that was used to generate another token has access to requested groups. In practice that means that users with token just for group 100 cannot create token for group 0 and so on. Also tokens scoped for group cannot be used to generate token for all groups that user belongs to (to generate unscoped token).

I hope this explains the issue. Also if any part of my pull request should be changed let me know and I will do my best.