### PR TITLE
[GOCA] permissions changes (breaking)

### DIFF
--- a/src/oca/go/src/goca/datastore.go
+++ b/src/oca/go/src/goca/datastore.go
@@ -128,8 +128,9 @@ func (dc *DatastoreController) Update(tpl string, uType parameters.UpdateType) e
 }
 
 // Chmod changes the permission bits of a datastore.
-func (dc *DatastoreController) Chmod(perm shared.Permissions) error {
-	_, err := dc.c.Client.Call("one.datastore.chmod", perm.ToArgs(dc.ID)...)
+func (dc *DatastoreController) Chmod(perm *shared.Permissions) error {
+	args := append([]interface{}{dc.ID}, perm.ToArgs()...)
+	_, err := dc.c.Client.Call("one.datastore.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/datastore.go
+++ b/src/oca/go/src/goca/datastore.go
@@ -128,7 +128,7 @@ func (dc *DatastoreController) Update(tpl string, uType parameters.UpdateType) e
 }
 
 // Chmod changes the permission bits of a datastore.
-func (dc *DatastoreController) Chmod(perm *shared.Permissions) error {
+func (dc *DatastoreController) Chmod(perm shared.Permissions) error {
 	_, err := dc.c.Client.Call("one.datastore.chmod", perm.ToArgs(dc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/document.go
+++ b/src/oca/go/src/goca/document.go
@@ -143,7 +143,7 @@ func (dc *DocumentController) Update(tpl string, uType parameters.UpdateType) er
 }
 
 // Chmod changes the permission bits of a document.
-func (dc *DocumentController) Chmod(perm *shared.Permissions) error {
+func (dc *DocumentController) Chmod(perm shared.Permissions) error {
 	_, err := dc.c.Client.Call("one.document.chmod", perm.ToArgs(dc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/document.go
+++ b/src/oca/go/src/goca/document.go
@@ -144,7 +144,8 @@ func (dc *DocumentController) Update(tpl string, uType parameters.UpdateType) er
 
 // Chmod changes the permission bits of a document.
 func (dc *DocumentController) Chmod(perm shared.Permissions) error {
-	_, err := dc.c.Client.Call("one.document.chmod", perm.ToArgs(dc.ID)...)
+	args := append([]interface{}{dc.ID}, perm.ToArgs()...)
+	_, err := dc.c.Client.Call("one.document.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -157,7 +157,7 @@ func (ic *ImageController) Chown(uid, gid int) error {
 
 // Chmod changes the permissions of the image. If any perm is -1 it will not
 // change
-func (ic *ImageController) Chmod(perm *shared.Permissions) error {
+func (ic *ImageController) Chmod(perm shared.Permissions) error {
 	_, err := ic.c.Client.Call("one.image.chmod", perm.ToArgs(ic.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -158,7 +158,9 @@ func (ic *ImageController) Chown(uid, gid int) error {
 // Chmod changes the permissions of the image. If any perm is -1 it will not
 // change
 func (ic *ImageController) Chmod(perm shared.Permissions) error {
-	_, err := ic.c.Client.Call("one.image.chmod", perm.ToArgs(ic.ID)...)
+	args := append([]interface{}{ic.ID}, perm.ToArgs()...)
+
+	_, err := ic.c.Client.Call("one.image.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/marketplace.go
+++ b/src/oca/go/src/goca/marketplace.go
@@ -133,7 +133,7 @@ func (mc *MarketPlaceController) Update(tpl string, uType parameters.UpdateType)
 }
 
 // Chmod changes the permission bits of a marketplace
-func (mc *MarketPlaceController) Chmod(perm *shared.Permissions) error {
+func (mc *MarketPlaceController) Chmod(perm shared.Permissions) error {
 	_, err := mc.c.Client.Call("one.market.chmod", perm.ToArgs(mc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/marketplace.go
+++ b/src/oca/go/src/goca/marketplace.go
@@ -134,7 +134,9 @@ func (mc *MarketPlaceController) Update(tpl string, uType parameters.UpdateType)
 
 // Chmod changes the permission bits of a marketplace
 func (mc *MarketPlaceController) Chmod(perm shared.Permissions) error {
-	_, err := mc.c.Client.Call("one.market.chmod", perm.ToArgs(mc.ID)...)
+	args := append([]interface{}{mc.ID}, perm.ToArgs()...)
+
+	_, err := mc.c.Client.Call("one.market.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/marketplace_test.go
+++ b/src/oca/go/src/goca/marketplace_test.go
@@ -86,7 +86,7 @@ func TestMarketplace(t *testing.T) {
 	}
 
 	//Change permissions for Marketpkace
-	err = marketCtrl.Chmod(&shared.Permissions{1, 1, 1, 1, 1, 1, 1, 1, 1})
+	err = marketCtrl.Chmod(shared.Permissions{1, 1, 1, 1, 1, 1, 1, 1, 1})
 
 	if err != nil {
 		t.Errorf("Test failed:\n" + err.Error())

--- a/src/oca/go/src/goca/marketplaceapp.go
+++ b/src/oca/go/src/goca/marketplaceapp.go
@@ -142,7 +142,8 @@ func (mc *MarketPlaceAppController) Update(tpl string, uType parameters.UpdateTy
 
 // Chmod changes the permission bits of a marketplace app
 func (mc *MarketPlaceAppController) Chmod(perm shared.Permissions) error {
-	_, err := mc.c.Client.Call("one.marketapp.chmod", perm.ToArgs(mc.ID)...)
+	args := append([]interface{}{mc.ID}, perm.ToArgs()...)
+	_, err := mc.c.Client.Call("one.marketapp.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/marketplaceapp.go
+++ b/src/oca/go/src/goca/marketplaceapp.go
@@ -141,7 +141,7 @@ func (mc *MarketPlaceAppController) Update(tpl string, uType parameters.UpdateTy
 }
 
 // Chmod changes the permission bits of a marketplace app
-func (mc *MarketPlaceAppController) Chmod(perm *shared.Permissions) error {
+func (mc *MarketPlaceAppController) Chmod(perm shared.Permissions) error {
 	_, err := mc.c.Client.Call("one.marketapp.chmod", perm.ToArgs(mc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/schemas/shared/permissions.go
+++ b/src/oca/go/src/goca/schemas/shared/permissions.go
@@ -41,7 +41,7 @@ type Permissions struct {
 var permStr = [8]string{"---", "--a", "-m-", "-ma", "u--", "u-a", "um-", "uma"}
 
 // If a bit is set to -1, it will not change when calling Chmod
-func (p *Permissions) ToArgs(id int) []interface{} {
+func (p Permissions) ToArgs(id int) []interface{} {
 	return []interface{}{
 		id,
 		p.OwnerU, p.OwnerM, p.OwnerA,
@@ -50,7 +50,7 @@ func (p *Permissions) ToArgs(id int) []interface{} {
 	}
 }
 
-func (p *Permissions) String() string {
+func (p Permissions) String() string {
 	owner := permStr[p.OwnerU<<2|p.OwnerM<<1|p.OwnerA]
 	group := permStr[p.GroupU<<2|p.GroupM<<1|p.GroupA]
 	other := permStr[p.OtherU<<2|p.OtherM<<1|p.OtherA]

--- a/src/oca/go/src/goca/schemas/shared/permissions.go
+++ b/src/oca/go/src/goca/schemas/shared/permissions.go
@@ -40,10 +40,13 @@ type Permissions struct {
 
 var permStr = [8]string{"---", "--a", "-m-", "-ma", "u--", "u-a", "um-", "uma"}
 
+func NewDefaultPermission() Permissions {
+	return Permissions{-1, -1, -1, -1, -1, -1, -1, -1, -1}
+}
+
 // If a bit is set to -1, it will not change when calling Chmod
-func (p Permissions) ToArgs(id int) []interface{} {
+func (p Permissions) ToArgs() []interface{} {
 	return []interface{}{
-		id,
 		p.OwnerU, p.OwnerM, p.OwnerA,
 		p.GroupU, p.GroupM, p.GroupA,
 		p.OtherU, p.OtherM, p.OtherA,

--- a/src/oca/go/src/goca/securitygroup.go
+++ b/src/oca/go/src/goca/securitygroup.go
@@ -151,7 +151,8 @@ func (sc *SecurityGroupController) Commit(recovery bool) error {
 
 // Chmod changes the permission bits of a security group
 func (sc *SecurityGroupController) Chmod(perm shared.Permissions) error {
-	_, err := sc.c.Client.Call("one.secgroup.chmod", perm.ToArgs(sc.ID)...)
+	args := append([]interface{}{sc.ID}, perm.ToArgs()...)
+	_, err := sc.c.Client.Call("one.secgroup.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/securitygroup.go
+++ b/src/oca/go/src/goca/securitygroup.go
@@ -150,7 +150,7 @@ func (sc *SecurityGroupController) Commit(recovery bool) error {
 }
 
 // Chmod changes the permission bits of a security group
-func (sc *SecurityGroupController) Chmod(perm *shared.Permissions) error {
+func (sc *SecurityGroupController) Chmod(perm shared.Permissions) error {
 	_, err := sc.c.Client.Call("one.secgroup.chmod", perm.ToArgs(sc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/securitygroup_test.go
+++ b/src/oca/go/src/goca/securitygroup_test.go
@@ -109,7 +109,7 @@ func TestSGAllocate(t *testing.T) {
 	testCtrl.SecurityGroup(clone_id).Delete()
 
 	//Change permission of SG
-	err = sgC.Chmod(&shared.Permissions{1, 1, 1, 1, 1, 1, 1, 1, 1})
+	err = sgC.Chmod(shared.Permissions{1, 1, 1, 1, 1, 1, 1, 1, 1})
 
 	if err != nil {
 		t.Errorf("Test failed:\n" + err.Error())

--- a/src/oca/go/src/goca/template.go
+++ b/src/oca/go/src/goca/template.go
@@ -135,7 +135,8 @@ func (tc *TemplateController) Chown(uid, gid int) error {
 // Chmod changes the permissions of a template. If any perm is -1 it will not
 // change
 func (tc *TemplateController) Chmod(perm shared.Permissions) error {
-	_, err := tc.c.Client.Call("one.template.chmod", perm.ToArgs(tc.ID)...)
+	args := append([]interface{}{tc.ID}, perm.ToArgs()...)
+	_, err := tc.c.Client.Call("one.template.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/template.go
+++ b/src/oca/go/src/goca/template.go
@@ -134,7 +134,7 @@ func (tc *TemplateController) Chown(uid, gid int) error {
 
 // Chmod changes the permissions of a template. If any perm is -1 it will not
 // change
-func (tc *TemplateController) Chmod(perm *shared.Permissions) error {
+func (tc *TemplateController) Chmod(perm shared.Permissions) error {
 	_, err := tc.c.Client.Call("one.template.chmod", perm.ToArgs(tc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/virtualnetwork.go
+++ b/src/oca/go/src/goca/virtualnetwork.go
@@ -194,7 +194,7 @@ func (vc *VirtualNetworkController) Update(tpl string, uType parameters.UpdateTy
 }
 
 // Chmod changes the permission bits of a virtual network.
-func (vc *VirtualNetworkController) Chmod(perm *shared.Permissions) error {
+func (vc *VirtualNetworkController) Chmod(perm shared.Permissions) error {
 	_, err := vc.c.Client.Call("one.vn.chmod", perm.ToArgs(vc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/virtualnetwork.go
+++ b/src/oca/go/src/goca/virtualnetwork.go
@@ -195,7 +195,8 @@ func (vc *VirtualNetworkController) Update(tpl string, uType parameters.UpdateTy
 
 // Chmod changes the permission bits of a virtual network.
 func (vc *VirtualNetworkController) Chmod(perm shared.Permissions) error {
-	_, err := vc.c.Client.Call("one.vn.chmod", perm.ToArgs(vc.ID)...)
+	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
+	_, err := vc.c.Client.Call("one.vn.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/virtualrouter.go
+++ b/src/oca/go/src/goca/virtualrouter.go
@@ -145,7 +145,9 @@ func (vc *VirtualRouterController) Chown(uid, gid int) error {
 // Chmod changes the permissions of a virtual router. If any perm is -1 it will not
 // change
 func (vc *VirtualRouterController) Chmod(perm shared.Permissions) error {
-	_, err := vc.c.Client.Call("one.vrouter.chmod", perm.ToArgs(vc.ID)...)
+	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
+
+	_, err := vc.c.Client.Call("one.vrouter.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/virtualrouter.go
+++ b/src/oca/go/src/goca/virtualrouter.go
@@ -144,7 +144,7 @@ func (vc *VirtualRouterController) Chown(uid, gid int) error {
 
 // Chmod changes the permissions of a virtual router. If any perm is -1 it will not
 // change
-func (vc *VirtualRouterController) Chmod(perm *shared.Permissions) error {
+func (vc *VirtualRouterController) Chmod(perm shared.Permissions) error {
 	_, err := vc.c.Client.Call("one.vrouter.chmod", perm.ToArgs(vc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/virtualrouter_test.go
+++ b/src/oca/go/src/goca/virtualrouter_test.go
@@ -89,7 +89,7 @@ func TestVirtualRouter(t *testing.T) {
 	}
 
 	//Change permissions of VirtualRouter
-	err = vrC.Chmod(&shared.Permissions{1, 1, 1, 1, 1, 1, 1, 1, 1})
+	err = vrC.Chmod(shared.Permissions{1, 1, 1, 1, 1, 1, 1, 1, 1})
 
 	if err != nil {
 		t.Errorf("Test failed:\n" + err.Error())

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -286,7 +286,8 @@ func (vc *VMController) Chown(uid, gid int) error {
 // Chmod changes the permissions of a VM. If any perm is -1 it will not
 // change
 func (vc *VMController) Chmod(perm shared.Permissions) error {
-	_, err := vc.c.Client.Call("one.vm.chmod", perm.ToArgs(vc.ID)...)
+	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
+	_, err := vc.c.Client.Call("one.vm.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -285,7 +285,7 @@ func (vc *VMController) Chown(uid, gid int) error {
 
 // Chmod changes the permissions of a VM. If any perm is -1 it will not
 // change
-func (vc *VMController) Chmod(perm *shared.Permissions) error {
+func (vc *VMController) Chmod(perm shared.Permissions) error {
 	_, err := vc.c.Client.Call("one.vm.chmod", perm.ToArgs(vc.ID)...)
 	return err
 }

--- a/src/oca/go/src/goca/vmgroup.go
+++ b/src/oca/go/src/goca/vmgroup.go
@@ -138,7 +138,8 @@ func (vc *VMGroupController) Update(tpl string, uType int) error {
 
 // Chmod changes the permission bits of a vmGroup.
 func (vc *VMGroupController) Chmod(perm shared.Permissions) error {
-	_, err := vc.c.Client.Call("one.vmgroup.chmod", perm.ToArgs(vc.ID)...)
+	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
+	_, err := vc.c.Client.Call("one.vmgroup.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/vmgroup.go
+++ b/src/oca/go/src/goca/vmgroup.go
@@ -137,17 +137,8 @@ func (vc *VMGroupController) Update(tpl string, uType int) error {
 }
 
 // Chmod changes the permission bits of a vmGroup.
-// * uu: USER USE bit. If set to -1, it will not change.
-// * um: USER MANAGE bit. If set to -1, it will not change.
-// * ua: USER ADMIN bit. If set to -1, it will not change.
-// * gu: GROUP USE bit. If set to -1, it will not change.
-// * gm: GROUP MANAGE bit. If set to -1, it will not change.
-// * ga: GROUP ADMIN bit. If set to -1, it will not change.
-// * ou: OTHER USE bit. If set to -1, it will not change.
-// * om: OTHER MANAGE bit. If set to -1, it will not change.
-// * oa: OTHER ADMIN bit. If set to -1, it will not change.
-func (vc *VMGroupController) Chmod(uu, um, ua, gu, gm, ga, ou, om, oa int) error {
-	_, err := vc.c.Client.Call("one.vmgroup.chmod", vc.ID, uu, um, ua, gu, gm, ga, ou, om, oa)
+func (vc *VMGroupController) Chmod(perm shared.Permissions) error {
+	_, err := vc.c.Client.Call("one.vmgroup.chmod", perm.ToArgs(vc.ID)...)
 	return err
 }
 

--- a/src/oca/go/src/goca/vntemplate.go
+++ b/src/oca/go/src/goca/vntemplate.go
@@ -138,7 +138,8 @@ func (vc *VNTemplateController) Chown(uid, gid int) error {
 // Chmod changes the permissions of a vntemplate. If any perm is -1 it will not
 // change
 func (vc *VNTemplateController) Chmod(perm shared.Permissions) error {
-	_, err := vc.c.Client.Call("one.vntemplate.chmod", perm.ToArgs(vc.ID)...)
+	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
+	_, err := vc.c.Client.Call("one.vntemplate.chmod", args...)
 	return err
 }
 

--- a/src/oca/go/src/goca/vntemplate.go
+++ b/src/oca/go/src/goca/vntemplate.go
@@ -137,7 +137,7 @@ func (vc *VNTemplateController) Chown(uid, gid int) error {
 
 // Chmod changes the permissions of a vntemplate. If any perm is -1 it will not
 // change
-func (vc *VNTemplateController) Chmod(perm *shared.Permissions) error {
+func (vc *VNTemplateController) Chmod(perm shared.Permissions) error {
 	_, err := vc.c.Client.Call("one.vntemplate.chmod", perm.ToArgs(vc.ID)...)
 	return err
 }


### PR DESCRIPTION
Initial PR #4135 splitted in two, in order to move the breaking part only in this PR.

This part remove pointers used for permission structures.