### PR TITLE
Allow vlan range notation in ovs

### DIFF
--- a/src/vnm_mad/remotes/ovswitch/OpenvSwitch.rb
+++ b/src/vnm_mad/remotes/ovswitch/OpenvSwitch.rb
@@ -336,7 +336,7 @@ class OpenvSwitchVLAN < VNMMAD::VNMDriver
     end
 
     def range?(range)
-        !range.to_s.match(/^\d+(,\d+)*$/).nil?
+        !range.to_s.match(/^\d+([,-]\d+)*$/).nil?
     end
 
 private


### PR DESCRIPTION
Trivial fix concerning feature #1865 
Tested for ex with VLAN_TAGGED_ID=42,300-400,500 and get 
`trunks              : [42, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 500]`