### PR TITLE
Fix LXD market importer

### DIFF
--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -159,6 +159,7 @@ apt-get install curl -y > /dev/null 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context_$selected_tag-1.deb -Lsfo /root/context.deb
 apt-get install /root/context.deb -y > /dev/null 2>&1
+rm /root/context.deb
 EOC
 )
     ;;
@@ -168,9 +169,11 @@ EOC
 export PATH=\$PATH:/bin:/sbin
 
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
+yum install epel-release -y > /root/epel-log 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el6.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1
+rm /root/context.rpm
 EOC
 )
     ;;
@@ -179,8 +182,14 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
+## New yum version requires random bits to initialize GnuTLS, but chroot
+## prevents access to /dev/urandom (as desgined).
+mknod -m 666 /dev/random c 1 8
+mknod -m 666 /dev/urandom c 1 9
+
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1
+rm /root/context.rpm
 EOC
 )
     ;;
@@ -188,9 +197,11 @@ EOC
     terminal="/bin/ash"
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
+apk add curl > /dev/null 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-r1.apk -Lsfo /root/context.apk
 apk add --allow-untrusted /root/context.apk > /dev/null 2>&1
+rm /root/context.apk
 EOC
 )
     ;;

--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -36,6 +36,11 @@ MARKET_URL=$1
 CONTEXT_API="https://api.github.com/repos/OpenNebula/addon-context-linux/releases"
 CONTEXT_URL="https://github.com/OpenNebula/addon-context-linux/releases/download"
 
+PKG_DEB="curl dbus openssh-server"
+PKG_RPM="openssh-server"
+PKG_CENTOS6="epel-release $PKG_RPM"
+PKG_APK="curl openssh"
+
 #Default DNS server to download the packages
 DNS_SERVER="8.8.8.8"
 
@@ -155,7 +160,7 @@ rm -f /etc/resolv.conf > /dev/null 2>&1
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
 apt-get update > /dev/null
-apt-get install curl -y > /dev/null 2>&1
+apt-get install $PKG_DEB -y > /dev/null 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context_$selected_tag-1.deb -Lsfo /root/context.deb
 apt-get install /root/context.deb -y > /dev/null 2>&1
@@ -169,7 +174,8 @@ EOC
 export PATH=\$PATH:/bin:/sbin
 
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
-yum install epel-release -y > /root/epel-log 2>&1
+
+yum install $PKG_CENTOS6 -y > /dev/null 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el6.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1
@@ -187,6 +193,8 @@ echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 mknod -m 666 /dev/random c 1 8
 mknod -m 666 /dev/urandom c 1 9
 
+yum install $PKG_RPM -y > /dev/null 2>&1
+
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1
 rm /root/context.rpm
@@ -197,7 +205,8 @@ EOC
     terminal="/bin/ash"
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
-apk add curl > /dev/null 2>&1
+
+apk add $PKG_APK > /dev/null 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-r1.apk -Lsfo /root/context.apk
 apk add --allow-untrusted /root/context.apk > /dev/null 2>&1

--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -208,6 +208,8 @@ echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
 apk add $PKG_APK > /dev/null 2>&1
 
+rc-update add sshd
+
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-r1.apk -Lsfo /root/context.apk
 apk add --allow-untrusted /root/context.apk > /dev/null 2>&1
 rm /root/context.apk


### PR DESCRIPTION
Replaces #3138 

- centos 6 and 7 enable sshd at startup after installing openssh-server
- alpine was missing curl, so it couldn't get the context package
- packages were being left on container `/root/` directory

Since we won't add ssh dependency for alpine on context-package, we could install openssh here on alpine case.
