### PR TITLE
B #4076: Use xs:string for ACLs

### DIFF
--- a/share/doc/xsd/acl_pool.xsd
+++ b/share/doc/xsd/acl_pool.xsd
@@ -8,10 +8,10 @@
           <xs:complexType>
             <xs:sequence>
               <xs:element name="ID" type="xs:integer"/>
-              <xs:element name="USER" type="xs:integer"/>
-              <xs:element name="RESOURCE" type="xs:integer"/>
-              <xs:element name="RIGHTS" type="xs:integer"/>
-              <xs:element name="ZONE" type="xs:integer"/>
+              <xs:element name="USER" type="xs:string"/>
+              <xs:element name="RESOURCE" type="xs:string"/>
+              <xs:element name="RIGHTS" type="xs:string"/>
+              <xs:element name="ZONE" type="xs:string"/>
               <xs:element name="STRING" type="xs:string"/>
             </xs:sequence>
           </xs:complexType>


### PR DESCRIPTION
hexBinary fails due to non-even length
integer fails obviously when containig a-f chars