### PR TITLE
Update auto-context apps on LXD market

### DIFF
--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -36,10 +36,11 @@ MARKET_URL=$1
 CONTEXT_API="https://api.github.com/repos/OpenNebula/addon-context-linux/releases"
 CONTEXT_URL="https://github.com/OpenNebula/addon-context-linux/releases/download"
 
+PKG_APK="curl openssh"
 PKG_DEB="curl dbus openssh-server"
 PKG_RPM="openssh-server"
 PKG_CENTOS6="epel-release $PKG_RPM"
-PKG_APK="curl openssh"
+PKG_FEDORA="network-scripts $PKG_RPM"
 
 #Default DNS server to download the packages
 DNS_SERVER="8.8.8.8"
@@ -151,7 +152,7 @@ mkdir $TMP_DIR/$id
 # Generate installation scripts for each Linux distribution
 #-------------------------------------------------------------------------------
 case "$rootfs_url" in
-*ubuntu*|*debian*)
+*ubuntu*|*debian*|*devuan*)
     terminal="/bin/bash"
     commands=$(cat <<EOC
 export PATH=\$PATH:/bin:/sbin
@@ -194,6 +195,38 @@ mknod -m 666 /dev/random c 1 8
 mknod -m 666 /dev/urandom c 1 9
 
 yum install $PKG_RPM -y > /dev/null 2>&1
+
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
+yum install /root/context.rpm -y > /dev/null 2>&1
+rm /root/context.rpm
+EOC
+)
+    ;;
+*fedora28*)
+    terminal="/bin/bash"
+    commands=$(cat <<EOC
+echo "nameserver $DNS_SERVER" > /etc/resolv.conf
+
+yum install $PKG_RPM -y > /dev/null 2>&1
+
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
+yum install /root/context.rpm -y > /dev/null 2>&1
+rm /root/context.rpm
+EOC
+)
+    ;;
+*fedora/29*|*fedora/30*)
+    terminal="/bin/bash"
+    commands=$(cat <<EOC
+rm /etc/resolv.conf
+echo "nameserver $DNS_SERVER" > /etc/resolv.conf
+
+## New yum version requires random bits to initialize GnuTLS, but chroot
+## prevents access to /dev/urandom (as desgined).
+mknod -m 666 /dev/random c 1 8
+mknod -m 666 /dev/urandom c 1 9
+
+yum install $PKG_FEDORA -y > /dev/null 2>&1
 
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1

--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -199,6 +199,8 @@ yum install $PKG_RPM -y > /dev/null 2>&1
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1
 rm /root/context.rpm
+
+rm /dev/random /dev/urandom
 EOC
 )
     ;;
@@ -231,6 +233,8 @@ yum install $PKG_FEDORA -y > /dev/null 2>&1
 $CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
 yum install /root/context.rpm -y > /dev/null 2>&1
 rm /root/context.rpm
+
+rm /dev/random /dev/urandom
 EOC
 )
     ;;


### PR DESCRIPTION
Added devuan and fedora.

Fedora 30 still fails on hostname context though. See https://github.com/OpenNebula/one/issues/3178#issuecomment-509506277