### PR TITLE
B #3540: Ensure vnm clean

### DIFF
--- a/src/vmm_mad/exec/one_vmm_exec.rb
+++ b/src/vmm_mad/exec/one_vmm_exec.rb
@@ -813,13 +813,14 @@ class ExecDriver < VirtualMachineDriver
                     :parameters => [:deploy_id, :host],
                     :no_fail    => true
                 }
-            steps <<
-                {
-                    :driver  => :vnm,
-                    :action  => :clean,
-                    :no_fail => true
-                }
         end
+
+        steps <<
+            {
+                :driver  => :vnm,
+                :action  => :clean,
+                :no_fail => true
+            }
 
         # Cancel the VM at the previous host (in case of migration)
         if mhost && !mhost.empty?


### PR DESCRIPTION
I believe the deploy_id isn't generated after the deploy action fails. So the cleanup action check skips the net clean steps. When vnm post fails the `deploy_id` is indeed generated and the vm cleanup runs successfully the network cleanup. 

I just moved the net clean outside of the check.

- Fixes #3540
- Applies to one-5.8 as well.
- [Doc PR](https://github.com/OpenNebula/docs/pull/709)

