### PR TITLE
Lxd snap update

### DIFF
--- a/src/vnm_mad/remotes/lib/nic.rb
+++ b/src/vnm_mad/remotes/lib/nic.rb
@@ -105,9 +105,9 @@ module VNMMAD
             def initialize
                 super(nil)
 
-                _o, _e, snap = run('snap list lxd;') # avoid cmd not found with;
+                _o, _e, snap = Open3.capture3('snap list lxd;') # avoid cmd not found with;
                 @lxc_cmd = 'lxc'
-                @lxc_cmd.prepend('sudo ') if snap.zero?
+                @lxc_cmd.prepend('sudo ') if snap.exitstatus.zero?
             end
 
             # Get the VM information with lxc config show
@@ -121,7 +121,7 @@ module VNMMAD
                 return if !deploy_id || !vm.vm_info[:dumpxml].nil?
 
                 cmd = "#{@lxc_cmd} config show #{deploy_id}"
-                config, _e, _s = run(cmd)
+                config, _e, _s = Open3.capture3(cmd)
 
                 vm.vm_info[:dumpxml] = YAML.safe_load(config)
 
@@ -162,12 +162,6 @@ module VNMMAD
                     return path unless tmp.nil?
                 end
                 nil
-            end
-
-            # Runs command with open3
-            def run(cmd)
-                stdout, stderr, process = Open3.capture3(cmd)
-                [stdout, stderr, process.exitstatus]
             end
 
         end

--- a/src/vnm_mad/remotes/lib/nic.rb
+++ b/src/vnm_mad/remotes/lib/nic.rb
@@ -38,12 +38,12 @@ module VNMMAD
 
         end
 
-        ############################################################################
+        ########################################################################
         # Hypervisor specific implementation of network interfaces. Each class
         # implements the following interface:
         #   - get_info to populste the VM.vm_info Hash
         #   - get_tap to set the [:tap] attribute with the associated NIC
-        ############################################################################
+        ########################################################################
 
         # A NIC using KVM. This class implements functions to get the physical
         # interface that the NIC is using, based on the MAC address
@@ -63,7 +63,7 @@ module VNMMAD
                     deploy_id = vm['DEPLOY_ID']
                 end
 
-                return unless deploy_id && vm.vm_info[:dumpxml].nil?
+                return if !deploy_id || !vm.vm_info[:dumpxml].nil?
 
                 virsh = (VNMNetwork::COMMANDS[:virsh]).to_s
                 cmd = "#{virsh} dumpxml #{deploy_id} 2>/dev/null"
@@ -76,7 +76,7 @@ module VNMMAD
             end
 
             # Look for the tap in
-            #   devices/interface[@type='bridge']/mac[@address='<mac>']/../target"
+            # devices/interface[@type='bridge']/mac[@address='<mac>']/../target"
             def get_tap(vm)
                 dumpxml = vm.vm_info[:dumpxml]
 
@@ -118,7 +118,7 @@ module VNMMAD
                     deploy_id = vm['DEPLOY_ID']
                 end
 
-                return unless deploy_id && vm.vm_info[:dumpxml].nil?
+                return if !deploy_id || !vm.vm_info[:dumpxml].nil?
 
                 cmd = "#{@lxc_cmd} config show #{deploy_id}"
                 config, _e, _s = run(cmd)


### PR DESCRIPTION
Updated the LXD snap-based setup detection mechanism on the network drivers.It seems `snapd` got updated and error output changed to

```
oneadmin@ubuntu1810-lxd-qcow2-0f30a-1:~$ lxc list
Sorry, home directories outside of /home are not currently supported. 
See https://forum.snapcraft.io/t/11209 for details.
```

Code doesn't require that output to be checked now

- Applies to master as well
- Closes #3596 
