### PR TITLE
F #2451 Fix dummy vnm hoks

### DIFF
--- a/src/vnm_mad/remotes/dummy/clean
+++ b/src/vnm_mad/remotes/dummy/clean
@@ -19,5 +19,5 @@
 stdin="$(</dev/stdin)"
 
 for f in "$0".d/* ; do
-  [ -x "$f" ] || exit 0 && echo "$stdin" | ./"$f" "$@"  || exit 1
+  [ -x "$f" ] || exit 0 && echo "$stdin" | "$f" "$@"  || exit 1
 done

--- a/src/vnm_mad/remotes/dummy/post
+++ b/src/vnm_mad/remotes/dummy/post
@@ -19,5 +19,5 @@
 stdin="$(</dev/stdin)"
 
 for f in "$0".d/* ; do
-  [ -x "$f" ] || exit 0 && echo "$stdin" | ./"$f" "$@"  || exit 1
+  [ -x "$f" ] || exit 0 && echo "$stdin" | "$f" "$@"  || exit 1
 done

--- a/src/vnm_mad/remotes/dummy/pre
+++ b/src/vnm_mad/remotes/dummy/pre
@@ -19,5 +19,5 @@
 stdin="$(</dev/stdin)"
 
 for f in "$0".d/* ; do
-  [ -x "$f" ] || exit 0 && echo "$stdin" | ./"$f" "$@"  || exit 1
+  [ -x "$f" ] || exit 0 && echo "$stdin" | "$f" "$@"  || exit 1
 done


### PR DESCRIPTION
File path was being wrong on execution.
```
.//var/tmp/one/vnm/dummy/pre.d/01_ruby1: No such file or directory
```