### PR TITLE
F #3099 Show container log when action fails

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -166,6 +166,17 @@ class Container
         Command.execute(cmd, true)
     end
 
+    def show_log
+        cmd = "#{@lxc_command} info --show-log #{@lxc['name']}"
+        rc, o, e = Command.execute(cmd, false)
+
+        if rc.zero?
+            OpenNebula.log o
+        else
+            OpenNebula.log_error e
+        end
+    end
+
     #---------------------------------------------------------------------------
     # Contianer Status Control
     #---------------------------------------------------------------------------
@@ -385,6 +396,9 @@ class Container
     # Waits or no for response depending on wait value
     def wait?(response, wait, timeout)
         @client.wait(response, timeout) unless wait == false
+    rescue LXDError => e
+        show_log
+        raise e
     end
 
     # Performs an action on the container that changes the execution status.


### PR DESCRIPTION
the log is embedded into `wait?` method, so the rest of the containers methods benefit from it 