### PR TITLE
B #2674: GOCA - fix missing state value of image

### DIFF
--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -45,6 +45,9 @@ const (
 	// ImageDelete image is in delete state
 	ImageDelete
 
+	// ImageUsedPers image is in use and persistent
+	ImageUsedPers
+
 	// ImageLockUsed image is in locked state (non-persistent)
 	ImageLockUsed
 


### PR DESCRIPTION
This pull request add a missing value for the state attribute.
It's documented and the corresponding string is present in sources so it's probably a mistake.