### PR TITLE
B #3490 Fix wrong parameter for one.user.login

### DIFF
--- a/src/oca/go/src/goca/user.go
+++ b/src/oca/go/src/goca/user.go
@@ -135,11 +135,11 @@ func (user *User) Passwd(password string) error {
 }
 
 // Login generates or sets a login token.
-// * token: The token
+// * token: The token, if empty oned will generate one
 // * timeSeconds: Valid period in seconds; 0 reset the token and -1 for a non-expiring token.
 // * effectiveGID: Effective GID to use with this token. To use the current GID and user groups set it to -1
 func (user *User) Login(token string, timeSeconds int, effectiveGID int) error {
-	_, err := client.Call("one.user.login", user.ID, token, timeSeconds, effectiveGID)
+	_, err := client.Call("one.user.login", user.Name, token, timeSeconds, effectiveGID)
 	return err
 }
 


### PR DESCRIPTION
- `one.user.login` requires a username as the first parameter, not an ID
- See http://docs.opennebula.org/5.8/integration/system_interfaces/api.html#one-user-login
- Clarified doc string