### PR TITLE
#3029 Fix LXD snap patch running always on network pre script 

### DIFF
--- a/src/vnm_mad/remotes/lib/nic.rb
+++ b/src/vnm_mad/remotes/lib/nic.rb
@@ -14,6 +14,8 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
+require 'open3'
+
 module VNMMAD
 
     module VNMNetwork
@@ -110,12 +112,16 @@ module VNMMAD
                 end
 
                 if deploy_id && vm.vm_info[:dumpxml].nil?
-                    cmd = "lxc config show #{deploy_id} 2>/dev/null"
+                    cmd = "lxc config show #{deploy_id}"
 
-                    config = YAML.safe_load(`#{cmd}`)
-                    config = YAML.safe_load(`sudo #{cmd}`) if config.nil?
+                    config, e, s = Open3.capture3(cmd)
 
-                    vm.vm_info[:dumpxml] = config
+                    # Snap patch
+                    cmd.prepend('sudo') if s.exitstatus != 0 && e.include?('cannot create user data directory')
+
+                    config, _e, _s = Open3.capture3(cmd)
+
+                    vm.vm_info[:dumpxml] = YAML.safe_load(config)
 
                     vm.vm_info.each_key do |k|
                         vm.vm_info[k] = nil if vm.vm_info[k].to_s.strip.empty?

--- a/src/vnm_mad/remotes/lib/nic.rb
+++ b/src/vnm_mad/remotes/lib/nic.rb
@@ -116,10 +116,11 @@ module VNMMAD
 
                     config, e, s = Open3.capture3(cmd)
 
-                    # Snap patch
-                    cmd.prepend('sudo') if s.exitstatus != 0 && e.include?('cannot create user data directory')
-
-                    config, _e, _s = Open3.capture3(cmd)
+                    if s.exitstatus != 0 && e.include?('cannot create'\
+                        'user data directory')
+                        cmd.prepend('sudo')
+                        config, _e, _s = Open3.capture3(cmd)
+                    end
 
                     vm.vm_info[:dumpxml] = YAML.safe_load(config)
 

--- a/src/vnm_mad/remotes/lib/vm.rb
+++ b/src/vnm_mad/remotes/lib/vm.rb
@@ -16,100 +16,104 @@
 
 module VNMMAD
 
-module VNMNetwork
+    module VNMNetwork
 
-    ############################################################################
-    # This class represents the VM abstraction. It provides basic methods
-    # to interact with its network interfaces.
-    ############################################################################
-    class VM
-        attr_accessor :nics, :vm_info, :deploy_id, :vm_root
+        ########################################################################
+        # This class represents the VM abstraction. It provides basic methods
+        # to interact with its network interfaces.
+        ########################################################################
+        class VM
 
+            attr_accessor :nics, :vm_info, :deploy_id, :vm_root
 
-        # Creates a new VM object, and bootstrap the NICs array
-        #   @param vm_root [REXML] XML document representing the VM
-        #   @param xpath_filer [String] to get the VM NICs
-        #   @param deploy_id [String] refers to the VM in the hypervisor
-        def initialize(vm_root, xpath_filter, deploy_id)
-            @vm_root      = vm_root
-            @deploy_id    = deploy_id
+            # Creates a new VM object, and bootstrap the NICs array
+            #   @param vm_root [REXML] XML document representing the VM
+            #   @param xpath_filer [String] to get the VM NICs
+            #   @param deploy_id [String] refers to the VM in the hypervisor
+            def initialize(vm_root, xpath_filter, deploy_id)
+                @vm_root      = vm_root
+                @deploy_id    = deploy_id
 
-            @vm_info      = Hash.new
+                @vm_info      = {}
 
-            @deploy_id = nil if deploy_id == "-"
+                @deploy_id = nil if deploy_id == '-'
 
-            nics = VNMNetwork::Nics.new(hypervisor)
+                nics = VNMNetwork::Nics.new(hypervisor)
 
-            @vm_root.elements.each(xpath_filter) do |nic_element|
-                nic =  nics.new_nic
+                @vm_root.elements.each(xpath_filter) do |nic_element|
+                    nic = nics.new_nic
 
-                nic_build_hash(nic_element,nic)
+                    nic_build_hash(nic_element, nic)
 
-                nic.get_info(self)
-                nic.get_tap(self)
+                    if File.basename($PROGRAM_NAME) != 'pre'
+                        nic.get_info(self)
+                        nic.get_tap(self)
+                    end
 
-                nics << nic
+                    nics << nic
+                end
+
+                @nics = nics
             end
 
-            @nics = nics
-        end
+            # Iterator on each NIC of the VM
+            def each_nic(block)
+                return if @nics.nil?
 
-        # Iterator on each NIC of the VM
-        def each_nic(block)
-            if @nics != nil
                 @nics.each do |the_nic|
                     block.call(the_nic)
                 end
             end
-        end
 
-        # Access an XML Element of the VM
-        #   @param element [String] element name
-        #   @return [String] value of the element or nil if not found
-        def [](element)
-            if @vm_root
-                val = @vm_root.elements[element]
-                return val.text if !val.nil? && val.text
-            end
-
-            nil
-        end
-
-        # Gets the Hypervisor VM_MAD from the Template
-        # @return [String] name of the hypervisor driver
-        def hypervisor
-            xpath = 'HISTORY_RECORDS/HISTORY/VM_MAD'
-            @vm_root.root.elements[xpath].text
-        end
-
-        private
-
-        # Method to build the associated Hash from a NIC
-        #   @param nic_element [REXML] for the NIC
-        #   @param nic [Nic] class representation
-        def nic_build_hash(nic_element,nic)
-            nic_element.elements.each('*') do |nic_attribute|
-                key = nic_attribute.name.downcase.to_sym
-
-                if nic_attribute.has_elements?
-                    data = {}
-                    nic_build_hash(nic_attribute,data)
-                else
-                    data = nic_attribute.text
+            # Access an XML Element of the VM
+            #   @param element [String] element name
+            #   @return [String] value of the element or nil if not found
+            def [](element)
+                if @vm_root
+                    val = @vm_root.elements[element]
+                    return val.text if !val.nil? && val.text
                 end
 
-                if nic[key]
-                    if nic[key].instance_of?(Array)
-                        nic[key] << data
+                nil
+            end
+
+            # Gets the Hypervisor VM_MAD from the Template
+            # @return [String] name of the hypervisor driver
+            def hypervisor
+                xpath = 'HISTORY_RECORDS/HISTORY/VM_MAD'
+                @vm_root.root.elements[xpath].text
+            end
+
+            private
+
+            # Method to build the associated Hash from a NIC
+            #   @param nic_element [REXML] for the NIC
+            #   @param nic [Nic] class representation
+            def nic_build_hash(nic_element, nic)
+                nic_element.elements.each('*') do |nic_attribute|
+                    key = nic_attribute.name.downcase.to_sym
+
+                    if nic_attribute.has_elements?
+                        data = {}
+                        nic_build_hash(nic_attribute, data)
                     else
-                        nic[key] = [nic[key], data]
+                        data = nic_attribute.text
                     end
-                else
-                    nic[key] = data
+
+                    if nic[key]
+                        if nic[key].instance_of?(Array)
+                            nic[key] << data
+                        else
+                            nic[key] = [nic[key], data]
+                        end
+                    else
+                        nic[key] = data
+                    end
                 end
             end
+
         end
+
     end
-end
 
 end


### PR DESCRIPTION
Snap patch didn't take into account the error output of the `lxc config show` command which fails during network `pre` script because the container didn't exist and shows the auth errors in #3029 

- Updated the code to detect the error output and apply the snap patch if needed
- Applies to master and 5.8.1

We could consider using, for 5.10, the Container Class from the LXD drivers which uses the adequate lxc command.

Fixes #3029 