### PR TITLE
F #2352 #2359 #2981 #3130: Fix fs_lvm cleanup and offline migration issues

### DIFF
--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -41,67 +41,64 @@ source ${DRIVER_PATH}/../../datastore/libfs.sh
 # Return if deleting a disk, we will delete them when removing the
 # remote_system_ds directory for the VM (remotely)
 #-------------------------------------------------------------------------------
-DST_PATH=`arg_path $DST`
-DST_HOST=`arg_host $DST`
 
-DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
+# Workaround: take DST_HOST from the XML (#2352)
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onevm show -x $VM_ID | $XPATH \
+    /VM/HISTORY_RECORDS/HISTORY/HOSTNAME)
+unset i
+DST_HOST="${XPATH_ELEMENTS[i++]}"
+
+# Fallback take DST_HOST from the destination path
+DST_HOST="${DST_HOST:-$(arg_host $DST)}"
+DST_PATH=`arg_path $DST`
+
+if [ "${DST_PATH##*/}" = "$VM_ID" ]; then
+    DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-1)}')
+    FIND_DEPTH=1
+else
+    DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
+    FIND_DEPTH=0
+fi
 
 # Zero space
 ZERO_CMD=$(cat <<EOF
     set -x
-    DEV=\$(readlink $DST_PATH)
-
-    if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
-        ${DD} if=/dev/zero of="\${DEV}" bs=64k || :
-    fi
+    while read DISK_PATH; do
+        DEV=\$(readlink \$DISK_PATH)
+        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+            ${SUDO} ${LVCHANGE} -ay "\${DEV}"
+            ${DD} if=/dev/zero of="\${DEV}" bs=64k ||:
+        fi
+    done < <(find "$DST_PATH" -mindepth $FIND_DEPTH -maxdepth $FIND_DEPTH -type l)
 EOF
 )
 
 # Delete the device if it's a clone (LVM snapshot)
 DELETE_CMD=$(cat <<EOF
     set -x
-    DEV=\$(readlink $DST_PATH)
+    while read DISK_PATH; do
+        DEV=\$(readlink \$DISK_PATH)
+        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+            $SUDO $LVREMOVE -f "\$DEV" && rm -f "\$DISK_PATH"
+        fi
+    done < <(find "$DST_PATH" -mindepth $FIND_DEPTH -maxdepth $FIND_DEPTH -type l)
 
     if [ -d "$DST_PATH" ]; then
         rm -rf "$DST_PATH"
     else
-        rm -f $DST_PATH
-
-        if [ -z "\$DEV" ]; then
-            exit 0
-        fi
-
-        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
-            $SUDO $LVREMOVE -f \$DEV
-        fi
+        rm -f "$DST_PATH"
     fi
 EOF
 )
 
-if [ -n "${DS_SYS_ID}" ]; then
-
-    while IFS= read -r -d '' element; do
-        XPATH_ELEMENTS[i++]="$element"
-    done < <(onedatastore show -x $DS_SYS_ID | $XPATH \
-        /DATASTORE/TEMPLATE/BRIDGE_LIST)
-    unset i
-    BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
-
-    # Change DST_HOST to one of the BRIDGE_LIST to prevent
-    # running on frontend for undeployed VMs
-    if [ -n "$BRIDGE_LIST" ]; then
-        DST_HOST=$(get_destination_host)
-    fi
-
-    if [ "${ZERO_LVM_ON_DELETE}" = "yes" ]; then
-        ssh_exec_and_log "$DST_HOST" "$ZERO_CMD" "Error cleaning $DST_PATH"
-    fi
-
-    LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
-    exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" \
-        "Error deleting $DST_PATH"
-else
-    ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" "Error deleting $DST_PATH"
+if [ "${ZERO_LVM_ON_DELETE}" = "yes" ]; then
+    ssh_exec_and_log "$DST_HOST" "$ZERO_CMD" "Error cleaning $DST_PATH"
 fi
+
+LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
+exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" \
+    "Error deleting $DST_PATH"
 
 hup_collectd $DST_HOST

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -46,7 +46,7 @@ source ${DRIVER_PATH}/../../datastore/libfs.sh
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VM_ID | $XPATH \
-    /VM/HISTORY_RECORDS/HISTORY/HOSTNAME)
+    '/VM/HISTORY_RECORDS/HISTORY[last()]/HOSTNAME')
 unset i
 DST_HOST="${XPATH_ELEMENTS[i++]}"
 

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -57,17 +57,23 @@ DST_PATH=`arg_path $DST`
 if [ "${DST_PATH##*/}" = "$VM_ID" ]; then
     DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-1)}')
     FIND_DEPTH=1
+    DISK_ID=
 else
     DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
     FIND_DEPTH=0
+    DISK_ID=${DST_PATH##*.}
 fi
+
+LV_NAME="lv-one-${VM_ID}-${DISK_ID}"
+VG_NAME="vg-one-${DS_SYS_ID}"
+DEV_PATH="/dev/${VG_NAME}/${LV_NAME}"
 
 # Zero space
 ZERO_CMD=$(cat <<EOF
     set -x
     while read DISK_PATH; do
         DEV=\$(readlink \$DISK_PATH)
-        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+        if echo "\$DEV" | grep "^$DEV_PATH" &>/dev/null; then
             ${SUDO} ${LVCHANGE} -ay "\${DEV}"
             ${DD} if=/dev/zero of="\${DEV}" bs=64k ||:
         fi
@@ -80,7 +86,7 @@ DELETE_CMD=$(cat <<EOF
     set -x
     while read DISK_PATH; do
         DEV=\$(readlink \$DISK_PATH)
-        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+        if echo "\$DEV" | grep "^$DEV_PATH" &>/dev/null; then
             $SUDO $LVREMOVE -f "\$DEV" && rm -f "\$DISK_PATH"
         fi
     done < <(find "$DST_PATH" -mindepth $FIND_DEPTH -maxdepth $FIND_DEPTH -type l)

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -54,6 +54,7 @@ DST_PATH=`arg_path $DST`
 SRC_HOST=`arg_host $SRC`
 DST_HOST=`arg_host $DST`
 
+SRC_DIR=`dirname $SRC_PATH`
 DST_DIR=`dirname $DST_PATH`
 
 SRC_DS_DIR=`dirname  $SRC_PATH`
@@ -81,16 +82,29 @@ if [ `is_disk $DST_PATH` -eq 1 ]; then
 
     LCM_STATE="${XPATH_ELEMENTS[j++]}"
 
-    # Ignore EPILOG_UNDEPLOY
-    if [ "${LCM_STATE}" = "30" ]; then
-        exit 0
-    fi
-
     LV_NAME="lv-one-${VMID}-${DISK_ID}"
     SRC_VG_NAME="vg-one-${SRC_DS_SYS_ID}"
     SRC_DEV="/dev/${SRC_VG_NAME}/${LV_NAME}"
     DST_VG_NAME="vg-one-${DST_DS_SYS_ID}"
     DST_DEV="/dev/${DST_VG_NAME}/${LV_NAME}"
+
+    # undeploy operation
+    if [ "${LCM_STATE}" = "30" ]; then
+      # deactivate
+      CMD=$(cat <<EOF
+          set -ex -o pipefail
+          ${SUDO} ${SYNC}
+          ${SUDO} ${LVSCAN}
+          ${SUDO} ${LVCHANGE} -an "${SRC_DEV}"
+
+          rm -f "${SRC_DIR}/.host" || :
+EOF
+)
+      ssh_exec_and_log "$SRC_HOST" "$CMD" \
+          "Error deactivating disk $SRC_PATH"
+
+      exit 0
+    fi
 
     # copy volume between datastores
     if [ "${SRC_PATH}" != "${DST_PATH}" ]; then

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -77,13 +77,12 @@ if [ `is_disk $DST_PATH` -eq 1 ]; then
     while IFS= read -r -d '' element; do
         XPATH_ELEMENTS[i++]="$element"
     done < <(onevm show -x $VMID | $XPATH  \
-                        /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/TYPE )
+                        /VM/LCM_STATE )
 
-    TYPE="${XPATH_ELEMENTS[j++]}"
+    LCM_STATE="${XPATH_ELEMENTS[j++]}"
 
-    ####
-
-    if [ "${TYPE}" != "BLOCK" ]; then
+    # Ignore EPILOG_UNDEPLOY
+    if [ "${LCM_STATE}" = "30" ]; then
         exit 0
     fi
 


### PR DESCRIPTION
#### Note for reviewer:

* **delete** action changes:

  *  Now it will take last VM's host, instead using host from BRIDGE_LIST 
     fixes #2352 *(but I still thinking that it is should be fixed on API level)*

  * Support for both path types, eg: `node:/var/lib/one//datastores/103/63/disk.0` and `node:/var/lib/one//datastores/103/63`. In second case it will zero and then remove all the lvm drives under VM directory recursively.
    fixes https://github.com/OpenNebula/one/issues/2981#issuecomment-478632787 and https://github.com/OpenNebula/one/issues/2981#issuecomment-478633894

* **mv** action changes:

  *  Remove check for `/VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/TYPE`. I don't see big reason in it. Perhaps it was attempt to define different mechanism for moving old volumes as files, if system datastore was converted from `shared` to `fs_lvm`. But I still thinking that it should also convert drive to use lvm instead file store during datastore migration. Besides, this check wasn't working anyway, this parameter always equal to `FILE`.
     fixes #2359 and #3130

  *  Added check for `/VM/LCM_STATE`. We don't need to execute `mv` on UNDEPLOY state.

Signed-off-by: kvaps <kvapss@gmail.com>