### PR TITLE
B #2824 fix LXD container monitoring

### DIFF
--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -129,13 +129,15 @@ module LXD
 
             state
         end
+        
+        def lxc_path(vm_name)
+            path = 'lxc/' + vm_name
+            path = "#{ENV['LXC_CGROUP_PREFIX']}#{path}" if ENV['LXC_CGROUP_PREFIX']
+        end    
 
         def get_memory(vm_name)
             begin
-                lxc_path = 'lxc/' + vm_name
-                lxc_path = "#{ENV['LXC_CGROUP_PREFIX']}#{lxc_path}" if ENV['LXC_CGROUP_PREFIX']
-                
-                stat = File.read('/sys/fs/cgroup/memory/' + lxc_path + '/memory.usage_in_bytes').to_i
+                stat = File.read('/sys/fs/cgroup/memory/' + lxc_path(vm_name) + '/memory.usage_in_bytes').to_i
                 stat / 1024
             rescue StandardError
                 return 0
@@ -202,12 +204,9 @@ module LXD
 
         def get_process_jiffies(vm_name)
             begin
-                lxc_path = 'lxc/' + vm_name
-                if ENV['LXC_CGROUP_PREFIX']
-                    lxc_path = ENV['LXC_CGROUP_PREFIX'] + lxc_path
-                end
                 jiffies = 0
-                stat = File.read('/sys/fs/cgroup/cpu,cpuacct/' + lxc_path + '/cpuacct.stat')
+                
+                stat = File.read('/sys/fs/cgroup/cpu,cpuacct/' + lxc_path(vm_name) + '/cpuacct.stat')
                 stat.lines.each {|line| jiffies += line.split(' ')[1] }
             rescue StandardError
                 return 0

--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -133,9 +133,8 @@ module LXD
         def get_memory(vm_name)
             begin
                 lxc_path = 'lxc/' + vm_name
-                if ENV['LXC_CGROUP_PREFIX']
-                    lxc_path = ENV['LXC_CGROUP_PREFIX'] + lxc_path
-                end
+                lxc_path = "#{ENV['LXC_CGROUP_PREFIX']}#{lxc_path}" if ENV['LXC_CGROUP_PREFIX']
+                
                 stat = File.read('/sys/fs/cgroup/memory/' + lxc_path + '/memory.usage_in_bytes').to_i
                 stat / 1024
             rescue StandardError

--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -131,8 +131,16 @@ module LXD
         end
 
         def get_memory(vm_name)
-            stat = File.read('/sys/fs/cgroup/memory/lxc/' + vm_name + '/memory.usage_in_bytes').to_i
-            stat / 1024
+            begin
+                lxc_path = 'lxc/' + vm_name
+                if ENV['LXC_CGROUP_PREFIX']
+                    lxc_path = ENV['LXC_CGROUP_PREFIX'] + lxc_path
+                end
+                stat = File.read('/sys/fs/cgroup/memory/' + lxc_path + '/memory.usage_in_bytes').to_i
+                stat / 1024
+            rescue StandardError
+                return 0
+            end
         end
 
         def get_net_statistics(vmd)
@@ -195,8 +203,12 @@ module LXD
 
         def get_process_jiffies(vm_name)
             begin
+                lxc_path = 'lxc/' + vm_name
+                if ENV['LXC_CGROUP_PREFIX']
+                    lxc_path = ENV['LXC_CGROUP_PREFIX'] + lxc_path
+                end
                 jiffies = 0
-                stat = File.read('/sys/fs/cgroup/cpu,cpuacct/lxc/' + vm_name + '/cpuacct.stat')
+                stat = File.read('/sys/fs/cgroup/cpu,cpuacct/' + lxc_path + '/cpuacct.stat')
                 stat.lines.each {|line| jiffies += line.split(' ')[1] }
             rescue StandardError
                 return 0


### PR DESCRIPTION
* handle exceptions in get_memory()
* add option to set cgroup prefix to the container path via the environment variable `LXC_CGROUP_PREFIX`

In case of a more complex cgroup configuration the containers cgroup could be placed in separate slice instead of default root cgroup. In this case the defining LXC_CGROUP_PREFIX="system.slice/" (note the trailing slash) in the environment will help vmm/lxd/poll to construct correct path the needed *memory* and *cpu,cpuacct* cgroups

```bash
su - oneadmin -c 'echo "export LXC_CGROUP_PREFIX=system.slice" >>~/.bashrc'
```