### PR TITLE
B #3354 add NIC aliases to the IP spoofing filter

### DIFF
--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -429,6 +429,14 @@ module SGIPTables
                 ipv4s << nic[key] if !nic[key].nil? && !nic[key].empty?
             end
 
+            if !nic[:aliases].nil? && !nic[:aliases].empty?
+                nic[:aliases].each do |nicalias|
+                    [:ip, :vrouter_ip].each do |key|
+                        ipv4s << nicalias[key] if !nicalias[key].nil? && !nicalias[key].empty?
+                    end
+                end
+            end
+
             if !ipv4s.empty?
                 #bootp
                 commands.add :iptables, "-A #{chain_out} -p udp "\
@@ -454,6 +462,14 @@ module SGIPTables
 
             [:ip6, :ip6_global, :ip6_link, :ip6_ula].each do |key|
                 ipv6s << nic[key] if !nic[key].nil? && !nic[key].empty?
+            end
+
+            if !nic[:aliases].nil? && !nic[:aliases].empty?
+                nic[:aliases].each do |nicalias|
+                    [:ip6, :ip6_global, :ip6_link, :ip6_ula].each do |key|
+                        ipv6s << nicalias[key] if !nicalias[key].nil? && !nicalias[key].empty?
+                    end
+                end
             end
 
             if !ipv6s.empty?

--- a/src/vnm_mad/remotes/lib/vm.rb
+++ b/src/vnm_mad/remotes/lib/vm.rb
@@ -50,6 +50,15 @@ module VNMMAD
                         nic.get_tap(self)
                     end
 
+                    if !nic[:alias_ids].nil?
+                        nic[:aliases] = []
+                        @vm_root.elements.each("TEMPLATE/NIC_ALIAS[PARENT_ID=\"#{nic[:nic_id]}\"]") do |nicalias_element|
+                            nicalias = nics.new_nic
+                            nic_build_hash(nicalias_element, nicalias)
+                            nic[:aliases] << nicalias
+                        end
+                    end
+
                     nics << nic
                 end
 


### PR DESCRIPTION
in src/vnm_mad/remotes/lib/vm.rb:
   add array of NIC aliases to the nic Array

in src/vnm_mad/remotes/lib/security_groups_iptables.rb
   update ipv4s(and ipv6s) with the alias ips

Signed-off-by: Anton Todorov <atodorov-storpool@users.noreply.github.com>