### PR TITLE
F#2153 Do Command flush requires one parameter to run

### DIFF
--- a/src/cli/etc/onehost.yaml
+++ b/src/cli/etc/onehost.yaml
@@ -74,3 +74,6 @@
 - :ALLOCATED_CPU
 - :ALLOCATED_MEM
 - :STAT
+
+:default_actions:
+  - :flush: resched


### PR DESCRIPTION
## USAGE
flush <range|hostid_list>
        Disables the host and reschedules all the running VMs in it.

## OPTIONS
     -h, --help                Show this message
     -V, --version             Show version and copyright information
     --user name               User name used to connect to OpenNebula
     --password password       Password to authenticate with OpenNebula
     --endpoint endpoint       URL of OpenNebula xmlrpc frontend command more configurable