### PR TITLE
Fix LXD not handling nic removal from openvswitch bridges

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -384,6 +384,21 @@ class Container
 
     private
 
+    # Deletes the switch port. Unlike libvirt, LXD doesn't handle this.
+    def del_bridge_port(nic)
+        return 'not ovswitch' unless nic['VN_MAD'] == 'ovswitch'
+
+        cmd = 'sudo ovs-vsctl --if-exists del-port '\
+        "#{nic['BRIDGE']} #{nic['TARGET']}"
+
+        rc, _o, e = Command.execute(cmd, false)
+
+        return true if rc.zero?
+
+        OpenNebula.log_error "#{__method__}: #{e}"
+        nil
+    end
+
     # Waits or no for response depending on wait value
     def wait?(response, wait, timeout)
         @client.wait(response, timeout) unless wait == false

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -177,6 +177,11 @@ class Container
 
     def stop(options = { :timeout => 120 })
         change_state(__method__, options)
+
+        # Remove nic from ovs-switch if needed
+        @one.get_nics.each do |nic|
+            del_bridge_port(nic) # network driver matching implemented here
+    end
     end
 
     def restart(options = {})

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -392,7 +392,7 @@ class Container
 
     # Deletes the switch port. Unlike libvirt, LXD doesn't handle this.
     def del_bridge_port(nic)
-        return true unless nic['VN_MAD'] == 'ovswitch'
+        return true unless /ovswitch/ =~ nic['VN_MAD'] 
 
         cmd = 'sudo ovs-vsctl --if-exists del-port '\
         "#{nic['BRIDGE']} #{nic['TARGET']}"

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -181,7 +181,7 @@ class Container
         # Remove nic from ovs-switch if needed
         @one.get_nics.each do |nic|
             del_bridge_port(nic) # network driver matching implemented here
-    end
+        end
     end
 
     def restart(options = {})
@@ -218,7 +218,8 @@ class Container
             device.include?('eth') && config['hwaddr'] == mac
         end
 
-        update
+        # Removes nic from ovs-switch if needed
+        update if del_bridge_port(@one.get_nic_by_mac(mac))
     end
 
     #---------------------------------------------------------------------------

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -392,7 +392,7 @@ class Container
 
     # Deletes the switch port. Unlike libvirt, LXD doesn't handle this.
     def del_bridge_port(nic)
-        return 'not ovswitch' unless nic['VN_MAD'] == 'ovswitch'
+        return true unless nic['VN_MAD'] == 'ovswitch'
 
         cmd = 'sudo ovs-vsctl --if-exists del-port '\
         "#{nic['BRIDGE']} #{nic['TARGET']}"
@@ -402,7 +402,7 @@ class Container
         return true if rc.zero?
 
         OpenNebula.log_error "#{__method__}: #{e}"
-        nil
+        false
     end
 
     # Waits or no for response depending on wait value

--- a/src/vmm_mad/remotes/lxd/reboot
+++ b/src/vmm_mad/remotes/lxd/reboot
@@ -23,7 +23,7 @@ require 'container'
 require_relative '../../scripts_common'
 
 # ------------------------------------------------------------------------------
-# Action Arguments, STDIN includes XML description of the OpenNebula VM
+# Action Arguments, STDIN doesn't include XML description of the OpenNebula VM
 # ------------------------------------------------------------------------------
 vm_name = ARGV[0]
 

--- a/src/vmm_mad/remotes/lxd/reboot
+++ b/src/vmm_mad/remotes/lxd/reboot
@@ -29,6 +29,7 @@ vm_name = ARGV[0]
 
 client    = LXDClient.new
 container = Container.get(vm_name, nil, client)
+container = Container.get(vm_name, container.config['user.xml'], client)
 
 # ------------------------------------------------------------------------------
 # Stop the container, start it


### PR DESCRIPTION
Unlike libvirt which handles the ports removal on nic detach action nad powerofss, LXD just handles nic port creation on start and nic attach. The drivers have been updated to remove ports on unhandled actions if nic matches ovswitch driver.

Fixes #3058 