### PR TITLE
Update recontextualization execution

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -170,11 +170,22 @@ class Container
         @lxc = @client.get("#{CONTAINERS}/#{name}")['metadata']
     end
 
-    # Runs command inside container
+    # Runs command inside container using the LXD CLI
     # @param command [String] to execute through lxc exec
     def exec(command)
         cmd = "#{@lxc_command} exec #{@one.vm_name} -- #{command}"
         Command.execute(cmd, true)
+    end
+
+    # Runs command inside container using REST. Execution isn't managed.
+    # @param full command [String] to execute
+    def exec_rest(command)
+        body = { 'command'              => command.split(' '),
+                 'wait-for-websocket'   => false,
+                 'record-output'        => false,
+                 'interactive'          => false }
+
+        @client.post("#{CONTAINERS}/#{name}/exec", body)
     end
 
     def show_log

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -325,7 +325,7 @@ class Container
 
         csrc = @lxc['devices']['context']['source'].clone
 
-        @lxc['devices'].delete('context')['source']
+        @lxc['devices'].delete('context')
 
         update
 
@@ -374,7 +374,7 @@ class Container
             container devices\n#{@lxc['devices']}"
         end
 
-        @lxc['devices'].delete(disk_name)['source']
+        @lxc['devices'].delete(disk_name)
 
         update
 

--- a/src/vmm_mad/remotes/lxd/reconfigure
+++ b/src/vmm_mad/remotes/lxd/reconfigure
@@ -40,6 +40,4 @@ container = Container.get(vm_name, xml, client)
 
 raise 'Failed to attach context' unless container.attach_context
 
-rc, _out, err = container.exec('service one-context-reconfigure restart')
-
-OpenNebula.log_error "Failed to run recontextualization service \n#{err}" unless rc.zero?
+container.exec_rest('service one-context-reconfigure restart')


### PR DESCRIPTION
Reconfigure now runs recontextualization through REST API, simply post and don't verify nor wait for result.

We cannot get rid of snap hacks yet since we still need exec through CLI for svncterm  :(

Hopefully this and #3406 will solve https://github.com/OpenNebula/one/issues/3390 and https://github.com/OpenNebula/one/issues/3389