### PR TITLE
F #3668 B #3663 Generalize contextualization process

### DIFF
--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -149,23 +149,35 @@ esac
 
 mkdir $TMP_DIR/$id
 
-# Generate installation scripts for each Linux distribution
-#-------------------------------------------------------------------------------
+# Generate contextualization procedure per supported platform.
+# The Goal is to install the required context package for each distro
+#--------------------------------------------------------------------
+# Overview:
+# 1- Setup name resolution
+# 2- Setup randomness
+# 3- Download and install context package
+#--------------------------------------------------------------------
+
 case "$rootfs_url" in
 *ubuntu*|*debian*|*devuan*)
     terminal="/bin/bash"
     commands=$(cat <<EOC
 export PATH=\$PATH:/bin:/sbin
 
-rm -f /etc/resolv.conf > /dev/null 2>&1
+rm -f /etc/resolv.conf >> /var/log/chroot.log 2>&1
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-apt-get update > /dev/null
-apt-get install $PKG_DEB -y > /dev/null 2>&1
+mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
-$CURL $CONTEXT_URL/v$selected_tag/one-context_$selected_tag-1.deb -Lsfo /root/context.deb
-apt-get install /root/context.deb -y > /dev/null 2>&1
+apt-get update >> /var/log/chroot.log 2>&1
+apt-get install $PKG_DEB -y >> /var/log/chroot.log 2>&1
+
+$CURL $CONTEXT_URL/v$selected_tag/one-context_$selected_tag-1.deb -Lsfo /root/context.deb >> /var/log/chroot.log 2>&1
+apt-get install -y /root/context.deb >> /var/log/chroot.log 2>&1
 rm /root/context.deb
+
+rm /dev/random /dev/urandom
 EOC
 )
     ;;
@@ -176,11 +188,16 @@ export PATH=\$PATH:/bin:/sbin
 
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-yum install $PKG_CENTOS6 -y > /dev/null 2>&1
+mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
-$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el6.noarch.rpm -Lsfo /root/context.rpm
-yum install /root/context.rpm -y > /dev/null 2>&1
+yum install $PKG_CENTOS6 -y  >> /var/log/chroot.log 2>&1
+
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el6.noarch.rpm -Lsfo /root/context.rpm  >> /var/log/chroot.log 2>&1
+yum install /root/context.rpm -y  >> /var/log/chroot.log 2>&1
 rm /root/context.rpm
+
+rm /dev/random /dev/urandom
 EOC
 )
     ;;
@@ -189,15 +206,13 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-## New yum version requires random bits to initialize GnuTLS, but chroot
-## prevents access to /dev/urandom (as desgined).
-mknod -m 666 /dev/random c 1 8
-mknod -m 666 /dev/urandom c 1 9
+mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
-yum install $PKG_RPM -y > /dev/null 2>&1
+yum install $PKG_RPM -y >> /var/log/chroot.log 2>&1
 
-$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
-yum install /root/context.rpm -y > /dev/null 2>&1
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm >> /var/log/chroot.log 2>&1
+yum install /root/context.rpm -y >> /var/log/chroot.log 2>&1
 rm /root/context.rpm
 
 rm /dev/random /dev/urandom
@@ -209,11 +224,16 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-yum install $PKG_RPM -y > /dev/null 2>&1
+mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
-$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
-yum install /root/context.rpm -y > /dev/null 2>&1
+yum install $PKG_RPM -y >> /var/log/chroot.log 2>&1
+
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm >> /var/log/chroot.log 2>&1
+yum install /root/context.rpm -y >> /var/log/chroot.log 2>&1
 rm /root/context.rpm
+
+rm /dev/random /dev/urandom
 EOC
 )
     ;;
@@ -223,15 +243,13 @@ EOC
 rm /etc/resolv.conf
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-## New yum version requires random bits to initialize GnuTLS, but chroot
-## prevents access to /dev/urandom (as desgined).
 mknod -m 666 /dev/random c 1 8
 mknod -m 666 /dev/urandom c 1 9
 
-yum install $PKG_FEDORA -y > /dev/null 2>&1
+yum install $PKG_FEDORA -y >> /var/log/chroot.log 2>&1
 
-$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm
-yum install /root/context.rpm -y > /dev/null 2>&1
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-1.el7.noarch.rpm -Lsfo /root/context.rpm >> /var/log/chroot.log 2>&1
+yum install /root/context.rpm -y >> /var/log/chroot.log 2>&1
 rm /root/context.rpm
 
 rm /dev/random /dev/urandom
@@ -243,13 +261,18 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-apk add $PKG_APK > /dev/null 2>&1
+mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
-rc-update add sshd > /dev/null 2>&1
+apk add $PKG_APK >> /var/log/chroot.log 2>&1
 
-$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-r1.apk -Lsfo /root/context.apk
-apk add --allow-untrusted /root/context.apk > /dev/null 2>&1
+rc-update add sshd >> /var/log/chroot.log 2>&1
+
+$CURL $CONTEXT_URL/v$selected_tag/one-context-$selected_tag-r1.apk -Lsfo /root/context.apk >> /var/log/chroot.log 2>&1
+apk add --allow-untrusted /root/context.apk >> /var/log/chroot.log 2>&1
 rm /root/context.apk
+
+rm /dev/random /dev/urandom
 EOC
 )
     ;;

--- a/src/datastore_mad/remotes/lxd_downloader.sh
+++ b/src/datastore_mad/remotes/lxd_downloader.sh
@@ -167,8 +167,8 @@ export PATH=\$PATH:/bin:/sbin
 rm -f /etc/resolv.conf >> /var/log/chroot.log 2>&1
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
-mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/random ] && mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/urandom ] && mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
 apt-get update >> /var/log/chroot.log 2>&1
 apt-get install $PKG_DEB -y >> /var/log/chroot.log 2>&1
@@ -188,8 +188,8 @@ export PATH=\$PATH:/bin:/sbin
 
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
-mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/random ] && mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/urandom ] && mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
 yum install $PKG_CENTOS6 -y  >> /var/log/chroot.log 2>&1
 
@@ -206,8 +206,8 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
-mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/random ] && mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/urandom ] && mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
 yum install $PKG_RPM -y >> /var/log/chroot.log 2>&1
 
@@ -224,8 +224,8 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
-mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/random ] && mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/urandom ] && mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
 yum install $PKG_RPM -y >> /var/log/chroot.log 2>&1
 
@@ -243,8 +243,8 @@ EOC
 rm /etc/resolv.conf
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-mknod -m 666 /dev/random c 1 8
-mknod -m 666 /dev/urandom c 1 9
+[ ! -e /dev/random ] && mknod -m 666 /dev/random c 1 8
+[ ! -e /dev/urandom ] && mknod -m 666 /dev/urandom c 1 9
 
 yum install $PKG_FEDORA -y >> /var/log/chroot.log 2>&1
 
@@ -261,8 +261,8 @@ EOC
     commands=$(cat <<EOC
 echo "nameserver $DNS_SERVER" > /etc/resolv.conf
 
-mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
-mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/random ] && mknod -m 666 /dev/random c 1 8  >> /var/log/chroot.log 2>&1
+[ ! -e /dev/urandom ] && mknod -m 666 /dev/urandom c 1 9  >> /var/log/chroot.log 2>&1
 
 apk add $PKG_APK >> /var/log/chroot.log 2>&1
 


### PR DESCRIPTION
- Every app now follows the same procedure
https://github.com/OpenNebula/one/blob/b21d77484e164f7fecfc0e1550f667699cf3c8a4/src/datastore_mad/remotes/lxd_downloader.sh#L155-L159
- Critical operations during the auto-contextualization process are logged now into `/var/log/chroot.log` in the app file-system. 

- Applies to master and one-5.8
- Fixes #3663 
- Closes #3668
- [Docu PR](https://github.com/OpenNebula/docs/pull/743)