### PR TITLE
B 3369: pass via STDIN the $TEMPLATE variable when

### DIFF
--- a/src/hm_mad/one_hm.rb
+++ b/src/hm_mad/one_hm.rb
@@ -45,12 +45,21 @@ class HookManagerDriver < OpenNebulaDriver
 
     def action_execute(number, hook_name, host, script, *arguments)
         cmd=nil
+        stdin=nil
+        arguments[0].each_with_index do |arg,idx|
+            if arg=='STDIN' && idx<arguments[0].length-1
+                stdin=a[0][idx+1]
+                arguments[0].delete_at(idx+1)
+                arguments[0].delete_at(idx)
+                break
+            end
+        end
         cmd_string="#{script} #{arguments.join(' ')}"
 
         if host.upcase=="LOCAL"
-            cmd=LocalCommand.run(cmd_string, log_method(number))
+            cmd=LocalCommand.run(cmd_string, log_method(number), stdin)
         else
-            cmd=SSHCommand.run("'#{cmd_string}'", host, log_method(number))
+            cmd=SSHCommand.run("'#{cmd_string}'", host, log_method(number), stdin)
         end
 
         if cmd.code==0


### PR DESCRIPTION
prefixed with 'STDIN' keyword. for example
```
VM_HOOK = [
    name      = "net_fw_hook",
    on        = "CUSTOM",
    state     = "ACTIVE",
    lcm_state = "HOTPLUG_NIC",
    command   = "net_fw_hook",
    remote    = "YES",
    arguments = "STDIN $TEMPLATE" ]
```

Without the keyword current workflow is executed

Signed-off-by: Anton Todorov <a.todorov@storpool.com>