### PR TITLE
Add support for PowerPC CPUs

### DIFF
--- a/src/im_mad/remotes/kvm-probes.d/cpu.sh
+++ b/src/im_mad/remotes/kvm-probes.d/cpu.sh
@@ -16,14 +16,20 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
+MODEL=''
+
 if [ -f /proc/cpuinfo ]; then
-    MODELNAME_EXP="model name"
-    if (uname -m | grep -Eq ^ppc64); then
-        MODELNAME_EXP="model"
-    fi
+    for NAME in 'model name' 'cpu'; do
+        MODEL=$(grep -m1 "^${NAME}[[:space:]]*:" /proc/cpuinfo | \
+            cut -d: -f2 | \
+            sed -e 's/^ *//')
 
-    echo -n "MODELNAME=\""
-    grep -m 1 "${MODELNAME_EXP}" /proc/cpuinfo | cut -d: -f2 | sed -e 's/^ *//' | sed -e 's/$/"/'
-
+        if [ -n "${MODEL}" ]; then
+            break
+        fi
+    done
 fi
 
+if [ -n "${MODEL}" ]; then
+    echo "MODELNAME=\"${MODEL}\""
+fi

--- a/src/im_mad/remotes/kvm-probes.d/cpu.sh
+++ b/src/im_mad/remotes/kvm-probes.d/cpu.sh
@@ -18,7 +18,7 @@
 
 if [ -f /proc/cpuinfo ]; then
     MODELNAME_EXP="model name"
-    if [[ "$(uname -m)" =~ ^ppc64 ]]; then
+    if (uname -m | grep -Eq ^ppc64); then
         MODELNAME_EXP="model"
     fi
 

--- a/src/im_mad/remotes/kvm-probes.d/cpu.sh
+++ b/src/im_mad/remotes/kvm-probes.d/cpu.sh
@@ -17,9 +17,13 @@
 #--------------------------------------------------------------------------- #
 
 if [ -f /proc/cpuinfo ]; then
+    MODELNAME_EXP="model name"
+    if [[ "$(uname -m)" =~ ^ppc64 ]]; then
+        MODELNAME_EXP="model"
+    fi
 
     echo -n "MODELNAME=\""
-    grep -m 1 "model name" /proc/cpuinfo | cut -d: -f2 | sed -e 's/^ *//' | sed -e 's/$/"/'
+    grep -m 1 "${MODELNAME_EXP}" /proc/cpuinfo | cut -d: -f2 | sed -e 's/^ *//' | sed -e 's/$/"/'
 
 fi
 


### PR DESCRIPTION
This minor adjustment allows the detection of PPC CPUs by the standard KVM driver.
I have 2 POWER8 machines that i use as KVM host with this change in place.

The only thing needed besides that is a correct node selection and the definition of EMULATOR in the VM template