### PR TITLE
F #3738: Secure cookie flag if scheme is https

### DIFF
--- a/src/sunstone/sunstone-server.rb
+++ b/src/sunstone/sunstone-server.rb
@@ -411,6 +411,12 @@ helpers do
 
         # end user options
 
+        # secure cookies
+        if request.scheme == 'https'
+            env['rack.session.options'][:secure] = true
+        end
+        # end secure cookies
+
         if params[:remember] == 'true'
             env['rack.session.options'][:expire_after] = 30*60*60*24-1
         end
@@ -522,6 +528,11 @@ end
 
 after do
     unless request.path=='/login' || request.path=='/' || request.path=='/'
+        # secure cookies
+        if request.scheme == 'https'
+            env['rack.session.options'][:secure] = true
+        end
+        # end secure cookies
         unless session[:remember] == "true"
             if params[:timeout] == "true"
                 env['rack.session.options'][:defer] = true


### PR DESCRIPTION
Build in functionality so Sunstone marks cookies set as Secure to ensure only secure servers can access the session cookie.

I've also made [a PR to OpenNebula/docs](https://github.com/OpenNebula/docs/pull/771) to document this change.

PS: It'd be nice to have a ISSUE_TEMPLATE so I know what GitCop expects so I don't make this mistake of writing PRs this way.