### PR TITLE
fixes "ERROR:  While executing gem ... (OptionParser::InvalidOption) …

### DIFF
--- a/share/install_gems/install_gems
+++ b/share/install_gems/install_gems
@@ -205,7 +205,7 @@ EOT
 end
 
 def installed_gems
-    text=`gem list --no-versions --no-details`
+    text=`gem list --no-versions`
     if $?.exitstatus!=0
         nil
     else
@@ -497,7 +497,7 @@ EOT
         end.join(' ')+' '
     end
 
-    command_string = "#{prefix}gem install --no-ri --no-rdoc"
+    command_string = "#{prefix}gem install --no-document"
 
     install_warning(packages)
 


### PR DESCRIPTION
…    invalid option: --no-ri "

this pull Fixes 

"ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-ri
Error executing rake="/usr/bin/rake" gem install --no-ri --no-rdoc zendesk_api "

While setting up "OpenNebula Sunstone " using guide available at "https://github.com/OpenNebula/docs/blob/master/source/deployment/sunstone_setup/sunstone.rst"  

and running command 

.. prompt:: bash # auto
    # /usr/share/one/install_gems sunstone

As "--no-ri and --no-rdoc " is removed and "--no-document" is introduced in "gem install " command options .

The change log is at https://blog.rubygems.org/2018/12/19/3.0.0-released.html 

And also "--no-details" option is also removed from "gem list" command.