### PR TITLE
Feature - Add support for host-model

### DIFF
--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -505,6 +505,10 @@ int LibVirtDriver::deployment_description_kvm(
         {
             cpu_mode = "host-passthrough";
         }
+        else if ( cpu_model == "host-model" )
+        {
+            cpu_mode = "host-model";
+        }
         else
         {
             cpu_mode = "custom";


### PR DESCRIPTION
> Libvirt supports a third way to configure CPU models known as "Host model". This uses the QEMU "Named model" feature, automatically picking a CPU model that is similar the host CPU, and then adding extra features to approximate the host model as closely as possible. This does not guarantee the CPU family, stepping, etc will precisely match the host CPU, as they would with "Host passthrough", but gives much of the benefit of passthrough, while making live migration safe

https://www.berrange.com/posts/2018/06/29/cpu-model-configuration-for-qemu-kvm-on-x86-hosts/