### PR TITLE
B #4076 Keep xs:integer type for acl

### DIFF
--- a/share/doc/xsd/acl_pool.xsd
+++ b/share/doc/xsd/acl_pool.xsd
@@ -8,10 +8,10 @@
           <xs:complexType>
             <xs:sequence>
               <xs:element name="ID" type="xs:integer"/>
-              <xs:element name="USER" type="xs:hexBinary"/>
-              <xs:element name="RESOURCE" type="xs:hexBinary"/>
-              <xs:element name="RIGHTS" type="xs:hexBinary"/>
-              <xs:element name="ZONE" type="xs:hexBinary"/>
+              <xs:element name="USER" type="xs:integer"/>
+              <xs:element name="RESOURCE" type="xs:integer"/>
+              <xs:element name="RIGHTS" type="xs:integer"/>
+              <xs:element name="ZONE" type="xs:integer"/>
               <xs:element name="STRING" type="xs:string"/>
             </xs:sequence>
           </xs:complexType>


### PR DESCRIPTION
Although the format is hexadecimal, ONE produces
values where length is not even (without adding
leading zero). This violates xs:hexBinary type.