### PR TITLE
[#878] Allow the VNC JS WS client to connect to a different port than :vnc_proxy_port

### DIFF
--- a/src/sunstone/etc/sunstone-server.conf
+++ b/src/sunstone/etc/sunstone-server.conf
@@ -104,7 +104,7 @@
 # UI Settings
 ################################################################################
 # :vnc_proxy_
-#   port:           port where the vnc proxy will listen
+#   port:           port where the vnc proxy will listen. Could be prefixed with an address on which the sever will be listening (ex: 127.0.0.1:29876).
 #   support_wss:    no | yes | only. For yes and only, provide path to
 #                   cert and key. "yes" means both ws and wss connections will be
 #                   supported.
@@ -112,6 +112,8 @@
 #   vnc_proxy_key:  Key for wss connections. Only necessary if not included in cert.
 #   vnc_proxy_ipv6: Enable ipv6 support for novnc-server
 #
+# :vnc_client_port: port where the vnc JS client will connect
+#   If not set, will use the port section of :vnc_proxy_port
 # :vnc_request_password: true | false
 #   Request VNC password for external windows, by default it will not be requested
 #

--- a/src/sunstone/public/app/sunstone-config.js
+++ b/src/sunstone/public/app/sunstone-config.js
@@ -146,7 +146,7 @@ define(function(require) {
     },
 
     'tableOrder': _config['user_config']['table_order'],
-    'vncProxyPort': _config['system_config']['vnc_proxy_port'],
+    'vncProxyPort': _config['system_config']['vnc_client_port'] || _config['system_config']['vnc_proxy_port'].split(':')[1] || _config['system_config']['vnc_proxy_port'],
     'vncWSS': _config['user_config']['vnc_wss'],
     'requestVNCPassword': _config['system_config']['vnc_request_password'],
     'logo': (_config['view']["small_logo"] || "images/one_small_logo.png"),


### PR DESCRIPTION
### Summary of #878 

> Actually we have the @websocketproxy.py@ listening on the port @29876@ and the NoVNC client open a WebSocket directly on that port.

> I would like the client to only use the port @443@ as I already have a nginx reverse proxy.

### Pull request

**N.B: this a quick fix but this modification doesn't introduce any breaking change. It could be refactored later or pulled out and replaced with a true fix for the next major release.**

In addition to the diff within this PR, this configuration should allow the web client to connect through a reverse proxy on `:443` .

* /etc/one/sunstone-server.conf
```yaml
:vnc_proxy_port: 127.0.0.1:29876
:vnc_proxy_support_wss: yes
:vnc_proxy_cert: /etc/pki/nginx/sunstone.crt
:vnc_proxy_key: /etc/pki/nginx/private/sunstone.key
:vnc_proxy_ipv6: false
:vnc_request_password: false
:vnc_client_port: 443
```
* /etc/nginx/conf.d/sunstone-server.conf
```nginx
upstream opennebula-sunstone {
    server  127.0.0.1:9869;
}

upstream opennebula-sunstone-vnc {
    server  127.0.0.1:29876;
}

server {
    listen       443 ssl;
    listen       [::]:443 ssl;

    access_log  /var/log/nginx/opennebula-sunstone-access.log;
    error_log   /var/log/nginx/opennebula-sunstone-error.log;

    location / {
        proxy_http_version  1.1;
        proxy_set_header     Upgrade $http_upgrade;
        proxy_set_header     Connection "upgrade";

        proxy_pass      http://opennebula-sunstone;

        if ($http_upgrade = "websocket") { # "IF-IS-EVIL" so i would gladly have someone's proposition shift it.
            proxy_pass http://opennebula-sunstone-vnc; # hope sunstone-server itself didn't use WS...
        }
    }
}
```