### PR TITLE
B #3127 Remove status handling from filesystem code

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/mapper/mapper.rb
+++ b/src/vmm_mad/remotes/lib/lxd/mapper/mapper.rb
@@ -139,7 +139,7 @@ class Mapper
 
         fstype = get_fstype(device)
 
-        return unless reset_fs_uuid(fstype, device)
+        reset_fs_uuid(fstype, device)
 
         mount_resize_fs(device, directory, fstype, disk)
     end
@@ -521,10 +521,9 @@ class Mapper
         end
 
         rc, o, e = Command.execute(cmd, false)
-        return true if rc.zero?
+        return if rc.zero?
 
         OpenNebula.log_error "#{__method__}: error changing UUID: #{o}\n#{e}\n"
-        false
     end
 
     def get_fstype(device)


### PR DESCRIPTION
Another follow up to #3127 

Removed the mapper execution based on the status of this part of the code. 1604 fails  and fails both `e2fsck` and `tune2fs`. If that fails the code will handle it later