### PR TITLE
Monitor ceph ec pool space usage

### DIFF
--- a/src/tm_mad/ceph/monitor
+++ b/src/tm_mad/ceph/monitor
@@ -91,6 +91,7 @@ MONITOR_STATUS=$?
 if [ "$MONITOR_STATUS" = "0" ]; then
     XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
     echo -e "$(rbd_df_monitor ${MONITOR_DATA} ${POOL_NAME})"
+    echo -e "$(rbd_df_monitor ${MONITOR_DATA} ec)"
 else
     echo "$MONITOR_DATA"
     exit $MONITOR_STATUS


### PR DESCRIPTION
Running ceph monitor now outputs

```
oneadmin@ubuntu1804-lxd-ceph-luminous-7dbb9-0:~$ /var/lib/one/remotes/datastore/ceph/monitor PERTX0RSSVZFUl9BQ1RJT05fREFUQT48REFUQVNUT1JFPjxJRD4xPC9JRD48VUlEPjA8L1VJRD48R0lEPjA8L0dJRD48VU5BTUU+b25lYWRtaW48L1VOQU1FPjxHTkFNRT5vbmVhZG1pbjwvR05BTUU+PE5BTUU+ZGVmYXVsdDwvTkFNRT48UEVSTUlTU0lPTlM+PE9XTkVSX1U+MTwvT1dORVJfVT48T1dORVJfTT4xPC9PV05FUl9NPjxPV05FUl9BPjA8L09XTkVSX0E+PEdST1VQX1U+MTwvR1JPVVBfVT48R1JPVVBfTT4wPC9HUk9VUF9NPjxHUk9VUF9BPjA8L0dST1VQX0E+PE9USEVSX1U+MDwvT1RIRVJfVT48T1RIRVJfTT4wPC9PVEhFUl9NPjxPVEhFUl9BPjA8L09USEVSX0E+PC9QRVJNSVNTSU9OUz48RFNfTUFEPjwhW0NEQVRBW2NlcGhdXT48L0RTX01BRD48VE1fTUFEPjwhW0NEQVRBW2NlcGhdXT48L1RNX01BRD48QkFTRV9QQVRIPjwhW0NEQVRBWy92YXIvbGliL29uZS8vZGF0YXN0b3Jlcy8xXV0+PC9CQVNFX1BBVEg+PFRZUEU+MDwvVFlQRT48RElTS19UWVBFPjM8L0RJU0tfVFlQRT48U1RBVEU+MDwvU1RBVEU+PENMVVNURVJTPjxJRD4wPC9JRD48L0NMVVNURVJTPjxUT1RBTF9NQj4zNzgxNjwvVE9UQUxfTUI+PEZSRUVfTUI+Mzc0OTY8L0ZSRUVfTUI+PFVTRURfTUI+MzE5PC9VU0VEX01CPjxJTUFHRVM+PElEPjA8L0lEPjxJRD4xPC9JRD48L0lNQUdFUz48VEVNUExBVEU+PEFMTE9XX09SUEhBTlM+PCFbQ0RBVEFbbWl4ZWRdXT48L0FMTE9XX09SUEhBTlM+PEJSSURHRV9MSVNUPjwhW0NEQVRBW3VidW50dTE4MDQtbHhkLWNlcGgtbHVtaW5vdXMtN2RiYjktMS50ZXN0IHVidW50dTE4MDQtbHhkLWNlcGgtbHVtaW5vdXMtN2RiYjktMi50ZXN0XV0+PC9CUklER0VfTElTVD48Q0VQSF9IT1NUPjwhW0NEQVRBW3VidW50dTE4MDQtbHhkLWNlcGgtbHVtaW5vdXMtN2RiYjktMC50ZXN0XV0+PC9DRVBIX0hPU1Q+PENFUEhfU0VDUkVUPjwhW0NEQVRBWzdlYmIyNDQ1LWU5NmUtNDRjNi1iN2M3LTA3ZGM3YTUwZjMxMV1dPjwvQ0VQSF9TRUNSRVQ+PENFUEhfVVNFUj48IVtDREFUQVtvbmVhZG1pbl1dPjwvQ0VQSF9VU0VSPjxDTE9ORV9UQVJHRVQ+PCFbQ0RBVEFbU0VMRl1dPjwvQ0xPTkVfVEFSR0VUPjxDTE9ORV9UQVJHRVRfU0hBUkVEPjwhW0NEQVRBW1NFTEZdXT48L0NMT05FX1RBUkdFVF9TSEFSRUQ+PENMT05FX1RBUkdFVF9TU0g+PCFbQ0RBVEFbU1lTVEVNXV0+PC9DTE9ORV9UQVJHRVRfU1NIPjxESVNLX1RZUEU+PCFbQ0RBVEFbUkJEXV0+PC9ESVNLX1RZUEU+PERJU0tfVFlQRV9TSEFSRUQ+PCFbQ0RBVEFbUkJEXV0+PC9ESVNLX1RZUEVfU0hBUkVEPjxESVNLX1RZUEVfU1NIPjwhW0NEQVRBW0ZJTEVdXT48L0RJU0tfVFlQRV9TU0g+PERSSVZFUj48IVtDREFUQVtyYXddXT48L0RSSVZFUj48RFNfTUFEPjwhW0NEQVRBW2NlcGhdXT48L0RTX01BRD48TE5fVEFSR0VUPjwhW0NEQVRBW05PTkVdXT48L0xOX1RBUkdFVD48TE5fVEFSR0VUX1NIQVJFRD48IVtDREFUQVtOT05FXV0+PC9MTl9UQVJHRVRfU0hBUkVEPjxMTl9UQVJHRVRfU1NIPjwhW0NEQVRBW1NZU1RFTV1dPjwvTE5fVEFSR0VUX1NTSD48UE9PTF9OQU1FPjwhW0NEQVRBW29uZV1dPjwvUE9PTF9OQU1FPjxSRVNUUklDVEVEX0RJUlM+PCFbQ0RBVEFbL11dPjwvUkVTVFJJQ1RFRF9ESVJTPjxTQUZFX0RJUlM+PCFbQ0RBVEFbL3Zhci90bXAgL3RtcF1dPjwvU0FGRV9ESVJTPjxUTV9NQUQ+PCFbQ0RBVEFbY2VwaF1dPjwvVE1fTUFEPjxUTV9NQURfU1lTVEVNPjwhW0NEQVRBW3NzaCxzaGFyZWRdXT48L1RNX01BRF9TWVNURU0+PFRZUEU+PCFbQ0RBVEFbSU1BR0VfRFNdXT48L1RZUEU+PC9URU1QTEFURT48L0RBVEFTVE9SRT48L0RTX0RSSVZFUl9BQ1RJT05fREFUQT4= 1
USED_MB=319
TOTAL_MB=37816
FREE_MB=37496

USED_MB=0
TOTAL_MB=49995
FREE_MB=49995
```

which corresponds to monitor command output, human readable
```
root@ubuntu1804-lxd-ceph-luminous-7dbb9-1:~# ceph --id oneadmin df detail
GLOBAL:
    SIZE        AVAIL       RAW USED     %RAW USED     OBJECTS 
    79.8GiB     77.2GiB      2.58GiB          3.23         100 
POOLS:
    NAME     ID     QUOTA OBJECTS     QUOTA BYTES     USED       %USED     MAX AVAIL     OBJECTS     DIRTY     READ     WRITE     RAW USED 
    one      1      N/A               N/A             320MiB      0.84       36.6GiB         100       100      53B      160B       639MiB 
    ec       2      N/A               N/A                 0B         0       48.8GiB           0         0       0B        0B           0B
```

It would be neccesary for the core to establish how the data will be received, maybe 3 arrays with 2 integers each one, or 6 different variables.