### PR TITLE
F #2799: install_gems warns if gems are packaged

### DIFF
--- a/share/install_gems/install_gems
+++ b/share/install_gems/install_gems
@@ -438,6 +438,24 @@ def install_bundler_gem
 end
 
 def install_gems(packages, bundler = false)
+    gems_location = '/usr/share/one/gems'
+    if File.directory?(gems_location)
+        STDERR.puts(<<-EOT.unindent(12))
+            WARNING: Running install_gems is not necessary anymore, as all the
+            required dependencies are already installed by your packaging
+            system into symlinked location #{gems_location}. Ruby gems
+            installed by this script won't be used until this symlink exists.
+            Remove the symlink before starting the OpenNebula services
+            to use Ruby gems installed by this script. E.g. execute
+
+                # unlink #{gems_location}
+
+            Execution continues in 15 seconds ...
+EOT
+
+        sleep(15)
+    end
+
     if bundler
         gems_list=which_gems(packages)
     else


### PR DESCRIPTION
A warning added if `install_gems` are executed on a machine where packaged Ruby gems are installed and will be used no matter if install_gems is run or not. E.g.,

```
# /usr/share/one/install_gems
WARNING: Running install_gems is not necessary anymore, as all the
required dependencies are already installed by your packaging
system into symlinked location /usr/share/one/gems. Ruby gems
installed by this script won't be used until this symlink exists.
Remove the symlink before starting the OpenNebula services
to use Ruby gems installed by this script. E.g. execute

    # unlink /usr/share/one/gems

Execution continues in 15 seconds ...
```