### PR TITLE
B #3873: fix race in vmm/kvm/detach_nic

### DIFF
--- a/src/vmm_mad/remotes/kvm/detach_nic
+++ b/src/vmm_mad/remotes/kvm/detach_nic
@@ -22,14 +22,23 @@ source $(dirname $0)/../../scripts_common.sh
 DOMAIN=$1
 MAC=$2
 
+function is_attached()
+{
+    virsh --connect $LIBVIRT_URI domiflist $DOMAIN | grep $MAC > /dev/null 2>&1
+}
+
+function detach_nic {
+    exec_and_log "virsh --connect $LIBVIRT_URI detach-interface $DETACH_ARGS" \
+        "Could not detach NIC ($MAC) from $DOMAIN"
+}
+
+if ! is_attached; then
+    exit 0
+fi
+
 DETACH_ARGS="--domain $DOMAIN --type bridge --mac $MAC"
 
-exec_and_log "virsh --connect $LIBVIRT_URI detach-interface $DETACH_ARGS" \
-    "Could not detach NIC ($MAC) from $DOMAIN"
+retry ${VIRSH_RETRIES:-3} detach_nic
 
-virsh --connect $LIBVIRT_URI domiflist $DOMAIN | grep $MAC > /dev/null 2>&1
-
-if [ $? -eq 0 ] ; then
-    error_message "Could not detach NIC ($MAC) from $DOMAIN"
-    exit -1
-fi
+error_message "Could not detach NIC ($MAC) from $DOMAIN"
+exit 1

--- a/src/vmm_mad/remotes/kvm/kvmrc
+++ b/src/vmm_mad/remotes/kvm/kvmrc
@@ -29,6 +29,10 @@ export SHUTDOWN_TIMEOUT=300
 # Uncomment this line to force VM cancellation after shutdown timeout
 #export FORCE_DESTROY=yes
 
+# Default number of "virsh" command retries when required
+# currently used in detach-interface, restore
+export VIRSH_RETRIES=3
+
 # Uncomment this line to force VM's without ACPI enabled to be destroyed
 # on shutdown
 #CANCEL_NO_ACPI=yes

--- a/src/vmm_mad/remotes/kvm/restore
+++ b/src/vmm_mad/remotes/kvm/restore
@@ -86,7 +86,7 @@ function restore_domain {
         "Could not restore from $FILE"
 }
 
-retry 3 restore_domain
+retry ${VIRSH_RETRIES:-3} restore_domain
 
 if [ $? -ne 0 ]; then
     exit 1


### PR DESCRIPTION
* return success if the MAC is not found
* retry few times before reporint detach failure
* option to define the number of retries (default is 3)

Signed-off-by: Anton Todorov <a.todorov@storpool.com>