### PR TITLE
F #3176: Incorrect string value during upgrade

### DIFF
--- a/src/onedb/local/5.6.0_to_5.7.80.rb
+++ b/src/onedb/local/5.6.0_to_5.7.80.rb
@@ -196,6 +196,7 @@ module Migrator
         @db.run 'ALTER TABLE vm_pool RENAME TO old_vm_pool;'
 
         create_table(:vm_pool)
+        @db.run 'ALTER TABLE vm_pool CONVERT TO CHARACTER SET utf8;'
 
         @db.transaction do
             @db.fetch('SELECT * FROM old_vm_pool') do |row|


### PR DESCRIPTION
Fix for "Incorrect string value" error, during `vm_pool` migration.