### PR TITLE
fix condition for calculate quotas for reserved networks

### DIFF
--- a/src/onedb/fsck/quotas.rb
+++ b/src/onedb/fsck/quotas.rb
@@ -475,7 +475,7 @@ module OneDBFsck
                 parent_id = ar.xpath('AR/PARENT_NETWORK_AR_ID')
                 parent_id = parent_id.text unless parent_id.nil?
 
-                next if parent_id.nil? || parent_id.empty?
+                next if !parent_id.nil? || !parent_id.empty?
 
                 vnet_usage[parent_id] = 0 if vnet_usage[parent_id].nil?
 


### PR DESCRIPTION
It’s seems additional quotas on not exist resourses is working from this condition:

fsck/quotas.rb

    475                 parent_id = ar.xpath('AR/PARENT_NETWORK_AR_ID')
    476                 parent_id = parent_id.text unless parent_id.nil?
    477 
    478                 next if parent_id.nil? || parent_id.empty?
    479 
    480                 vnet_usage[parent_id] = 0 if vnet_usage[parent_id].nil?
    481 
    482                 ar.xpath('AR/SIZE').each do |size|
    483                     vnet_usage[parent_id] += size.text.to_i
In this case if “PARENT_NETWORK_AR_ID” not exist we will be add VALUE to empty KEY, i.e. instead PARENT_NETWORK_AR_ID = [SIZE] we have __ = [SIZE].
May be will more logical if this will so:

 478                 next if !parent_id.nil? || !parent_id.empty?

If we meet empty or nil KEY PARENT_NETWORK_AR_ID, will missed it and won’t added additional quotas on not exist resources.