### PR TITLE
B #3510: Fix 802.1Q hooks

### DIFF
--- a/src/vnm_mad/remotes/lib/sg_driver.rb
+++ b/src/vnm_mad/remotes/lib/sg_driver.rb
@@ -113,6 +113,8 @@ module VNMMAD
             end
 
             unlock
+
+            0
         end
 
         # Clean iptables rules and chains
@@ -132,6 +134,8 @@ module VNMMAD
             ensure
                 unlock
             end
+
+            0
         end
     end
 end


### PR DESCRIPTION
Activates and deactivates methods in this class weren't returning 0 when successful, unlike other drivers classes.

Fixes #3510 

Doesn't apply to one-5.8