### PR TITLE
M #-: fix bug in onedb purge done

### DIFF
--- a/src/onedb/onedb_live.rb
+++ b/src/onedb/onedb_live.rb
@@ -210,7 +210,7 @@ class OneDBLive
         ops         = { :start_time => 0,
                         :end_time   => Time.now,
                         :pages      => PAGES }.merge(options)
-        vmpool      = OpenNebula::VirtualMachinePool.new(client)
+        vmpool      = OpenNebula::VirtualMachinePool.new(client, Pool::INFO_ALL)
         start_time  = ops[:start_time].to_i
         end_time    = ops[:end_time].to_i
         done        = OpenNebula::VirtualMachine::VM_STATE.index('DONE')


### PR DESCRIPTION
    Fix bug when there are no consecutive VMs, so the get_page
    function didn't return the pool.