### PR TITLE
B #3269: onedb purge-done eat too much RAM

### DIFF
--- a/src/onedb/onedb
+++ b/src/onedb/onedb
@@ -291,6 +291,14 @@ DELETE= {
     :description => "Delete all matched xpaths"
 }
 
+PAGES = {
+    :name => 'pages',
+    :short => '-p pages',
+    :large => '--pages pages',
+    :description => 'Nummber of pages to purge VMs',
+    :format => Integer
+}
+
 cmd=CommandParser::CmdParser.new(ARGV) do
     description <<-EOT.unindent
         This command enables the user to manage the OpenNebula database. It
@@ -500,7 +508,7 @@ cmd=CommandParser::CmdParser.new(ARGV) do
     EOT
 
     command :'purge-done', purge_done_desc,
-            :options => [START_TIME, END_TIME] do
+            :options => [START_TIME, END_TIME, PAGES] do
         begin
             action = OneDBLive.new
             action.purge_done_vm(options)

--- a/src/onedb/onedb_live.rb
+++ b/src/onedb/onedb_live.rb
@@ -5,7 +5,7 @@ require 'base64'
 class OneDBLive
 
     EDITOR_PATH = '/bin/vi'
-    PAGES       = 100
+    PAGES       = 0
 
     def initialize
         @client = nil

--- a/src/onedb/onedb_live.rb
+++ b/src/onedb/onedb_live.rb
@@ -4,7 +4,8 @@ require 'base64'
 
 class OneDBLive
 
-    EDITOR_PATH='/bin/vi'
+    EDITOR_PATH = '/bin/vi'
+    PAGES       = 100
 
     def initialize
         @client = nil
@@ -206,30 +207,23 @@ class OneDBLive
     end
 
     def purge_done_vm(options = {})
-        vmpool = OpenNebula::VirtualMachinePool.new(client)
-        vmpool.info(OpenNebula::Pool::INFO_ALL,
-                    -1,
-                    -1,
-                    OpenNebula::VirtualMachine::VM_STATE.index('DONE'))
-
-        ops = {
-            start_time: 0,
-            end_time: Time.now
-        }.merge(options)
-
+        ops         = { :start_time => 0,
+                        :end_time   => Time.now,
+                        :pages      => PAGES }.merge(options)
+        vmpool      = OpenNebula::VirtualMachinePool.new(client)
         start_time  = ops[:start_time].to_i
         end_time    = ops[:end_time].to_i
+        done        = OpenNebula::VirtualMachine::VM_STATE.index('DONE')
 
-        last_id = vmpool["/VM_POOL/VM[last()]/ID"]
+        vmpool.each_page(ops[:pages], done, false, true) do |obj|
+            print "VM with ID: #{obj['ID']} purged \r"
 
-        vmpool.each do |vm|
-            print percentage_line(vm.id, last_id, true)
+            time = obj['ETIME'].to_i
 
-            time = vm["ETIME"].to_i
             next unless time >= start_time && time < end_time
 
-            delete("vm_pool", "oid = #{vm.id}", false)
-            delete("history", "vid = #{vm.id}", false)
+            delete('vm_pool', "oid = #{obj['ID']}", false)
+            delete('history', "vid = #{obj['ID']}", false)
         end
     end
 


### PR DESCRIPTION
    * Process done VMs in pages, instead of all together
    * Add new method to iterate over pages
    * Add new CLI paramter to specify pages size