### PR TITLE
F #1684 handle disk TYPE=BLOCK for LxD containers

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -411,7 +411,7 @@ class Container
     #  so new mappers does not need to modified source code
     def new_disk_mapper(disk)
         case disk['TYPE']
-        when 'FILE'
+        when 'FILE', 'BLOCK'
 
             ds = @one.disk_source(disk)
 

--- a/src/vmm_mad/remotes/lib/lxd/mapper/mapper.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/mapper.rb
@@ -63,7 +63,7 @@ class Mapper
         :mkdir      => 'mkdir -p',
         :catfstab   => 'sudo catfstab',
         :cat        => 'cat',
-        :file       => 'file -L',
+        :file       => 'file -L -s',
         :blkid      => 'sudo blkid',
         :e2fsck     => 'sudo e2fsck',
         :resize2fs  => 'sudo resize2fs',

--- a/src/vmm_mad/remotes/lib/lxd/mapper/raw.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/raw.rb
@@ -60,7 +60,7 @@ class DiskRawMapper < Mapper
     # Fisrt line is matched to look for loop device 3, and return "/dev/loop3"
     def do_map(one_vm, disk, directory)
         dsrc = one_vm.disk_source(disk)
-        cmd  = "#{COMMANDS[:kpartx]} -av #{dsrc}"
+        cmd  = "#{COMMANDS[:kpartx]} -s -av #{dsrc}"
 
         rc, out, err = Command.execute(cmd, true)
 


### PR DESCRIPTION
* add '-s' to the _file_ command to read special devices
* add '-s' to enable "sync mode" _kpartx_ when adding partition mappings

and handle the DISK case for disk['TYPE']