### PR TITLE
B #1710: fix bug when parent_id is empty

### DIFF
--- a/src/onedb/fsck/quotas.rb
+++ b/src/onedb/fsck/quotas.rb
@@ -474,11 +474,13 @@ module OneDBFsck
             vnet_doc.xpath('VNET/AR_POOL').each do |ar|
                 parent_id = ar.xpath('AR/PARENT_NETWORK_AR_ID')
                 parent_id = parent_id.text unless parent_id.nil?
-                size      = ar.xpath('AR/SIZE').text.to_i
 
-                if !parent_id.nil?
-                    vnet_usage[parent_id] = 0 if vnet_usage[parent_id].nil?
-                    vnet_usage[parent_id] += size
+                next if parent_id.nil? || parent_id.empty?
+
+                vnet_usage[parent_id] = 0 if vnet_usage[parent_id].nil?
+
+                ar.xpath('AR/SIZE').each do |size|
+                    vnet_usage[parent_id] += size.text.to_i
                 end
             end
         end


### PR DESCRIPTION
Applies to 5.8 and master.