### PR TITLE
F #3272: extend vmm/save and vmm/restore

### DIFF
--- a/src/vmm_mad/remotes/kvm/restore
+++ b/src/vmm_mad/remotes/kvm/restore
@@ -95,4 +95,13 @@ fi
 rm "$FILE"
 rm "$FILE_XML"
 
-exit 0
+if [ -t 0 ]; then
+    exit 0
+fi
+
+# If there is a specific post hook for this TM_MAD call it:
+RESTORE_TM_FILE="${DRIVER_PATH}/restore.${TM_MAD}-post"
+
+if [ -x "$RESTORE_TM_FILE" ]; then
+    echo "$DRV_MESSAGE" | $RESTORE_TM_FILE "$@"
+fi

--- a/src/vmm_mad/remotes/kvm/save
+++ b/src/vmm_mad/remotes/kvm/save
@@ -38,6 +38,22 @@ fi
 touch "$FILE"
 chmod 666 "$FILE"
 
+if [ ! -t 0 ]; then
+    # There is data in stdin, read it
+    DRV_MESSAGE=$(cat)
+
+    # The data is the driver message. Extracting the System DS TM_MAD
+    XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+    TM_MAD=$(echo "$DRV_MESSAGE" | $XPATH /VMM_DRIVER_ACTION_DATA/DATASTORE/TM_MAD)
+
+    # If there is a specific pre hook for this TM_MAD call it:
+    SAVE_TM_FILE="${DRIVER_PATH}/save.${TM_MAD}-pre"
+
+    if [ -x "$SAVE_TM_FILE" ]; then
+        echo "$DRV_MESSAGE" | $SAVE_TM_FILE "$@"
+    fi
+fi
+
 exec_and_log "virsh --connect $LIBVIRT_URI save $DEPLOY_ID $FILE" \
     "Could not save $DEPLOY_ID to $FILE"
 


### PR DESCRIPTION
so both will have pre and post hooks as follow

save.<tm_mad>-pre
resotre.<tm_mad>-post

Signed-off-by: Anton Todorov <atodorov-storpool@users.noreply.github.com>