### PR TITLE
fix #2354 cant use shared with fs_lvm

### DIFF
--- a/src/tm_mad/shared/clone
+++ b/src/tm_mad/shared/clone
@@ -75,6 +75,10 @@ SIZE="${XPATH_ELEMENTS[j++]}"
 ORIGINAL_SIZE="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
 
+if [ "$TM_MAD" = "fs_lvm" ]; then
+    exec $DRIVER_PATH/../fs_lvm/clone "$@"
+fi
+
 if [ "$TM_MAD" = "ssh" ]; then
     MONITOR="ssh"
 else


### PR DESCRIPTION
This patch allows `shared` images datastore to use `fs_lvm` as system datastore.
All non persistent disks will be created as normal lvm devices

fixes: https://github.com/OpenNebula/one/issues/2354