### PR TITLE
OpenvSwitch “del_flows” override loop variables

### DIFF
--- a/src/vnm_mad/remotes/ovswitch/OpenvSwitch.rb
+++ b/src/vnm_mad/remotes/ovswitch/OpenvSwitch.rb
@@ -284,12 +284,12 @@ class OpenvSwitchVLAN < VNMMAD::VNMDriver
 
         # searching for flow just by MAC address is legacy,
         # we preferably look for a flow port with our note
-        ["note:#{port_note}", @nic[:mac]].each do |m|
+        ["note:#{port_note}", @nic[:mac]].each do |flow_matching|
             out_flows.lines do |flow|
-                next unless flow.match(m)
+                next unless flow.match(flow_matching)
 
-                if (m = flow.match(/in_port=(\d+)/))
-                    in_port_tmp = m[1]
+                if (port_match = flow.match(/in_port=(\d+)/))
+                    in_port_tmp = port_match[1]
 
                     if !the_ports.include?(in_port_tmp)
                         in_port = in_port_tmp


### PR DESCRIPTION
The “del_flows” override the loop variable “m” when matching the port,
on the second loop which result in the following error.

    /var/tmp/one/vnm/ovswitch/OpenvSwitch.rb:287:in `match': wrong argument type MatchData (expected Regexp) (TypeError)

* src/vnm_mad/remotes/ovswitch/OpenvSwitch.rb (OpenvSwitchVLAN#del_flows):
  use two different variables