### PR TITLE
B #3389: Add pre_boot status

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -131,6 +131,9 @@ class Container
         @lxc['source'] = { 'type' => 'none' }
         wait?(@client.post(CONTAINERS, @lxc), wait, timeout)
 
+        @lxc['config']['user.one_status'] = '0'
+        update
+
         @lxc = @client.get("#{CONTAINERS}/#{name}")['metadata']
     end
 
@@ -204,6 +207,10 @@ class Container
     #---------------------------------------------------------------------------
     def start(options = {})
         OpenNebula.log '--- Starting container ---'
+
+        @lxc['config'].delete('user.one_status')
+        update
+
         change_state(__method__, options)
     end
 

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -207,10 +207,12 @@ class Container
     def start(options = {})
         OpenNebula.log '--- Starting container ---'
 
+        operation = change_state(__method__, options)
+
         @lxc['config'].delete('user.one_status')
         update
 
-        change_state(__method__, options)
+        operation
     end
 
     def stop(options = { :timeout => 120 })

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -129,10 +129,9 @@ class Container
     # Create a container without a base image
     def create(wait: true, timeout: '')
         @lxc['source'] = { 'type' => 'none' }
-        wait?(@client.post(CONTAINERS, @lxc), wait, timeout)
-
         @lxc['config']['user.one_status'] = '0'
-        update
+
+        wait?(@client.post(CONTAINERS, @lxc), wait, timeout)
 
         @lxc = @client.get("#{CONTAINERS}/#{name}")['metadata']
     end

--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -121,6 +121,8 @@ module LXD
                 state = 'p'
             when 'stopped'
                 state = 'd'
+
+                state = '-' if container.config['user.one_status'] == '0'
             when 'failure'
                 state = 'e'
             else


### PR DESCRIPTION
Doesn't cover wild containers, but since the time they are stopped is minimal compared to full fledged containers, IMHO it isn't necessary. 