### PR TITLE
Restrict token regeneration using token

### DIFF
--- a/include/Request.h
+++ b/include/Request.h
@@ -55,11 +55,14 @@ public:
     int                       resp_id;  /**< Id of the object */
     string                    resp_msg; /**< Additional response message */
 
+    bool                      is_token; /**< If token was used for authentication */
+
     RequestAttributes()
     {
         resp_obj = PoolObjectSQL::NONE;
         resp_id  = -1;
         resp_msg = "";
+        is_token = false;
     };
 
     RequestAttributes(const RequestAttributes& ra)
@@ -84,6 +87,8 @@ public:
         resp_obj = ra.resp_obj;
         resp_id  = ra.resp_id;
         resp_msg = ra.resp_msg;
+
+        is_token = ra.is_token;
     };
 
     RequestAttributes(int _uid, int _gid, const RequestAttributes& ra)
@@ -110,6 +115,8 @@ public:
         resp_obj = PoolObjectSQL::NONE;
         resp_id  = -1;
         resp_msg = "";
+
+        is_token = ra.is_token;
     };
 };
 

--- a/include/UserPool.h
+++ b/include/UserPool.h
@@ -176,7 +176,8 @@ public:
                       string&       uname,
                       string&       gname,
                       set<int>&     group_ids,
-                      int&          umask);
+                      int&          umask,
+                      bool&         is_token);
     /**
      * Returns whether the operations described in a authorization request are
      * authorized ot not.
@@ -260,7 +261,8 @@ private:
                                string&       uname,
                                string&       gname,
                                set<int>&     group_ids,
-                               int&          umask);
+                               int&          umask,
+                               bool&         is_token);
 
     /**
      *  Function to authenticate internal users using a server driver

--- a/src/rm/Request.cc
+++ b/src/rm/Request.cc
@@ -281,7 +281,7 @@ void Request::execute(
     UserPool* upool     = nd.get_upool();
 
     bool authenticated = upool->authenticate(att.session, att.password,
-        att.uid, att.gid, att.uname, att.gname, att.group_ids, att.umask);
+        att.uid, att.gid, att.uname, att.gname, att.group_ids, att.umask, att.is_token);
 
     if ( log_method_call )
     {

--- a/src/rm/RequestManagerUser.cc
+++ b/src/rm/RequestManagerUser.cc
@@ -449,6 +449,12 @@ void UserLogin::request_execute(xmlrpc_c::paramList const& paramList,
         }
     }
 
+    if (att.is_token) {
+        att.resp_msg = "Cannot regenerate token using token";
+        failure_response(AUTHORIZATION, att);
+        return;
+    }
+
     user = static_cast<UserPool *>(pool)->get(uname, true);
 
     if ( user == 0 )

--- a/src/um/UserPool.cc
+++ b/src/um/UserPool.cc
@@ -608,7 +608,8 @@ bool UserPool::authenticate_internal(User *        user,
                                      string&       uname,
                                      string&       gname,
                                      set<int>&     group_ids,
-                                     int&          umask)
+                                     int&          umask,
+                                     bool&         is_token)
 {
     ostringstream oss;
 
@@ -685,6 +686,8 @@ bool UserPool::authenticate_internal(User *        user,
             group_ids.clear();
             group_ids.insert(egid);
         }
+
+        is_token = true;
 
         return true;
     }
@@ -1180,7 +1183,8 @@ bool UserPool::authenticate(const string& session,
                             string&       uname,
                             string&       gname,
                             set<int>&     group_ids,
-                            int&          umask)
+                            int&          umask,
+                            bool&         is_token)
 {
     User * user = 0;
     string username;
@@ -1210,7 +1214,7 @@ bool UserPool::authenticate(const string& session,
         else
         {
             ar = authenticate_internal(user, token, password, user_id, group_id,
-                uname, gname, group_ids, umask);
+                uname, gname, group_ids, umask, is_token);
         }
     }
     else


### PR DESCRIPTION
Hello,
there is a behavior in OpenNebula that allows subjects with token to generate another token. This might not sound like an issue but we think that subjects can regenerate token just before it is about to expire. For example, user was given a token for 1 hour but he generated another token just before the old one expired so now he can access cloud resource for longer, and can redo this process again to gain even more time.

This pull request is my solution to this problem and it might not be correct, so I am opened to all suggestions.