### PR TITLE
B #2173 always report RSS memory for KVM VMs

### DIFF
--- a/src/vmm_mad/remotes/kvm/poll
+++ b/src/vmm_mad/remotes/kvm/poll
@@ -78,13 +78,12 @@ module KVM
         cpu = get_cpu_info({one_vm => vm})
 
         resident_mem = psinfo[5].to_i
-        max_mem      = dominfo['Max memory'].split(/\s+/).first.to_i
 
         values=Hash.new
 
         values[:state]  = get_state(dominfo['State'])
         values[:cpu]    = cpu[vm[:pid]] if cpu[vm[:pid]]
-        values[:memory] = [resident_mem, max_mem].max
+        values[:memory] = resident_mem
 
         xml = dump_xml(one_vm)
 
@@ -136,13 +135,12 @@ module KVM
             dominfo = vm[:dominfo]
 
             resident_mem = ps_data[5].to_i
-            max_mem      = dominfo['Max memory'].split(/\s+/).first.to_i
 
             values = Hash.new
 
             values[:state]  = get_state(dominfo['State'])
             values[:cpu]    = cpu[vm[:pid]] if cpu[vm[:pid]]
-            values[:memory] = [resident_mem, max_mem].max
+            values[:memory] = resident_mem
 
             xml = dump_xml(name)
 


### PR DESCRIPTION
_max_memory_ is always equal to Available because:
  1. the memballoon is not used for resizing VM memory 
  2. the memballoon stats reporting is not enabled by default:

  ```
  <memballoon model='virtio'>
        <stats period='10'/>
    </memballoon>
  ```