### PR TITLE
B #4269: revert escapeDoubleQuotes change

### DIFF
--- a/src/sunstone/public/app/utils/wizard-fields.js
+++ b/src/sunstone/public/app/utils/wizard-fields.js
@@ -52,10 +52,8 @@ define(function(require) {
     return templateJSON;
   }
 
-  function _retrieveInput(value) {
-    return (value instanceof $)
-      ? value.val()
-      : TemplateUtils.escapeDoubleQuotes( value );
+  function _retrieveInput(input) {
+    return TemplateUtils.escapeDoubleQuotes( input.val() );
   }
 
   // TODO: wizard_field_64 for fill method


### PR DESCRIPTION
in src/sunstone/public/app/utils/wizard-fields.js
to restore doube quotes escape in `SCHED_REQUIREMENTS`
and `SCHED_DS_REQUIREMENTS`

Signed-off-by: Anton Todorov (a.todorov@storpool.com)