### PR TITLE
Flag container status transition before reboot.stop 

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -256,14 +256,12 @@ class Container
         case config['user.reboot_state']
         when 'STOPPED'
             start
-
             config['user.reboot_state'] = 'RUNNING'
             transition_end # container reached a final state
         else
-            check_stop(force)
-
-            config['user.reboot_state'] = 'STOPPED'
             transition_start # container will be started later
+            check_stop(force)
+            config['user.reboot_state'] = 'STOPPED'
         end
 
         update


### PR DESCRIPTION
Removed small time window from stopping to flag the transition_start.

Applicable to master.