### PR TITLE
B #2433 Monitoring VMs fails when there is not datastore associated

### DIFF
--- a/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
@@ -852,7 +852,9 @@ class Template
         str << "IMPORT_STATE =\"#{@state}\"\n"
 
         # Get DS information
-        str << "VCENTER_DS_REF = \"#{@vm_info["datastore"].last._ref}\"\n"
+        if !@vm_info["datastore"].last._ref.nil?
+            str << "VCENTER_DS_REF = \"#{@vm_info["datastore"].last._ref}\"\n"
+        end
 
         vnc_port = nil
         keymap = VCenterDriver::VIHelper.get_default("VM/TEMPLATE/GRAPHICS/KEYMAP")


### PR DESCRIPTION
apply to:
- master
- one-5.6
- one-5.6-devel