### PR TITLE
F #2940: GOCA - externalize the client and allow to extend it

### DIFF
--- a/src/oca/go/src/goca/acl.go
+++ b/src/oca/go/src/goca/acl.go
@@ -4,6 +4,7 @@ import "encoding/xml"
 
 // ACLPool represents an OpenNebula ACL list pool
 type ACLPool struct {
+	c        OneClient
 	ID       uint   `xml:"ID"`
 	User     int    `xml:"USER"`
 	Resource int    `xml:"RESOURCE"`
@@ -14,13 +15,13 @@ type ACLPool struct {
 
 // NewACLPool returns an acl pool. A connection to OpenNebula is
 // performed.
-func NewACLPool() (*ACLPool, error) {
+func NewACLPool(client OneClient) (*ACLPool, error) {
 	response, err := client.Call("one.acl.info")
 	if err != nil {
 		return nil, err
 	}
 
-	aclPool := &ACLPool{}
+	aclPool := &ACLPool{c: client}
 	err = xml.Unmarshal([]byte(response.Body()), aclPool)
 	if err != nil {
 		return nil, err
@@ -33,7 +34,7 @@ func NewACLPool() (*ACLPool, error) {
 // * user: User component of the new rule. A string containing a hex number.
 // * resource: Resource component of the new rule. A string containing a hex number.
 // * rights: Rights component of the new rule. A string containing a hex number.
-func CreateACLRule(user, resource, rights string) (uint, error) {
+func CreateACLRule(client OneClient, user, resource, rights string) (uint, error) {
 	response, err := client.Call("one.acl.addrule", user, resource, rights)
 	if err != nil {
 		return 0, err
@@ -43,7 +44,7 @@ func CreateACLRule(user, resource, rights string) (uint, error) {
 }
 
 // DeleteACLRule deletes an ACL rule.
-func DeleteACLRule(aclID uint) error {
+func DeleteACLRule(client OneClient, aclID uint) error {
 	_, err := client.Call("one.acl.delrule", int(aclID))
 	return err
 }

--- a/src/oca/go/src/goca/group.go
+++ b/src/oca/go/src/goca/group.go
@@ -7,6 +7,7 @@ import (
 
 // GroupPool represents an OpenNebula GroupPool
 type GroupPool struct {
+	c                 OneClient
 	Groups            []Group    `xml:"GROUP"`
 	Quotas            []quotas   `xml:"QUOTAS"`
 	DefaultUserQuotas quotasList `xml:"DEFAULT_USER_QUOTAS"`
@@ -14,6 +15,7 @@ type GroupPool struct {
 
 // Group represents an OpenNebula Group
 type Group struct {
+	c        OneClient
 	ID       uint          `xml:"ID"`
 	Name     string        `xml:"NAME"`
 	Users    []int         `xml:"USERS>ID"`
@@ -31,7 +33,7 @@ type groupTemplate struct {
 
 // NewGroupPool returns a group pool. A connection to OpenNebula is
 // performed.
-func NewGroupPool() (*GroupPool, error) {
+func NewGroupPool(client OneClient) (*GroupPool, error) {
 	response, err := client.Call("one.grouppool.info")
 	if err != nil {
 		return nil, err
@@ -43,21 +45,26 @@ func NewGroupPool() (*GroupPool, error) {
 		return nil, err
 	}
 
+	// Propagate the client
+	for i := 0; i < len(groupPool.Groups); i++ {
+		groupPool.Groups[i].c = client
+	}
+
 	return groupPool, nil
 }
 
 // NewGroup finds a group object by ID. No connection to OpenNebula.
-func NewGroup(id uint) *Group {
-	return &Group{ID: id}
+func NewGroup(client OneClient, id uint) *Group {
+	return &Group{c: client, ID: id}
 }
 
 // NewGroupFromName finds a group object by name. It connects to
 // OpenNebula to retrieve the pool, but doesn't perform the Info() call to
 // retrieve the attributes of the group.
-func NewGroupFromName(name string) (*Group, error) {
+func NewGroupFromName(client OneClient, name string) (*Group, error) {
 	var id uint
 
-	groupPool, err := NewGroupPool()
+	groupPool, err := NewGroupPool(client)
 	if err != nil {
 		return nil, err
 	}
@@ -77,11 +84,11 @@ func NewGroupFromName(name string) (*Group, error) {
 		return nil, errors.New("resource not found")
 	}
 
-	return NewGroup(id), nil
+	return NewGroup(client, id), nil
 }
 
 // CreateGroup allocates a new group. It returns the new group ID.
-func CreateGroup(name string) (uint, error) {
+func CreateGroup(client OneClient, name string) (uint, error) {
 	response, err := client.Call("one.group.allocate", name)
 	if err != nil {
 		return 0, err
@@ -92,13 +99,13 @@ func CreateGroup(name string) (uint, error) {
 
 // Delete deletes the given group from the pool.
 func (group *Group) Delete() error {
-	_, err := client.Call("one.group.delete", group.ID)
+	_, err := group.c.Call("one.group.delete", group.ID)
 	return err
 }
 
 // Info retrieves information for the group.
 func (group *Group) Info() error {
-	response, err := client.Call("one.group.info", group.ID)
+	response, err := group.c.Call("one.group.info", group.ID)
 	if err != nil {
 		return err
 	}
@@ -110,27 +117,27 @@ func (group *Group) Info() error {
 // * tpl: The new template contents. Syntax can be the usual attribute=value or XML.
 // * appendTemplate: Update type: 0: Replace the whole template. 1: Merge new template with the existing one.
 func (group *Group) Update(tpl string, appendTemplate int) error {
-	_, err := client.Call("one.group.update", group.ID, tpl, appendTemplate)
+	_, err := group.c.Call("one.group.update", group.ID, tpl, appendTemplate)
 	return err
 }
 
 // AddAdmin adds a User to the Group administrators set
 // * userID: The user ID.
 func (group *Group) AddAdmin(userID uint) error {
-	_, err := client.Call("one.group.addadmin", group.ID, int(userID))
+	_, err := group.c.Call("one.group.addadmin", group.ID, int(userID))
 	return err
 }
 
 // DelAdmin removes a User from the Group administrators set
 // * userID: The user ID.
 func (group *Group) DelAdmin(userID uint) error {
-	_, err := client.Call("one.group.deladmin", group.ID, int(userID))
+	_, err := group.c.Call("one.group.deladmin", group.ID, int(userID))
 	return err
 }
 
 // Quota sets the group quota limits.
 // * tpl: The new quota template contents. Syntax can be the usual attribute=value or XML.
 func (group *Group) Quota(tpl string) error {
-	_, err := client.Call("one.group.quota", group.ID, tpl)
+	_, err := group.c.Call("one.group.quota", group.ID, tpl)
 	return err
 }

--- a/src/oca/go/src/goca/host.go
+++ b/src/oca/go/src/goca/host.go
@@ -8,11 +8,13 @@ import (
 
 // HostPool represents an OpenNebula HostPool
 type HostPool struct {
+	c     OneClient
 	Hosts []Host `xml:"HOST"`
 }
 
 // Host represents an OpenNebula Host
 type Host struct {
+	c           OneClient
 	ID          uint         `xml:"ID"`
 	Name        string       `xml:"NAME"`
 	StateRaw    int          `xml:"STATE"`
@@ -123,32 +125,38 @@ func (st HostState) String() string {
 
 // NewHostPool returns a host pool. A connection to OpenNebula is
 // performed.
-func NewHostPool() (*HostPool, error) {
+func NewHostPool(client OneClient) (*HostPool, error) {
 	response, err := client.Call("one.hostpool.info")
 	if err != nil {
 		return nil, err
 	}
 
-	hostPool := &HostPool{}
+	hostPool := &HostPool{c: client}
 	err = xml.Unmarshal([]byte(response.Body()), &hostPool)
 	if err != nil {
 		return nil, err
 	}
+
+	// Propagate the client
+	for i := 0; i < len(hostPool.Hosts); i++ {
+		hostPool.Hosts[i].c = client
+	}
+
 	return hostPool, nil
 }
 
 // NewHost finds a host object by ID. No connection to OpenNebula.
-func NewHost(id uint) *Host {
-	return &Host{ID: id}
+func NewHost(client OneClient, id uint) *Host {
+	return &Host{c: client, ID: id}
 }
 
 // NewHostFromName finds a host object by name. It connects to
 // OpenNebula to retrieve the pool, but doesn't perform the Info() call to
 // retrieve the attributes of the host.
-func NewHostFromName(name string) (*Host, error) {
+func NewHostFromName(client OneClient, name string) (*Host, error) {
 	var id uint
 
-	hostPool, err := NewHostPool()
+	hostPool, err := NewHostPool(client)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +176,7 @@ func NewHostFromName(name string) (*Host, error) {
 		return nil, errors.New("resource not found")
 	}
 
-	return NewHost(id), nil
+	return NewHost(client, id), nil
 }
 
 // CreateHost allocates a new host. It returns the new host ID.
@@ -176,7 +184,7 @@ func NewHostFromName(name string) (*Host, error) {
 // * im: information driver for the host
 // * vm: virtualization driver for the host
 // * clusterID: The cluster ID. If it is -1, the default one will be used.
-func CreateHost(name, im, vm string, clusterID int) (uint, error) {
+func CreateHost(client OneClient, name, im, vm string, clusterID int) (uint, error) {
 	response, err := client.Call("one.host.allocate", name, im, vm, clusterID)
 	if err != nil {
 		return 0, err
@@ -187,14 +195,14 @@ func CreateHost(name, im, vm string, clusterID int) (uint, error) {
 
 // Delete deletes the given host from the pool
 func (host *Host) Delete() error {
-	_, err := client.Call("one.host.delete", host.ID)
+	_, err := host.c.Call("one.host.delete", host.ID)
 	return err
 }
 
 // Status sets the status of the host
 // * status: 0: ENABLED, 1: DISABLED, 2: OFFLINE
 func (host *Host) Status(status int) error {
-	_, err := client.Call("one.host.status", host.ID, status)
+	_, err := host.c.Call("one.host.status", host.ID, status)
 	return err
 }
 
@@ -202,20 +210,20 @@ func (host *Host) Status(status int) error {
 // * tpl: The new template contents. Syntax can be the usual attribute=value or XML.
 // * appendTemplate: Update type: 0: Replace the whole template. 1: Merge new template with the existing one.
 func (host *Host) Update(tpl string, appendTemplate int) error {
-	_, err := client.Call("one.host.update", host.ID, tpl, appendTemplate)
+	_, err := host.c.Call("one.host.update", host.ID, tpl, appendTemplate)
 	return err
 }
 
 // Rename renames a host.
 // * newName: The new name.
 func (host *Host) Rename(newName string) error {
-	_, err := client.Call("one.host.rename", host.ID, newName)
+	_, err := host.c.Call("one.host.rename", host.ID, newName)
 	return err
 }
 
 // Info retrieves information for the host.
 func (host *Host) Info() error {
-	response, err := client.Call("one.host.info", host.ID)
+	response, err := host.c.Call("one.host.info", host.ID)
 	if err != nil {
 		return err
 	}
@@ -225,7 +233,7 @@ func (host *Host) Info() error {
 
 // Monitoring returns the host monitoring records.
 func (host *Host) Monitoring() error {
-	_, err := client.Call("one.host.monitoring", host.ID)
+	_, err := host.c.Call("one.host.monitoring", host.ID)
 	return err
 }
 

--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -8,11 +8,13 @@ import (
 
 // ImagePool represents an OpenNebula Image pool
 type ImagePool struct {
+	c      OneClient
 	Images []Image `xml:"IMAGE"`
 }
 
 // Image represents an OpenNebula Image
 type Image struct {
+	c               OneClient
 	ID              uint          `xml:"ID"`
 	UID             int           `xml:"UID"`
 	GID             int           `xml:"GID"`
@@ -111,7 +113,7 @@ func (s ImageState) String() string {
 
 // CreateImage allocates a new image based on the template string provided. It
 // returns the image ID.
-func CreateImage(template string, dsid uint) (uint, error) {
+func CreateImage(client OneClient, template string, dsid uint) (uint, error) {
 	response, err := client.Call("one.image.allocate", template, dsid)
 	if err != nil {
 		return 0, err
@@ -122,7 +124,7 @@ func CreateImage(template string, dsid uint) (uint, error) {
 
 // NewImagePool returns a new image pool. It accepts the scope of the query. It
 // performs an OpenNebula connection to fetch the information.
-func NewImagePool(args ...int) (*ImagePool, error) {
+func NewImagePool(client OneClient, args ...int) (*ImagePool, error) {
 	var who, start, end int
 
 	switch len(args) {
@@ -143,10 +145,15 @@ func NewImagePool(args ...int) (*ImagePool, error) {
 		return nil, err
 	}
 
-	imagePool := &ImagePool{}
+	imagePool := &ImagePool{c: client}
 	err = xml.Unmarshal([]byte(response.Body()), imagePool)
 	if err != nil {
 		return nil, err
+	}
+
+	// Propagate the client
+	for i := 0; i < len(imagePool.Images); i++ {
+		imagePool.Images[i].c = client
 	}
 
 	return imagePool, nil
@@ -154,17 +161,17 @@ func NewImagePool(args ...int) (*ImagePool, error) {
 
 // NewImage finds an image by ID returns a new Image object. At this stage no
 // connection to OpenNebula is performed.
-func NewImage(id uint) *Image {
-	return &Image{ID: id}
+func NewImage(client OneClient, id uint) *Image {
+	return &Image{c: client, ID: id}
 }
 
 // NewImageFromName finds an image by name and returns Image object. It connects
 // to OpenNebula to retrieve the pool, but doesn't perform the Info() call to
 // retrieve the attributes of the image.
-func NewImageFromName(name string) (*Image, error) {
+func NewImageFromName(client OneClient, name string) (*Image, error) {
 	var id uint
 
-	imagePool, err := NewImagePool()
+	imagePool, err := NewImagePool(client)
 	if err != nil {
 		return nil, err
 	}
@@ -184,12 +191,12 @@ func NewImageFromName(name string) (*Image, error) {
 		return nil, errors.New("resource not found")
 	}
 
-	return NewImage(id), nil
+	return NewImage(client, id), nil
 }
 
 // Info connects to OpenNebula and fetches the information of the Image
 func (image *Image) Info() error {
-	response, err := client.Call("one.image.info", image.ID)
+	response, err := image.c.Call("one.image.info", image.ID)
 	if err != nil {
 		return err
 	}
@@ -217,7 +224,7 @@ func (image *Image) StateString() (string, error) {
 
 // Clone clones an existing image. It returns the clone ID
 func (image *Image) Clone(cloneName string, dsid int) (uint, error) {
-	response, err := client.Call("one.image.clone", image.ID, cloneName, dsid)
+	response, err := image.c.Call("one.image.clone", image.ID, cloneName, dsid)
 	if err != nil {
 		return 0, err
 	}
@@ -228,82 +235,82 @@ func (image *Image) Clone(cloneName string, dsid int) (uint, error) {
 // Update will modify the image's template. If appendTemplate is 0, it will
 // replace the whole template. If its 1, it will merge.
 func (image *Image) Update(tpl string, appendTemplate int) error {
-	_, err := client.Call("one.image.update", image.ID, tpl, appendTemplate)
+	_, err := image.c.Call("one.image.update", image.ID, tpl, appendTemplate)
 	return err
 }
 
 // Chtype changes the type of the Image
 func (image *Image) Chtype(newType string) error {
-	_, err := client.Call("one.image.chtype", image.ID, newType)
+	_, err := image.c.Call("one.image.chtype", image.ID, newType)
 	return err
 }
 
 // Chown changes the owner/group of the image. If uid or gid is -1 it will not
 // change
 func (image *Image) Chown(uid, gid int) error {
-	_, err := client.Call("one.image.chown", image.ID, uid, gid)
+	_, err := image.c.Call("one.image.chown", image.ID, uid, gid)
 	return err
 }
 
 // Chmod changes the permissions of the image. If any perm is -1 it will not
 // change
 func (image *Image) Chmod(uu, um, ua, gu, gm, ga, ou, om, oa int) error {
-	_, err := client.Call("one.image.chmod", image.ID, uu, um, ua, gu, gm, ga, ou, om, oa)
+	_, err := image.c.Call("one.image.chmod", image.ID, uu, um, ua, gu, gm, ga, ou, om, oa)
 	return err
 }
 
 // Rename changes the name of the image
 func (image *Image) Rename(newName string) error {
-	_, err := client.Call("one.image.rename", image.ID, newName)
+	_, err := image.c.Call("one.image.rename", image.ID, newName)
 	return err
 }
 
 // SnapshotDelete will delete a snapshot from the image
 func (image *Image) SnapshotDelete(snapID int) error {
-	_, err := client.Call("one.image.snapshotdelete", image.ID, snapID)
+	_, err := image.c.Call("one.image.snapshotdelete", image.ID, snapID)
 	return err
 }
 
 // SnapshotRevert reverts image state to a previous snapshot
 func (image *Image) SnapshotRevert(snapID int) error {
-	_, err := client.Call("one.image.snapshotrevert", image.ID, snapID)
+	_, err := image.c.Call("one.image.snapshotrevert", image.ID, snapID)
 	return err
 }
 
 // SnapshotFlatten flattens the snapshot image and discards others
 func (image *Image) SnapshotFlatten(snapID int) error {
-	_, err := client.Call("one.image.snapshotflatten", image.ID, snapID)
+	_, err := image.c.Call("one.image.snapshotflatten", image.ID, snapID)
 	return err
 }
 
 // Enable enables (or disables) the image
 func (image *Image) Enable(enable bool) error {
-	_, err := client.Call("one.image.enable", image.ID, enable)
+	_, err := image.c.Call("one.image.enable", image.ID, enable)
 	return err
 }
 
 // Persistent sets the image as persistent (or not)
 func (image *Image) Persistent(persistent bool) error {
-	_, err := client.Call("one.image.persistent", image.ID, persistent)
+	_, err := image.c.Call("one.image.persistent", image.ID, persistent)
 	return err
 }
 
 // Lock locks the image following block level.
 func (image *Image) Lock(level uint) error {
-	_, err := client.Call("one.image.lock", image.ID, level)
+	_, err := image.c.Call("one.image.lock", image.ID, level)
 	return err
 }
 
 // Unlock unlocks the image.
 func (image *Image) Unlock() error {
-	_, err := client.Call("one.image.unlock", image.ID)
+	_, err := image.c.Call("one.image.unlock", image.ID)
 	return err
 }
 
 // Delete will remove the image from OpenNebula, which will remove it from the
 // backend.
 func (image *Image) Delete() error {
-	_, err := client.Call("one.image.delete", image.ID)
+	_, err := image.c.Call("one.image.delete", image.ID)
 	return err
 }
 

--- a/src/oca/go/src/goca/securitygroup.go
+++ b/src/oca/go/src/goca/securitygroup.go
@@ -7,11 +7,13 @@ import (
 
 // SecurityGroupPool represents an OpenNebula SecurityGroupPool
 type SecurityGroupPool struct {
+	c              OneClient
 	SecurityGroups []SecurityGroup `xml:"SECURITY_GROUP"`
 }
 
 // SecurityGroup represents an OpenNebula SecurityGroup
 type SecurityGroup struct {
+	c           OneClient
 	ID          uint                  `xml:"ID"`
 	UID         int                   `xml:"UID"`
 	GID         int                   `xml:"GID"`
@@ -40,7 +42,7 @@ type securityGroupRule struct {
 
 // NewSecurityGroupPool returns a security group pool. A connection to OpenNebula is
 // performed.
-func NewSecurityGroupPool(args ...int) (*SecurityGroupPool, error) {
+func NewSecurityGroupPool(client OneClient, args ...int) (*SecurityGroupPool, error) {
 	var who, start, end int
 
 	switch len(args) {
@@ -60,32 +62,37 @@ func NewSecurityGroupPool(args ...int) (*SecurityGroupPool, error) {
 		return nil, errors.New("Wrong number of arguments")
 	}
 
-    response, err := client.Call("one.secgrouppool.info", who, start, end)
+	response, err := client.Call("one.secgrouppool.info", who, start, end)
 	if err != nil {
 		return nil, err
 	}
 
-	secgroupPool := &SecurityGroupPool{}
+	secgroupPool := &SecurityGroupPool{c: client}
 	err = xml.Unmarshal([]byte(response.Body()), secgroupPool)
 	if err != nil {
 		return nil, err
+	}
+
+	// Propagate the client
+	for i := 0; i < len(secgroupPool.SecurityGroups); i++ {
+		secgroupPool.SecurityGroups[i].c = client
 	}
 
 	return secgroupPool, nil
 }
 
 // NewSecurityGroup finds a security group object by ID. No connection to OpenNebula.
-func NewSecurityGroup(id uint) *SecurityGroup {
-	return &SecurityGroup{ID: id}
+func NewSecurityGroup(client OneClient, id uint) *SecurityGroup {
+	return &SecurityGroup{c: client, ID: id}
 }
 
 // NewSecurityGroupFromName finds a security group object by name. It connects to
 // OpenNebula to retrieve the pool, but doesn't perform the Info() call to
 // retrieve the attributes of the security group.
-func NewSecurityGroupFromName(name string) (*SecurityGroup, error) {
+func NewSecurityGroupFromName(client OneClient, name string) (*SecurityGroup, error) {
 	var id uint
 
-	secgroupPool, err := NewSecurityGroupPool()
+	secgroupPool, err := NewSecurityGroupPool(client)
 	if err != nil {
 		return nil, err
 	}
@@ -105,12 +112,12 @@ func NewSecurityGroupFromName(name string) (*SecurityGroup, error) {
 		return nil, errors.New("resource not found")
 	}
 
-	return NewSecurityGroup(id), nil
+	return NewSecurityGroup(client, id), nil
 }
 
 // CreateSecurityGroup allocates a new security group. It returns the new security group ID.
 // * tpl: template of the security group
-func CreateSecurityGroup(tpl string) (uint, error) {
+func CreateSecurityGroup(client OneClient, tpl string) (uint, error) {
 	response, err := client.Call("one.secgroup.allocate", tpl)
 	if err != nil {
 		return 0, err
@@ -121,7 +128,7 @@ func CreateSecurityGroup(tpl string) (uint, error) {
 
 // Clone clones an existing security group. It returns the clone ID
 func (sg *SecurityGroup) Clone(cloneName string) (uint, error) {
-	response, err := client.Call("one.secgroup.clone", sg.ID, cloneName)
+	response, err := sg.c.Call("one.secgroup.clone", sg.ID, cloneName)
 	if err != nil {
 		return 0, err
 	}
@@ -131,7 +138,7 @@ func (sg *SecurityGroup) Clone(cloneName string) (uint, error) {
 
 // Delete deletes the given security group from the pool.
 func (sg *SecurityGroup) Delete() error {
-	_, err := client.Call("one.secgroup.delete", sg.ID)
+	_, err := sg.c.Call("one.secgroup.delete", sg.ID)
 	return err
 }
 
@@ -139,15 +146,15 @@ func (sg *SecurityGroup) Delete() error {
 // * tpl: The new template contents. Syntax can be the usual attribute=value or XML.
 // * appendTemplate: Update type: 0: Replace the whole template. 1: Merge new template with the existing one.
 func (sg *SecurityGroup) Update(tpl string, appendTemplate int) error {
-	_, err := client.Call("one.secgroup.update", sg.ID, tpl, appendTemplate)
+	_, err := sg.c.Call("one.secgroup.update", sg.ID, tpl, appendTemplate)
 	return err
 }
 
 // Commit apply security group changes to associated VMs.
 // * recovery: If set the commit operation will only operate on outdated and error VMs. If not set operate on all VMs
 func (sg *SecurityGroup) Commit(recovery bool) error {
-    _, err := client.Call("one.secgroup.commit", sg.ID, recovery)
-    return err
+	_, err := sg.c.Call("one.secgroup.commit", sg.ID, recovery)
+	return err
 }
 
 // Chmod changes the permission bits of a security group
@@ -161,7 +168,7 @@ func (sg *SecurityGroup) Commit(recovery bool) error {
 // * om: OTHER MANAGE bit. If set to -1, it will not change.
 // * oa: OTHER ADMIN bit. If set to -1, it will not change.
 func (sg *SecurityGroup) Chmod(uu, um, ua, gu, gm, ga, ou, om, oa int) error {
-	_, err := client.Call("one.secgroup.chmod", sg.ID, uu, um, ua, gu, gm, ga, ou, om, oa)
+	_, err := sg.c.Call("one.secgroup.chmod", sg.ID, uu, um, ua, gu, gm, ga, ou, om, oa)
 	return err
 }
 
@@ -169,20 +176,20 @@ func (sg *SecurityGroup) Chmod(uu, um, ua, gu, gm, ga, ou, om, oa int) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (sg *SecurityGroup) Chown(userID, groupID int) error {
-	_, err := client.Call("one.secgroup.chown", sg.ID, userID, groupID)
+	_, err := sg.c.Call("one.secgroup.chown", sg.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a security group.
 // * newName: The new name.
 func (sg *SecurityGroup) Rename(newName string) error {
-	_, err := client.Call("one.secgroup.rename", sg.ID, newName)
+	_, err := sg.c.Call("one.secgroup.rename", sg.ID, newName)
 	return err
 }
 
 // Info retrieves information for the security group.
 func (sg *SecurityGroup) Info() error {
-	response, err := client.Call("one.secgroup.info", sg.ID)
+	response, err := sg.c.Call("one.secgroup.info", sg.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Firstly, I propose to externalize the client in providing a method NewClient, allowing the user to create new clients as they want and make request on the client they want.
To fully enable this, I add a pointer (in fact, an interface) to the client in each entity structure.

Secondly I define an interface for the GOCA client (a client has to define Call methods).
If a new defined client satisfy this interface, it can be used with all entities (VM, Host ...) to make the requests.

It imply important API changes.