### PR TITLE
F #3440: Improve NSX import process

### DIFF
--- a/share/hooks/vcenter/create_vcenter_net.rb
+++ b/share/hooks/vcenter/create_vcenter_net.rb
@@ -159,11 +159,14 @@ begin
                 <guestVlanAllowed>false</guestVlanAllowed>\
             </virtualWireCreateSpec>"
         logical_switch = NSXDriver::VirtualWire
-                          .new(nsx_client, nil, tz_id, virtual_wire_spec)
+                         .new(nsx_client, nil, tz_id, virtual_wire_spec)
         # Get reference will have in vcenter and vni
         vnet_ref = logical_switch.ls_vcenter_ref
         ls_vni   = logical_switch.ls_vni
-        net_info = "NSX_ID=\"#{logical_switch.ls_id}\"\nNSX_VNI=\"#{ls_vni}\"\n"
+        ls_name = logical_switch.ls_name
+        net_info = "NSX_ID=\"#{logical_switch.ls_id}\"\n"
+        net_info << "NSX_VNI=\"#{ls_vni}\"\n"
+        net_info << "BRIDGE=\"#{ls_name}\"\n"
     end
 
     if pg_type == VCenterDriver::Network::NETWORK_TYPE_NSXT
@@ -178,12 +181,14 @@ begin
             }
         )
         logical_switch = NSXDriver::OpaqueNetwork
-                          .new(nsx_client, nil, nil, opaque_network_spec)
+                         .new(nsx_client, nil, nil, opaque_network_spec)
         # Get NSX_VNI
         vnet_ref = dc.nsx_network(logical_switch.ls_id, pg_type)
         ls_vni = logical_switch.ls_vni
-        net_info << "NSX_ID=\"#{logical_switch.ls_id}\"\n"
+        ls_name = logical_switch.ls_name
+        net_info = "NSX_ID=\"#{logical_switch.ls_id}\"\n"
         net_info << "NSX_VNI=\"#{ls_vni}\"\n"
+        net_info << "BRIDGE=\"#{ls_name}\"\n"
     end
 
     # With DVS we have to work at datacenter level and then for each host

--- a/src/vmm_mad/remotes/lib/nsx_driver/virtual_wire.rb
+++ b/src/vmm_mad/remotes/lib/nsx_driver/virtual_wire.rb
@@ -25,6 +25,7 @@ module NSXDriver
         BACKING_XPATH = '//virtualWire/vdsContextWithBacking/backingValue'
         OBJECTID_XPATH = '//virtualWire/vdsContextWithBacking/switch/objectId'
         TZ_XPATH = '//virtualWire/vdnScopeId'
+        VW_XPATH = '//virtualWire'
         SECTION_LS = '/vdn/virtualwires/'
         SECTION_TZ = '/vdn/scopes/'
 
@@ -53,6 +54,17 @@ module NSXDriver
             end
         end
 
+        # Creates a NSXDriver::VirtualWire from its name
+        def self.new_from_name(nsx_client, ls_name)
+            virtualwire = new(nsx_client)
+            ls_id = virtualwire.ls_id_from_name(nsx_client, ls_name)
+            raise "VirtualWire with name: #{ls_name} not found" unless ls_id
+
+            # initialize_with_id(@ls_id)
+            virtualwire.initialize_with_id(ls_id)
+            virtualwire
+        end
+
         # Creates a NSXDriver::VirtualWire from its id
         def initialize_with_id(ls_id)
             @ls_id = ls_id
@@ -66,6 +78,26 @@ module NSXDriver
                 @guest_vlan_allowed = false
             end
             raise "VirtualWire with id: #{ls_id} not found" unless ls?
+        end
+
+        # Get the logical switch id from its name
+        def ls_id_from_name(nsx_client, name)
+            url = @base_url + SECTION_LS
+            virtualwires = nsx_client.get_xml(url).xpath(VW_XPATH)
+            virtualwires.each do |virtualwire|
+                # name = "vxw-dvs-48-virtualwire-14-sid-5009-testLS-TZ2"
+                lsname_arr = name.split(/-sid-/)
+                # lsname_arr = ["vxw-dvs-48-virtualwire-14", "5009-testLS-TZ2"]
+                lsname = lsname_arr[-1].split('-', 2)[-1]
+                # lsname = testLS-TZ2
+                lsid = lsname_arr[0].split(/vxw-dvs-\w.-/)[-1]
+                # lsid = virtualwire-14
+                if virtualwire.xpath('name').text == lsname
+                    return virtualwire.xpath('objectId').text \
+                            if virtualwire.xpath('objectId').text == lsid
+                end
+            end
+            nil
         end
 
         # METHODS

--- a/src/vmm_mad/remotes/lib/nsx_driver/virtual_wire.rb
+++ b/src/vmm_mad/remotes/lib/nsx_driver/virtual_wire.rb
@@ -85,13 +85,9 @@ module NSXDriver
             url = @base_url + SECTION_LS
             virtualwires = nsx_client.get_xml(url).xpath(VW_XPATH)
             virtualwires.each do |virtualwire|
-                # name = "vxw-dvs-48-virtualwire-14-sid-5009-testLS-TZ2"
                 lsname_arr = name.split(/-sid-/)
-                # lsname_arr = ["vxw-dvs-48-virtualwire-14", "5009-testLS-TZ2"]
                 lsname = lsname_arr[-1].split('-', 2)[-1]
-                # lsname = testLS-TZ2
                 lsid = lsname_arr[0].split(/vxw-dvs-\w.-/)[-1]
-                # lsid = virtualwire-14
                 if virtualwire.xpath('name').text == lsname
                     return virtualwire.xpath('objectId').text \
                             if virtualwire.xpath('objectId').text == lsid

--- a/src/vmm_mad/remotes/lib/vcenter_driver/datacenter.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/datacenter.rb
@@ -376,7 +376,12 @@ class DatacenterFolder
             networks[r.obj._ref] = r.to_hash if r.obj.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) || r.obj.is_a?(RbVmomi::VIM::Network) || r.obj.is_a?(RbVmomi::VIM::OpaqueNetwork)
 
             if r.obj.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup)
-                networks[r.obj._ref][:network_type] = VCenterDriver::Network::NETWORK_TYPE_DPG
+                # Here can be NETWORK_TYPE_DPG or NETWORK_TYPE_NSXV
+                if r['name'].match(/^vxw-dvs-(.*)-virtualwire-(.*)-sid-(.*)/)
+                    networks[r.obj._ref][:network_type] = VCenterDriver::Network::NETWORK_TYPE_NSXV
+                else
+                    networks[r.obj._ref][:network_type] = VCenterDriver::Network::NETWORK_TYPE_DPG
+                end
             elsif r.obj.is_a?(RbVmomi::VIM::OpaqueNetwork)
                 networks[r.obj._ref][:network_type] = VCenterDriver::Network::NETWORK_TYPE_NSXT
             elsif r.obj.is_a?(RbVmomi::VIM::Network)

--- a/src/vmm_mad/remotes/lib/vcenter_driver/network.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/network.rb
@@ -414,6 +414,27 @@ class NetImporter < VCenterDriver::VcImporter
         net = VCenterDriver::Network.new_from_ref(selected[:ref], @vi_client)
         vid = VCenterDriver::Network.retrieve_vlanid(net.item) if net
 
+        # If type is NSX we need to update values
+        if selected[:type] == VCenterDriver::Network::NETWORK_TYPE_NSXV
+            host_id = @vi_client.instance_variable_get '@host_id'
+            nsx_client = NSXDriver::NSXClient.new_from_id(host_id)
+            nsx_net = NSXDriver::VirtualWire
+                      .new_from_name(nsx_client, selected[:name])
+            selected[:one] << "NSX_ID=\"#{nsx_net.ls_id}\"\n"
+            selected[:one] << "NSX_VNI=\"#{nsx_net.ls_vni}\"\n"
+            selected[:one] << "NSX_TZ_ID=\"#{nsx_net.tz_id}\"\n"
+        end
+
+        if selected[:type] == VCenterDriver::Network::NETWORK_TYPE_NSXT
+            host_id = @vi_client.instance_variable_get '@host_id'
+            nsx_client = NSXDriver::NSXClient.new_from_id(host_id)
+            nsx_net = NSXDriver::OpaqueNetwork
+                      .new_from_name(nsx_client, selected[:name])
+            selected[:one] << "NSX_ID=\"#{nsx_net.ls_id}\"\n"
+            selected[:one] << "NSX_VNI=\"#{nsx_net.ls_vni}\"\n"
+            selected[:one] << "NSX_TZ_ID=\"#{nsx_net.tz_id}\"\n"
+        end
+
         if vid
             vlanid = VCenterDriver::Network.vlanid(vid)
 


### PR DESCRIPTION
    These attributes are added when importing a NSX network
    NSX_ID
    NSX_VNI
    NSX_TZ_ID
    
    Also now there is a different VCENTER_PORTGROUP_TYPE for
    distributed port groups and NSX-V portgroups
