### PR TITLE
M #-: Change Spice module from Freedesktop to GH

### DIFF
--- a/src/sunstone/public/bower.json
+++ b/src/sunstone/public/bower.json
@@ -7,7 +7,7 @@
     "flot.tooltip": "0.8.4",
     "no-vnc": "https://github.com/novnc/noVNC.git#9fe2fd04d4",
     "resumablejs": "https://github.com/23/resumable.js.git#420cd351c5",
-    "spice-html5": "https://gitlab.freedesktop.org/spice/spice-html5.git#spice-html5-0.1.6",
+    "spice-html5": "https://github.com/freedesktop/spice-html5.git#spice-html5-0.1.6",
     "require-handlebars-plugin": "0.11.2",
     "almond": "0.3.1",
     "vis": "4.12.0",


### PR DESCRIPTION
Domain of the freedesktop.org has expired, so the build was failing due to unavailability of their GitLab server. Proposed change switches to their mirror located on GitHub.

![image](https://user-images.githubusercontent.com/414850/68108606-7dec0b80-fee8-11e9-8df9-254de428c4ed.png)

