### PR TITLE
F #2476: Erasure-coded Ceph VM images forget about being erasure-coded after restoring a snapshot

### DIFF
--- a/src/datastore_mad/remotes/ceph/snap_revert
+++ b/src/datastore_mad/remotes/ceph/snap_revert
@@ -49,6 +49,7 @@ while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/POOL_NAME \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/EC_POOL_NAME \
                     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/CEPH_USER \
@@ -59,6 +60,7 @@ unset i
 
 BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
 POOL_NAME="${XPATH_ELEMENTS[i++]:-$POOL_NAME}"
+EC_POOL_NAME="${XPATH_ELEMENTS[i++]}"
 RBD_SRC="${XPATH_ELEMENTS[i++]}"
 SNAP_ID="${XPATH_ELEMENTS[i++]}"
 CEPH_USER="${XPATH_ELEMENTS[i++]}"
@@ -84,6 +86,10 @@ if [ -n "$CEPH_CONF" ]; then
     RBD="$RBD --conf ${CEPH_CONF}"
 fi
 
+if [ -n "$EC_POOL_NAME" ]; then
+    EC_POOL_OPT="--data-pool ${EC_POOL_NAME}"
+fi
+
 SNAP_REVERT_CMD=$(cat <<EOF
     RBD="${RBD}"
 
@@ -98,7 +104,7 @@ SNAP_REVERT_CMD=$(cat <<EOF
         exit 1
     fi
 
-    $RBD clone \${RBD_TGT}@$SNAP_ID $RBD_SRC
+    $RBD ${EC_POOL_OPT} clone \${RBD_TGT}@$SNAP_ID $RBD_SRC
 EOF
 )
 

--- a/src/tm_mad/ceph/snap_revert
+++ b/src/tm_mad/ceph/snap_revert
@@ -81,6 +81,19 @@ else
 fi
 
 #-------------------------------------------------------------------------------
+# Get Datastore information
+#-------------------------------------------------------------------------------
+
+unset i j XPATH_ELEMENTS
+
+while IFS= read -r -d '' element; do
+        XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x $DS_ID | $XPATH \
+                    /DATASTORE/TEMPLATE/EC_POOL_NAME)
+
+EC_POOL_NAME="${XPATH_ELEMENTS[j++]}"
+
+#-------------------------------------------------------------------------------
 # Revert to Snapshot. Using the following tree structure
 #
 # one-3-13-0-1:2:3
@@ -115,6 +128,10 @@ if [ -n "$CEPH_CONF" ]; then
     RBD="$RBD --conf ${CEPH_CONF}"
 fi
 
+if [ -n "$EC_POOL_NAME" ]; then
+    EC_POOL_OPT="--data-pool ${EC_POOL_NAME}"
+fi
+
 if [ "${TYPE}" != 'RBD' ]; then
     error_message "$script_name: Operation not supported on disk type ${TYPE}"
     exit 1
@@ -134,7 +151,7 @@ SNAP_REVERT_CMD=$(cat <<EOF
         exit 1
     fi
 
-    $RBD clone \${RBD_TGT}@$SNAP_ID $RBD_DST
+    $RBD ${EC_POOL_OPT} clone \${RBD_TGT}@$SNAP_ID $RBD_DST
 EOF
 )
 


### PR DESCRIPTION
Hi, I fixed the bug I've posted before.
Please review and merge if the fix is ok :)