### PR TITLE
Feature 1684

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/mapper/mapper.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/mapper.rb
@@ -446,4 +446,31 @@ class Mapper
         end
     end
 
+    # Returns true if device has mapped partitions
+    def parts_on?(device)
+        partitions = lsblk(device)
+        return true if partitions[0]['type'] == 'part'
+
+        false
+    end
+
+    def show_parts(device)
+        action_parts(device, '-s -av')
+    end
+
+    def hide_parts(device)
+        action_parts(device, '-d')
+    end
+
+    # Runs kpartx vs a device with required flags as arguments
+    def action_parts(device, action)
+        cmd = "#{COMMANDS[:kpartx]} #{action} #{device}"
+        rc, _out, err = Command.execute(cmd, false)
+
+        return true if rc.zero?
+
+        OpenNebula.log_error("#{__method__}: #{err}")
+        false
+    end
+
 end

--- a/src/vmm_mad/remotes/lib/lxd/mapper/qcow2.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/qcow2.rb
@@ -43,7 +43,7 @@ class Qcow2Mapper < Mapper
         end
 
         # TODO: improve wait condition
-        sleep 5 # wait for parts to come out
+        sleep 1 # wait for parts to come out
 
         show_parts(device) unless parts_on?(device)
 

--- a/src/vmm_mad/remotes/lib/lxd/mapper/qcow2.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/qcow2.rb
@@ -69,33 +69,6 @@ class Qcow2Mapper < Mapper
 
     private
 
-    # Returns true if device has mapped partitions
-    def parts_on?(device)
-        partitions = lsblk(device)
-        return true if partitions[0]['type'] == 'part'
-
-        false
-    end
-
-    def show_parts(device)
-        action_parts(device, '-s -av')
-    end
-
-    def hide_parts(device)
-        action_parts(device, '-d')
-    end
-
-    # Runs kpartx vs a device with required flags as arguments
-    def action_parts(device, action)
-        cmd = "#{COMMANDS[:kpartx]} #{action} #{device}"
-        rc, _out, err = Command.execute(cmd, false)
-
-        return true if rc.zero?
-
-        OpenNebula.log_error("#{__method__}: #{err}")
-        false
-    end
-
     def nbd_device
         sys_parts = lsblk('')
         device_id = -1

--- a/src/vmm_mad/remotes/lib/lxd/mapper/qcow2.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/qcow2.rb
@@ -24,7 +24,7 @@ class Qcow2Mapper < Mapper
 
     # Max number of block devices. This should be set to the parameter used
     # to load the nbd kernel module (default in kernel is 16)
-    NBDS_MAX = 256
+    NBDS_MAX = 256 # TODO: Read system config file
 
     def do_map(one_vm, disk, _directory)
         device = nbd_device
@@ -35,7 +35,7 @@ class Qcow2Mapper < Mapper
         File.chmod(0o664, dsrc) if File.symlink?(one_vm.sysds_path)
 
         map = "#{COMMANDS[:nbd]} -c #{device} #{dsrc}"
-        rc, _out, err = Command.execute(map, false)
+        rc, _out, err = Command.execute(map, true)
 
         unless rc.zero?
             OpenNebula.log_error("#{__method__}: #{err}")
@@ -71,7 +71,6 @@ class Qcow2Mapper < Mapper
 
     def nbd_device
         sys_parts = lsblk('')
-        device_id = -1
         nbds      = []
 
         sys_parts.each do |p|

--- a/src/vmm_mad/remotes/lib/lxd/mapper/rbd.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/rbd.rb
@@ -35,7 +35,7 @@ class RBDMapper < Mapper
         rc, out, err = Command.execute(cmd, false)
 
         # TODO: improve wait condition
-        sleep 5 # wait for partition table
+        sleep 1 # wait for partition table
 
         return out.chomp if rc.zero?
 

--- a/src/vmm_mad/remotes/lib/lxd/mapper/rbd.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/rbd.rb
@@ -33,7 +33,13 @@ class RBDMapper < Mapper
 
         cmd = "#{COMMANDS[:rbd]} #{@ceph_user} map #{dsrc}"
 
-        rc, out, err = Command.execute(cmd, false)
+        rc, out, err = Command.execute(cmd, true)
+
+        unless rc.zero?
+
+            OpenNebula.log_error("#{__method__}: #{err}")
+            return
+        end
 
         # TODO: improve wait condition
         sleep 1 # wait for partition table


### PR DESCRIPTION
There is an issue with ceph mappers similar to what happened on qcow2 in 1604, whith previously used nbd devices remembering the partition table of the old image. When attempting to mount a partition or the device itself this is corrected.