### PR TITLE
 F #2352 #2359 #2981 #3130 #3233: Fix fs_lvm cleanup and offline migration issues

### DIFF
--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -50,38 +50,49 @@ else
     DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
 fi
 
+# Activate device
+ACTIVATE_CMD=$(cat <<EOF
+    set -ex -o pipefail
+    if [ -L "$DST_PATH" ]; then
+        DEV=\$(readlink $DST_PATH)
+        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+            ${SUDO} ${SYNC}
+            ${SUDO} ${LVSCAN}
+            ${SUDO} ${LVCHANGE} -ay "\${DEV}"
+        fi
+    fi
+EOF
+)
+
 # Zero space
 ZERO_CMD=$(cat <<EOF
     set -ex -o pipefail
-    DEV=\$(readlink $DST_PATH)
-
-    if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
-        ${SUDO} ${SYNC}
-        ${SUDO} ${LVSCAN}
-        ${SUDO} ${LVCHANGE} -ay "\${DEV}"
-        ${DD} if=/dev/zero of="\${DEV}" bs=64k || :
+    if [ -L "$DST_PATH" ]; then
+        DEV=\$(readlink $DST_PATH)
+        if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+            ${DD} if=/dev/zero of="\${DEV}" bs=64k || :
+        fi
     fi
 EOF
 )
 
 # Delete the device if it's a clone (LVM snapshot)
 DELETE_CMD=$(cat <<EOF
-    set -x
-    DEV=\$(readlink $DST_PATH)
+    set -ex -o pipefail
 
     if [ -d "$DST_PATH" ]; then
         rm -rf "$DST_PATH"
-    else
-        rm -f $DST_PATH
+        exit 0
+    fi
 
-        if [ -z "\$DEV" ]; then
-            exit 0
-        fi
-
+    if [ -L "$DST_PATH" ]; then
+        DEV=\$(readlink $DST_PATH)
         if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
-            $SUDO $LVREMOVE -f \$DEV
+            $SUDO $LVREMOVE -f "\$DEV"
         fi
     fi
+
+    rm -f "$DST_PATH"
 EOF
 )
 
@@ -101,6 +112,10 @@ if [ -n "${DS_SYS_ID}" ]; then
     fi
 
     if [ "${ZERO_LVM_ON_DELETE}" = "yes" ]; then
+        LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
+        exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$ACTIVATE_CMD" \
+            "Error activating disk $SRC_PATH"
+
         ssh_exec_and_log "$DST_HOST" "$ZERO_CMD" "Error cleaning $DST_PATH"
     fi
 

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -52,10 +52,13 @@ fi
 
 # Zero space
 ZERO_CMD=$(cat <<EOF
-    set -x
+    set -ex -o pipefail
     DEV=\$(readlink $DST_PATH)
 
     if echo "\$DEV" | grep "^/dev/" &>/dev/null; then
+        ${SUDO} ${SYNC}
+        ${SUDO} ${LVSCAN}
+        ${SUDO} ${LVCHANGE} -ay "\${DEV}"
         ${DD} if=/dev/zero of="\${DEV}" bs=64k || :
     fi
 EOF

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -50,6 +50,31 @@ else
     DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-1)}')
 fi
 
+unset i j XPATH_ELEMENTS
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onevm show -x $VM_ID | $XPATH \
+    '/VM/HISTORY_RECORDS/HISTORY[last()]/HOSTNAME')
+
+LAST_HOST="${XPATH_ELEMENTS[j++]}"
+
+
+# Change DST_HOST to one of the BRIDGE_LIST to prevent
+# running on frontend for undeployed VMs
+if [ "$LAST_HOST" != "$DST_HOST" ]; then
+    unset i j XPATH_ELEMENTS
+    while IFS= read -r -d '' element; do
+        XPATH_ELEMENTS[i++]="$element"
+    done < <(onedatastore show -x $DS_SYS_ID | $XPATH \
+        /DATASTORE/TEMPLATE/BRIDGE_LIST)
+
+    BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
+
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=$(get_destination_host)
+    fi
+fi
+
 # Activate device
 ACTIVATE_CMD=$(cat <<EOF
     set -ex -o pipefail
@@ -95,19 +120,6 @@ DELETE_CMD=$(cat <<EOF
     rm -f "$DST_PATH"
 EOF
 )
-
-while IFS= read -r -d '' element; do
-    XPATH_ELEMENTS[i++]="$element"
-done < <(onedatastore show -x $DS_SYS_ID | $XPATH \
-    /DATASTORE/TEMPLATE/BRIDGE_LIST)
-unset i
-BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
-
-# Change DST_HOST to one of the BRIDGE_LIST to prevent
-# running on frontend for undeployed VMs
-if [ -n "$BRIDGE_LIST" ]; then
-    DST_HOST=$(get_destination_host)
-fi
 
 if [ "${ZERO_LVM_ON_DELETE}" = "yes" ]; then
     LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -44,10 +44,10 @@ source ${DRIVER_PATH}/../../datastore/libfs.sh
 DST_PATH=`arg_path $DST`
 DST_HOST=`arg_host $DST`
 
-if [ "${DST_PATH##*/}" = "$VM_ID" ]; then
-    DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-1)}')
+if [ `is_disk $DST_PATH` -eq 1 ]; then
+    DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-2)}')
 else
-    DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
+    DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-1)}')
 fi
 
 # Activate device
@@ -96,34 +96,29 @@ DELETE_CMD=$(cat <<EOF
 EOF
 )
 
-if [ -n "${DS_SYS_ID}" ]; then
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <(onedatastore show -x $DS_SYS_ID | $XPATH \
+    /DATASTORE/TEMPLATE/BRIDGE_LIST)
+unset i
+BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
 
-    while IFS= read -r -d '' element; do
-        XPATH_ELEMENTS[i++]="$element"
-    done < <(onedatastore show -x $DS_SYS_ID | $XPATH \
-        /DATASTORE/TEMPLATE/BRIDGE_LIST)
-    unset i
-    BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
-
-    # Change DST_HOST to one of the BRIDGE_LIST to prevent
-    # running on frontend for undeployed VMs
-    if [ -n "$BRIDGE_LIST" ]; then
-        DST_HOST=$(get_destination_host)
-    fi
-
-    if [ "${ZERO_LVM_ON_DELETE}" = "yes" ]; then
-        LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
-        exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$ACTIVATE_CMD" \
-            "Error activating disk $SRC_PATH"
-
-        ssh_exec_and_log "$DST_HOST" "$ZERO_CMD" "Error cleaning $DST_PATH"
-    fi
-
-    LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
-    exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" \
-        "Error deleting $DST_PATH"
-else
-    ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" "Error deleting $DST_PATH"
+# Change DST_HOST to one of the BRIDGE_LIST to prevent
+# running on frontend for undeployed VMs
+if [ -n "$BRIDGE_LIST" ]; then
+    DST_HOST=$(get_destination_host)
 fi
+
+if [ "${ZERO_LVM_ON_DELETE}" = "yes" ]; then
+    LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
+    exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$ACTIVATE_CMD" \
+        "Error activating disk $SRC_PATH"
+
+    ssh_exec_and_log "$DST_HOST" "$ZERO_CMD" "Error cleaning $DST_PATH"
+fi
+
+LOCK="tm-fs_lvm-${DS_SYS_ID}.lock"
+exclusive "${LOCK}" 120 ssh_exec_and_log "$DST_HOST" "$DELETE_CMD" \
+    "Error deleting $DST_PATH"
 
 hup_collectd $DST_HOST

--- a/src/tm_mad/fs_lvm/delete
+++ b/src/tm_mad/fs_lvm/delete
@@ -44,7 +44,11 @@ source ${DRIVER_PATH}/../../datastore/libfs.sh
 DST_PATH=`arg_path $DST`
 DST_HOST=`arg_host $DST`
 
-DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
+if [ "${DST_PATH##*/}" = "$VM_ID" ]; then
+    DS_SYS_ID=$(echo $DST_PATH | $AWK -F '/' '{print $(NF-1)}')
+else
+    DS_SYS_ID=$(echo $DST_PATH | grep -E '\/disk\.[[:digit:]]+$' | $AWK -F '/' '{print $(NF-2)}')
+fi
 
 # Zero space
 ZERO_CMD=$(cat <<EOF

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -59,14 +59,14 @@ DST_HOST=`arg_host $DST`
 SRC_DIR=`dirname $SRC_PATH`
 DST_DIR=`dirname $DST_PATH`
 
-SRC_DS_SYS_ID=$(echo $SRC_DIR | $AWK -F '/' '{print $(NF-1)}')
-DST_DS_SYS_ID=$(echo $DST_DIR | $AWK -F '/' '{print $(NF-1)}')
-
 # Activate the disk in the target host
 if [ `is_disk $SRC_PATH` -eq 1 ]; then
     #---------------------------------------------------------------------------
     # Get Image information
     #---------------------------------------------------------------------------
+
+    SRC_DS_SYS_ID=$(echo $SRC_DIR | $AWK -F '/' '{print $(NF-1)}')
+    DST_DS_SYS_ID=$(echo $DST_DIR | $AWK -F '/' '{print $(NF-1)}')
 
     DISK_ID=${SRC_PATH##*.}
 
@@ -89,23 +89,23 @@ if [ `is_disk $SRC_PATH` -eq 1 ]; then
 
     # for stop + undeploy operation just deactivate the LV
     if [[ "$LCM_STATE" =~ ^(10|30|41|42)$ ]]; then
-      # deactivate
-      CMD=$(cat <<EOF
-          set -ex -o pipefail
-          if [ -b "${SRC_DEV}" ]; then
-            ${SUDO} ${SYNC}
-            ${SUDO} ${LVSCAN}
-            ${SUDO} ${LVCHANGE} -an "${SRC_DEV}"
-          fi
+        # deactivate
+        CMD=$(cat <<EOF
+            set -ex -o pipefail
+            if [ -b "${SRC_DEV}" ]; then
+              ${SUDO} ${SYNC}
+              ${SUDO} ${LVSCAN}
+              ${SUDO} ${LVCHANGE} -an "${SRC_DEV}"
+            fi
 
-          rm -f "${SRC_DIR}/.host" || :
+            rm -f "${SRC_DIR}/.host" || :
 EOF
 )
-      LOCK="tm-fs_lvm-${SRC_DS_SYS_ID}.lock"
-      exclusive "${LOCK}" 120 ssh_exec_and_log "${SRC_HOST}" "${CMD}" \
-          "Error deactivating disk ${SRC_PATH}"
+        LOCK="tm-fs_lvm-${SRC_DS_SYS_ID}.lock"
+        exclusive "${LOCK}" 120 ssh_exec_and_log "${SRC_HOST}" "${CMD}" \
+            "Error deactivating disk ${SRC_PATH}"
 
-      exit 0
+        exit 0
     fi
 
     # copy volume between datastores

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -87,8 +87,8 @@ if [ `is_disk $SRC_PATH` -eq 1 ]; then
     DST_VG_NAME="vg-one-${DST_DS_SYS_ID}"
     DST_DEV="/dev/${DST_VG_NAME}/${LV_NAME}"
 
-    # for stop + undeploy operation just deactivate the LV
-    if [[ "$LCM_STATE" =~ ^(10|30|41|42)$ ]]; then
+    # for prolog operation skip deactivate
+    if ! [[ "$LCM_STATE" =~ ^(31|50)$ ]]; then
         # deactivate
         CMD=$(cat <<EOF
             set -ex -o pipefail
@@ -104,7 +104,10 @@ EOF
         LOCK="tm-fs_lvm-${SRC_DS_SYS_ID}.lock"
         exclusive "${LOCK}" 120 ssh_exec_and_log "${SRC_HOST}" "${CMD}" \
             "Error deactivating disk ${SRC_PATH}"
+    fi
 
+    # for stop + undeploy operation we got nothing to do
+    if [[ "$LCM_STATE" =~ ^(10|30|41|42)$ ]]; then
         exit 0
     fi
 

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -90,8 +90,8 @@ if [ `is_disk $DST_PATH` -eq 1 ]; then
     DST_VG_NAME="vg-one-${DST_DS_SYS_ID}"
     DST_DEV="/dev/${DST_VG_NAME}/${LV_NAME}"
 
-    # undeploy operation
-    if [ "${LCM_STATE}" = "30" ] || [ "${LCM_STATE}" = "42" ]; then
+    # for stop + undeploy operation just deactivate the LV
+    if [[ "$LCM_STATE" =~ ^(10|30|41|42)$ ]]; then
       # deactivate
       CMD=$(cat <<EOF
           set -ex -o pipefail

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -89,7 +89,7 @@ if [ `is_disk $DST_PATH` -eq 1 ]; then
     DST_DEV="/dev/${DST_VG_NAME}/${LV_NAME}"
 
     # undeploy operation
-    if [ "${LCM_STATE}" = "30" ]; then
+    if [ "${LCM_STATE}" = "30" ] || [ "${LCM_STATE}" = "42" ]; then
       # deactivate
       CMD=$(cat <<EOF
           set -ex -o pipefail
@@ -102,8 +102,9 @@ if [ `is_disk $DST_PATH` -eq 1 ]; then
           rm -f "${SRC_DIR}/.host" || :
 EOF
 )
-      ssh_exec_and_log "$SRC_HOST" "$CMD" \
-          "Error deactivating disk $SRC_PATH"
+      LOCK="tm-fs_lvm-${SRC_DS_SYS_ID}.lock"
+      exclusive "${LOCK}" 120 ssh_exec_and_log "${SRC_HOST}" "${CMD}" \
+          "Error deactivating disk ${SRC_PATH}"
 
       exit 0
     fi

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -59,19 +59,16 @@ DST_HOST=`arg_host $DST`
 SRC_DIR=`dirname $SRC_PATH`
 DST_DIR=`dirname $DST_PATH`
 
-SRC_DS_DIR=`dirname  $SRC_PATH`
-SRC_VM_DIR=`basename $SRC_PATH`
-
-SRC_DS_SYS_ID=$(echo $SRC_DS_DIR | $AWK -F '/' '{print $(NF-1)}')
+SRC_DS_SYS_ID=$(echo $SRC_DIR | $AWK -F '/' '{print $(NF-1)}')
 DST_DS_SYS_ID=$(echo $DST_DIR | $AWK -F '/' '{print $(NF-1)}')
 
 # Activate the disk in the target host
-if [ `is_disk $DST_PATH` -eq 1 ]; then
+if [ `is_disk $SRC_PATH` -eq 1 ]; then
     #---------------------------------------------------------------------------
     # Get Image information
     #---------------------------------------------------------------------------
 
-    DISK_ID=${SRC_VM_DIR##*.}
+    DISK_ID=${SRC_PATH##*.}
 
     XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
 

--- a/src/tm_mad/fs_lvm/mv
+++ b/src/tm_mad/fs_lvm/mv
@@ -54,6 +54,7 @@ DST_PATH=`arg_path $DST`
 SRC_HOST=`arg_host $SRC`
 DST_HOST=`arg_host $DST`
 
+SRC_DIR=`dirname $SRC_PATH`
 DST_DIR=`dirname $DST_PATH`
 
 SRC_DS_DIR=`dirname  $SRC_PATH`
@@ -77,21 +78,35 @@ if [ `is_disk $DST_PATH` -eq 1 ]; then
     while IFS= read -r -d '' element; do
         XPATH_ELEMENTS[i++]="$element"
     done < <(onevm show -x $VMID | $XPATH  \
-                        /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/TYPE )
+                        /VM/LCM_STATE )
 
-    TYPE="${XPATH_ELEMENTS[j++]}"
-
-    ####
-
-    if [ "${TYPE}" != "BLOCK" ]; then
-        exit 0
-    fi
+    LCM_STATE="${XPATH_ELEMENTS[j++]}"
 
     LV_NAME="lv-one-${VMID}-${DISK_ID}"
     SRC_VG_NAME="vg-one-${SRC_DS_SYS_ID}"
     SRC_DEV="/dev/${SRC_VG_NAME}/${LV_NAME}"
     DST_VG_NAME="vg-one-${DST_DS_SYS_ID}"
     DST_DEV="/dev/${DST_VG_NAME}/${LV_NAME}"
+
+    # undeploy operation
+    if [ "${LCM_STATE}" = "30" ]; then
+      # deactivate
+      CMD=$(cat <<EOF
+          set -ex -o pipefail
+          if [ -b "${SRC_DEV}" ]; then
+            ${SUDO} ${SYNC}
+            ${SUDO} ${LVSCAN}
+            ${SUDO} ${LVCHANGE} -an "${SRC_DEV}"
+          fi
+
+          rm -f "${SRC_DIR}/.host" || :
+EOF
+)
+      ssh_exec_and_log "$SRC_HOST" "$CMD" \
+          "Error deactivating disk $SRC_PATH"
+
+      exit 0
+    fi
 
     # copy volume between datastores
     if [ "${SRC_PATH}" != "${DST_PATH}" ]; then


### PR DESCRIPTION
**Note for reviewer:**

This PR includes the next fixes:

1) Remove check for `/VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/TYPE` solves problem with offline and datastore migration. fixes #2359 and #3130. Add check for `LCM_STATE` instead, fs_lvm driver now correctly disables logical volume during undeploy VM.

2) Fix directory cleanup during termination undeployed VM for storage with the `BRIDGE_LIST` variable set. The expression for finding `DS_SYS_ID` was never work if `DST_PATH` is directory. fixes https://github.com/OpenNebula/one/issues/2981#issuecomment-478632787 and #2352 

5) Fix when node in `BRIDGE_LIST` have no activated lvm device, so zeroing is not working. Now it will always activate the device before zeroing.