### PR TITLE
M #-: Bump version in Ansible openenbula-repository

### DIFF
--- a/share/oneprovision/ansible/roles/opennebula-repository/defaults/main.yml
+++ b/share/oneprovision/ansible/roles/opennebula-repository/defaults/main.yml
@@ -5,7 +5,7 @@
 ###############################################################################
 
 # OpenNebula repository version
-opennebula_repository_version: '5.8'
+opennebula_repository_version: '5.10'
 
 # Repository of the OpenNebula packages
 opennebula_repository_base: 'https://downloads.opennebula.org/repo/{{ opennebula_repository_version }}'


### PR DESCRIPTION
Provision deployment will now fail until 5.10 is released.