### PR TITLE
Fix "scp: error: unexpected filename: ."

### DIFF
--- a/src/cli/one_helper/onehost_helper.rb
+++ b/src/cli/one_helper/onehost_helper.rb
@@ -363,7 +363,7 @@ class OneHostHelper < OpenNebulaHelper::OneHelper
                         sync_cmd = "rsync -Laz --delete #{REMOTES_LOCATION}" \
                                    " #{host['NAME']}:#{remote_dir}"
                     else
-                        sync_cmd = "scp -rp #{REMOTES_LOCATION}/. " \
+                        sync_cmd = "scp -rp #{REMOTES_LOCATION}/* " \
                                    "#{host['NAME']}:#{remote_dir} 2> /dev/null"
                     end
 

--- a/src/im_mad/im_exec/one_im_exec.rb
+++ b/src/im_mad/im_exec/one_im_exec.rb
@@ -74,7 +74,7 @@ class InformationManagerDriver < OpenNebulaDriver
         if !action_is_local?(:MONITOR)
             if do_update == "1" || @options[:force_copy]
                 # Use SCP to sync:
-                sync_cmd = "scp -r #{@local_scripts_base_path}/. " \
+                sync_cmd = "scp -r #{@local_scripts_base_path}/* " \
                     "#{host}:#{@remote_scripts_base_path}"
 
                 # Use rsync to sync:

--- a/src/mad/ruby/CommandManager.rb
+++ b/src/mad/ruby/CommandManager.rb
@@ -268,7 +268,7 @@ private
         SSHCommand.run("mkdir -p #{remote_dir}",host,logger)
 
         # Use SCP to sync:
-        sync_cmd = "scp -rp #{REMOTES_LOCATION}/. #{host}:#{remote_dir}"
+        sync_cmd = "scp -rp #{REMOTES_LOCATION}/* #{host}:#{remote_dir}"
 
         # Use rsync to sync:
         # sync_cmd = "rsync -Laz #{REMOTES_LOCATION} #{host}:#{@remote_dir}"


### PR DESCRIPTION
OpenNebula was failing to enlist a new host. I made this change and restarted the nebula services and the host was then enlisted correctly.

```
Fri Feb  8 15:04:34 2019 [Z0][InM][I]: Command execution failed (exit code: 1): scp -rp /var/lib/one/remotes/. sd-prod-kvm1106:/var/tmp/one
Fri Feb  8 15:04:34 2019 [Z0][InM][I]: scp: error: unexpected filename: .
```

I was also able to reproduce this from the command line:

```
oneadmin@sd-prod-nebula1:~$ scp -rp /var/lib/one/remotes/. sd-prod-kvm1106:/var/tmp/one
scp: error: unexpected filename: .
```