### PR TITLE
B #3189: Update when flagging trans_start

### DIFF
--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -253,8 +253,7 @@ class Container
 
     # Extended reboot required for OpenNebula execution flow
     def reboot(force)
-        case transient?
-        when true
+        if transient?
             start
 
             transition_end # container reached the final state of rebooting
@@ -498,7 +497,7 @@ class Container
 
     # Helper method for querying transition phase
     def transient?
-        true if @lxc['config']['user.one_status'] == '0'
+        @lxc['config']['user.one_status'] == '0'
     end
 
     private

--- a/src/vmm_mad/remotes/lib/lxd/container.rb
+++ b/src/vmm_mad/remotes/lib/lxd/container.rb
@@ -253,18 +253,18 @@ class Container
 
     # Extended reboot required for OpenNebula execution flow
     def reboot(force)
-        case config['user.reboot_state']
-        when 'STOPPED'
+        case transient?
+        when true
             start
-            config['user.reboot_state'] = 'RUNNING'
-            transition_end # container reached a final state
+
+            transition_end # container reached the final state of rebooting
+            update
         else
             transition_start # container will be started later
-            check_stop(force)
-            config['user.reboot_state'] = 'STOPPED'
-        end
+            update
 
-        update
+            check_stop(force)
+        end
     end
 
     def restart(options = {})
@@ -494,6 +494,11 @@ class Container
     # Removes transient state flag. Requires updating the container.
     def transition_end
         @lxc['config'].delete('user.one_status')
+    end
+
+    # Helper method for querying transition phase
+    def transient?
+        true if @lxc['config']['user.one_status'] == '0'
     end
 
     private

--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -108,7 +108,7 @@ module LXD
         #  * 'stopped' container not running or in the process of shutting down.
         #  * 'failure' container have failed.
         def get_state(container)
-            return '-' if container.config['user.one_status'] == '0'
+            return '-' if container.transient?
 
             begin
                 status = container.status.downcase


### PR DESCRIPTION
Transition start flag was removed when stopping (@lxc gets overriden by change_state).

- removed reboot flags (using the transition methods now)
- added helper method

Applicable to master