### PR TITLE
F#1684: Fix building svncterm server for LxD

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/svncterm_server/SConstruct
+++ b/src/vmm_mad/remotes/lib/lxd/svncterm_server/SConstruct
@@ -19,6 +19,7 @@ import os
 env = Environment()
 
 env['LIBS'] = ['-lz']
+nv['CFLAGS'] = ['-std=c99','-Wall']
 
 env.Program('genfont.c')
 
@@ -26,6 +27,6 @@ env = Environment()
 env['LIBS'] = ['-lvncserver', '-lnsl', '-lpthread', '-lz', '-ljpeg', 
     '-lutil', '-lgnutls']
 
-env['CFLAGS'] = ['-D_GNU_SOURCE']
+env['CFLAGS'] = ['-D_GNU_SOURCE','-std=c99','-Wall']
 
 env.Program('svncterm_server.c')

--- a/src/vmm_mad/remotes/lib/lxd/svncterm_server/SConstruct
+++ b/src/vmm_mad/remotes/lib/lxd/svncterm_server/SConstruct
@@ -19,7 +19,7 @@ import os
 env = Environment()
 
 env['LIBS'] = ['-lz']
-nv['CFLAGS'] = ['-std=c99','-Wall']
+env['CFLAGS'] = ['-std=c99','-Wall']
 
 env.Program('genfont.c')
 

--- a/src/vmm_mad/remotes/lib/lxd/svncterm_server/genfont.c
+++ b/src/vmm_mad/remotes/lib/lxd/svncterm_server/genfont.c
@@ -33,6 +33,8 @@
 #include <stdlib.h>
 #include <zlib.h> 
 #include <string.h>
+#include <linux/limits.h>
+#include <getopt.h>
 
 /* -------------------------------------------------------------------------- */
 /* Font glyph storage array and map pointer                                   */


### PR DESCRIPTION
in addition `libvncserver-devel` should be installed to build on CentOS7