### PR TITLE
B #3972: normalize the list of cpus

### DIFF
--- a/src/im_mad/remotes/node-probes.d/numa.rb
+++ b/src/im_mad/remotes/node-probes.d/numa.rb
@@ -109,6 +109,21 @@ def huge_pages(nodes, node_id)
     end
 end
 
+def normalize_list(list_format)
+    list = []
+    list_format.split(',').each do |range|
+        arr = range.split('-')
+        if arr.length > 1
+            for entry in arr[0]..arr[1] do
+                list << entry
+            end
+        else
+            list.concat(arr)
+        end
+    end
+    list
+end
+
 # ------------------------------------------------------------------------------
 # CPU topology
 # ------------------------------------------------------------------------------
@@ -134,7 +149,7 @@ def cpu_topology(nodes, node_id)
             core_path = "#{cpu_path}/#{cp}/topology"
 
             siblings = File.read("#{core_path}/thread_siblings_list").chomp
-            siblings = siblings.split(',')
+            siblings = normalize_list(siblings)
 
             cpu_visited.concat(siblings)
 


### PR DESCRIPTION
following the description in CPUSET(7) man page:

 List format
     The List Format for cpus and mems is a comma-separated list of CPU or
     memory-node numbers and ranges of numbers, in ASCII decimal.

     Examples of the List Format:

         0-4,9           # bits 0, 1, 2, 3, 4, and 9 set
         0-2,7,12-14     # bits 0, 1, 2, 7, 12, 13, and 14 set

Signed-off-by: Anton Todorov <a.todorov@storpool.com>