### PR TITLE
B #4087: Allows attach IDE disks

### DIFF
--- a/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
@@ -1971,8 +1971,14 @@ module VCenterDriver
 
             else
                 # TYPE is regular disk (not CDROM)
-                controller, unit_number = find_free_controller(position)
-
+                # disk_adapter
+                disk_adapter = disk['VCENTER_ADAPTER_TYPE']
+                case disk_adapter
+                when 'ide'
+                    controller, unit_number = find_free_ide_controller(position)
+                else
+                    controller, unit_number = find_free_controller(position)
+                end
                 storpod = disk["VCENTER_DS_REF"].start_with?('group-')
                 if storpod
                     vmdk_backing = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(


### PR DESCRIPTION
This allows attach IDE disk to VMS when the VM is
into powered off state.
The disk will have DEV_PREFIX="sd" by default, if you want
to have a DEV_PREVIX="hd" you need to change before into the
image template.