### PR TITLE
F #4556: Added option to conf VM logs location

### DIFF
--- a/share/etc/oned.conf
+++ b/share/etc/oned.conf
@@ -59,12 +59,14 @@
 #      syslog    to use the syslog facilities
 #      std       to use the default log stream (stderr) to use with systemd
 #   debug_level: 0 = ERROR, 1 = WARNING, 2 = INFO, 3 = DEBUG
+#   use_vms_location: defines if store VM logs in VMS_LOCATION
 #
 #*******************************************************************************
 
 LOG = [
   SYSTEM      = "file",
-  DEBUG_LEVEL = 3
+  DEBUG_LEVEL = 3,
+  USE_VMS_LOCATION = "NO"
 ]
 
 #MANAGER_TIMER = 15

--- a/src/nebula/Nebula.cc
+++ b/src/nebula/Nebula.cc
@@ -1290,8 +1290,16 @@ void Nebula::get_ds_location(string& dsloc)
 string Nebula::get_vm_log_filename(int oid)
 {
     ostringstream oss;
+    bool use_vms_location;
 
-    if (nebula_location == "/")
+    const VectorAttribute * log = nebula_configuration->get("LOG");
+
+    if ( log != 0 )
+    {
+        log->vector_value("USE_VMS_LOCATION", use_vms_location);
+    }
+
+    if (nebula_location == "/" && ! use_vms_location)
     {
         oss << log_location << oid << ".log";
     }

--- a/src/sunstone/models/SunstoneServer.rb
+++ b/src/sunstone/models/SunstoneServer.rb
@@ -266,10 +266,12 @@ class SunstoneServer < CloudServer
         if OpenNebula.is_error?(resource)
             return [404, nil]
         else
-            if !ONE_LOCATION
+            use_vms_location = $conf[:locals][:oned_conf]["LOG"]["USE_VMS_LOCATION"]
+
+            if !ONE_LOCATION && use_vms_location != "YES"
                 vm_log_file = LOG_LOCATION + "/#{id}.log"
             else
-                vm_log_file = LOG_LOCATION + "/vms/#{id}/vm.log"
+                vm_log_file = VMS_LOCATION + "/#{id}/vm.log"
             end
 
             begin

--- a/src/sunstone/sunstone-server.rb
+++ b/src/sunstone/sunstone-server.rb
@@ -37,6 +37,8 @@ else
     SUNSTONE_LOCATION = ONE_LOCATION + '/lib/sunstone'
 end
 
+VMS_LOCATION = VAR_LOCATION + "/vms"
+
 SUNSTONE_AUTH             = VAR_LOCATION + '/.one/sunstone_auth'
 SUNSTONE_LOG              = LOG_LOCATION + '/sunstone.log'
 CONFIGURATION_FILE        = ETC_LOCATION + '/sunstone-server.conf'
@@ -78,7 +80,8 @@ ONED_CONF_OPTS = {
         'MARKET_MAD_CONF',
         'VM_MAD',
         'IM_MAD',
-        'AUTH_MAD'
+        'AUTH_MAD',
+        'LOG'
     ],
     # Generate an array if there is only 1 element
     'ARRAY_KEYS' => [


### PR DESCRIPTION
This is usefull in HA Raft setup to easily share VM logs between HA nodes

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>