### PR TITLE
F #3406: Fix nil mappers. Centralize disk filter.

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -325,7 +325,7 @@ class Container
 
         csrc = @lxc['devices']['context']['source'].clone
 
-        @lxc['devices'].delete('context')['source']
+        @lxc['devices'].delete('context')
 
         update
 
@@ -374,7 +374,7 @@ class Container
             container devices\n#{@lxc['devices']}"
         end
 
-        @lxc['devices'].delete(disk_name)['source']
+        @lxc['devices'].delete(disk_name)
 
         update
 


### PR DESCRIPTION
Basically we have our mapper generation prone to being nil by not matching the supported mappers.

- Also simplified some logic centralization


1st of probably more PRs related to #3406, there could be more situation leading to map issues like #3389.