### PR TITLE
F #3613: Fixed vlan driver on el8 systems

### DIFF
--- a/src/vnm_mad/remotes/lib/vlan.rb
+++ b/src/vnm_mad/remotes/lib/vlan.rb
@@ -192,7 +192,7 @@ module VNMMAD
                 ip_show_master.split("\n").each do |l|
                     next if l !~ /^[0-9]*:/
 
-                    bridges[br_name] << l.split(': ')[1]
+                    bridges[br_name] << l.scan(/^\d+:\s([^:@]+)/)[0][0]
                 end
             end
 


### PR DESCRIPTION
Command `ip link show master br_name` list attached vlan devices with @master_dev on el8 systems. For example `team0.404@team0`. This commit fixes parsing bridges and attached devices.

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>