### PR TITLE
Log vnm hooks output

### DIFF
--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -363,7 +363,6 @@ module SGIPTables
 
         vars = SGIPTables.vars(vm, nic)
 
-        chain     = vars[:chain]
         chain_in  = vars[:chain_in]
         chain_out = vars[:chain_out]
 

--- a/src/vnm_mad/remotes/lib/vnm_driver.rb
+++ b/src/vnm_mad/remotes/lib/vnm_driver.rb
@@ -206,9 +206,11 @@ module VNMMAD
 
                 cmd = "#{file} #{args.join(' ')}"
 
-                _o, e, s = Open3.capture3(cmd, :stdin_data => stdin.to_s)
+                o, e, s = Open3.capture3(cmd, :stdin_data => stdin.to_s)
 
                 raise "Error running #{file}\n#{e}" unless s.exitstatus.zero?
+
+                OpenNebula.log o
             end
 
             0


### PR DESCRIPTION
Closes #3509 

By default stdout is logged, stderr is logged when custom script fails to run.