### PR TITLE
B #-: Fix fail access to fileName on empty CDs

### DIFF
--- a/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
@@ -1695,7 +1695,7 @@ module VCenterDriver
             vm.config.hardware.device.each do |disk|
                 if is_disk_or_cdrom?(disk)
                     # Let's try to find if disks is persistent
-                    source_unescaped = disk.backing.fileName.sub(/^\[(.*?)\] /, "")
+                    source_unescaped = disk.backing.fileName.sub(/^\[(.*?)\] /, "") rescue next
                     source = VCenterDriver::FileHelper.escape_path(source_unescaped)
 
                     persistent = VCenterDriver::VIHelper.find_persistent_image_by_source(source, ipool)


### PR DESCRIPTION
When a template or VM has a CDrom unit without file attached,
an error was raised trying to access to fileName attribute
because that attribute doesn't exist.