### PR TITLE
B #3559: Fix LXD market apps VM_Template

### DIFF
--- a/src/market_mad/remotes/linuxcontainers/monitor
+++ b/src/market_mad/remotes/linuxcontainers/monitor
@@ -42,11 +42,12 @@ class LinuxContainersMarket
         :skip_untested => 'yes'
     }
 
+    # TODO: Make configurable
     TEMPLATE = "
 HYPERVISOR = \"lxd\"
 CPU = \"1\"
 MEMORY = \"768\"
-LXD_SECURITY_PRIVILEGED = \"true\"
+LXD_SECURITY_PRIVILEGED = \"yes\"
 GRAPHICS = [
     LISTEN  =\"0.0.0.0\",
     TYPE  =\"vnc\"


### PR DESCRIPTION
"Original" values for the `security.privileged` container configuration key were `true/false`, so had the monitor script followed. However, the template wizard looks for [yes/no](https://github.com/OpenNebula/one/blob/424028d19c0607445be484e0f32e8cf3c0f2f25a/src/sunstone/public/app/tabs/templates-tab/form-panels/create/wizard-tabs/general/html.hbs#L121-L122) and these two parts of opennebula not with the same value led to #3559.

- Applies to one-5.8 and master
- Fixes #3559

- Added a possible feature as TODO