### PR TITLE
F #3534: VNM actions "pre" and "clean" pass argument "host"

### DIFF
--- a/src/vmm_mad/exec/one_vmm_exec.rb
+++ b/src/vmm_mad/exec/one_vmm_exec.rb
@@ -389,8 +389,9 @@ class ExecDriver < VirtualMachineDriver
         steps.concat([
             # Execute pre-boot networking setup
             {
-                :driver   => :vnm,
-                :action   => :pre
+                :driver     => :vnm,
+                :action     => :pre,
+                :parameters => [:host]
             },
             # Boot the Virtual Machine
             {
@@ -446,8 +447,9 @@ class ExecDriver < VirtualMachineDriver
             },
             # Execute networking clean up operations
             {
-                :driver   => :vnm,
-                :action   => :clean
+                :driver     => :vnm,
+                :action     => :clean,
+                :parameters => [:host]
             }
         ]
 
@@ -479,7 +481,8 @@ class ExecDriver < VirtualMachineDriver
             # Execute pre-boot networking setup
             {
                 :driver     => :vnm,
-                :action     => :pre
+                :action     => :pre,
+                :parameters => [:host]
             },
             # Restore the Virtual Machine from checkpoint
             {
@@ -529,6 +532,7 @@ class ExecDriver < VirtualMachineDriver
             {
                 :driver      => :vnm,
                 :action      => :pre,
+                :parameters  => [:dest_host],
                 :destination => true
             },
             # Migrate the Virtual Machine
@@ -552,6 +556,7 @@ class ExecDriver < VirtualMachineDriver
             {
                 :driver       => :vnm,
                 :action       => :clean,
+                :parameters   => [:host],
                 :no_fail      => true
             },
             # Execute post-boot networking setup on migrating host
@@ -813,9 +818,10 @@ class ExecDriver < VirtualMachineDriver
                 }
             steps <<
                 {
-                    :driver  => :vnm,
-                    :action  => :clean,
-                    :no_fail => true
+                    :driver     => :vnm,
+                    :action     => :clean,
+                    :parameters => [:host],
+                    :no_fail    => true
                 }
         end
 
@@ -831,10 +837,11 @@ class ExecDriver < VirtualMachineDriver
                 }
             steps <<
                 {
-                    :driver  => :vnm,
-                    :action  => :clean,
+                    :driver      => :vnm,
+                    :action      => :clean,
+                    :parameters  => [:dest_host],
                     :destination => true,
-                    :no_fail => true
+                    :no_fail     => true
                 }
         end
 
@@ -914,8 +921,9 @@ class ExecDriver < VirtualMachineDriver
             steps = [
                 # Execute pre-attach networking setup
                 {
-                    :driver   => :vnm,
-                    :action   => :pre
+                    :driver     => :vnm,
+                    :action     => :pre,
+                    :parameters => [:host]
                 },
                 # Attach the new NIC
                 {
@@ -941,8 +949,9 @@ class ExecDriver < VirtualMachineDriver
             steps = [
                 # Execute pre-attach networking setup
                 {
-                    :driver   => :vnm,
-                    :action   => :pre
+                    :driver     => :vnm,
+                    :action     => :pre,
+                    :parameters => [:host]
                 },
                 # Execute post-boot networking setup
                 {
@@ -1028,7 +1037,8 @@ class ExecDriver < VirtualMachineDriver
                 # Clean networking setup
                 {
                     :driver       => :vnm,
-                    :action       => :clean
+                    :action       => :clean,
+                    :parameters   => [:host]
                 }
             ]
         elsif nic_alias && external
@@ -1036,7 +1046,8 @@ class ExecDriver < VirtualMachineDriver
                 # Clean networking setup
                 {
                     :driver       => :vnm,
-                    :action       => :clean
+                    :action       => :clean,
+                    :parameters   => [:host]
                 }
             ]
         else
@@ -1160,8 +1171,9 @@ class ExecDriver < VirtualMachineDriver
             },
             # Execute networking clean up operations
             {
-                :driver   => :vnm,
-                :action   => :clean
+                :driver     => :vnm,
+                :action     => :clean,
+                :parameters => [:host]
             }
         ]
 

--- a/src/vnm_mad/remotes/802.1Q/clean
+++ b/src/vnm_mad/remotes/802.1Q/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vlan_tag_driver'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = VLANTagDriver::XPATH_FILTER
 

--- a/src/vnm_mad/remotes/802.1Q/pre
+++ b/src/vnm_mad/remotes/802.1Q/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vlan_tag_driver'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = VLANTagDriver::XPATH_FILTER
 
 hm = VLANTagDriver.from_base64(template64, xpath_filter, deploy_id)

--- a/src/vnm_mad/remotes/bridge/clean
+++ b/src/vnm_mad/remotes/bridge/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vnmmad'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = "TEMPLATE/NIC[VN_MAD='bridge']"
 

--- a/src/vnm_mad/remotes/bridge/pre
+++ b/src/vnm_mad/remotes/bridge/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vnmmad'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = "TEMPLATE/NIC[VN_MAD='bridge']"
 
 hm = VNMMAD::NoVLANDriver.from_base64(template64, xpath_filter, deploy_id)

--- a/src/vnm_mad/remotes/ebtables/clean
+++ b/src/vnm_mad/remotes/ebtables/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'Ebtables'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = EbtablesVLAN::XPATH_FILTER
 

--- a/src/vnm_mad/remotes/ebtables/pre
+++ b/src/vnm_mad/remotes/ebtables/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'Ebtables'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = EbtablesVLAN::XPATH_FILTER
 
 onevlan = EbtablesVLAN.from_base64(template64, xpath_filter, deploy_id)

--- a/src/vnm_mad/remotes/fw/clean
+++ b/src/vnm_mad/remotes/fw/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vnmmad'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = "TEMPLATE/NIC[VN_MAD='fw']"
 

--- a/src/vnm_mad/remotes/fw/pre
+++ b/src/vnm_mad/remotes/fw/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vnmmad'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = "TEMPLATE/NIC[VN_MAD='fw']"
 
 hm = VNMMAD::NoVLANDriver.from_base64(template64, xpath_filter, deploy_id)

--- a/src/vnm_mad/remotes/ovswitch/clean
+++ b/src/vnm_mad/remotes/ovswitch/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'OpenvSwitch'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = OpenvSwitchVLAN::XPATH_FILTER
 

--- a/src/vnm_mad/remotes/ovswitch/pre
+++ b/src/vnm_mad/remotes/ovswitch/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'OpenvSwitch'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = OpenvSwitchVLAN::XPATH_FILTER
 
 ovs = OpenvSwitchVLAN.from_base64(template64, xpath_filter, deploy_id)

--- a/src/vnm_mad/remotes/ovswitch_vxlan/clean
+++ b/src/vnm_mad/remotes/ovswitch_vxlan/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'OpenvSwitchVXLAN'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = OpenvSwitchVXLAN::XPATH_FILTER
 

--- a/src/vnm_mad/remotes/ovswitch_vxlan/pre
+++ b/src/vnm_mad/remotes/ovswitch_vxlan/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'OpenvSwitchVXLAN'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = OpenvSwitchVXLAN::XPATH_FILTER
 
 ovs = OpenvSwitchVXLAN.from_base64(template64, xpath_filter, deploy_id)

--- a/src/vnm_mad/remotes/vxlan/clean
+++ b/src/vnm_mad/remotes/vxlan/clean
@@ -22,6 +22,7 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vxlan_driver'
 
 template64   = ARGV[0]
+host         = ARGV[1]
 deploy_id    = nil
 xpath_filter = VXLANDriver::XPATH_FILTER
 

--- a/src/vnm_mad/remotes/vxlan/pre
+++ b/src/vnm_mad/remotes/vxlan/pre
@@ -22,7 +22,8 @@ $: << File.join(File.dirname(__FILE__), "..")
 require 'vxlan_driver'
 
 template64   = ARGV[0]
-deploy_id    = ARGV[1]
+host         = ARGV[1]
+deploy_id    = nil
 xpath_filter = VXLANDriver::XPATH_FILTER
 
 


### PR DESCRIPTION
Set deploy_id = nil in pre actions, because there is no deploy_id passed

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>