### PR TITLE
Fix LXD CPU and Memory monitoring

### DIFF
--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -195,7 +195,8 @@ module LXD
         def get_cpu_jiffies
             begin
                 stat = File.read('/proc/stat')
-            rescue StandardError
+            rescue StandardError => e
+                OpenNebula.log e
                 return 0
             end
 
@@ -210,16 +211,16 @@ module LXD
         end
 
         def get_process_jiffies(vm_name)
-            begin
-                jiffies = 0
+            jiffies = 0
+            stat = File.read('/sys/fs/cgroup/cpu,cpuacct/'\
+                "#{lxc_path(vm_name)}/cpuacct.stat")
 
-                stat = File.read('/sys/fs/cgroup/cpu,cpuacct/' + lxc_path(vm_name) + '/cpuacct.stat')
-                stat.lines.each {|line| jiffies += line.split(' ')[1] }
-            rescue StandardError
-                return 0
-            end
+            stat.lines.each {|line| jiffies += line.split(' ')[1].to_i }
 
             jiffies
+        rescue => e
+            OpenNebula.log e
+            0
         end
 
         def parse_memory(memory)

--- a/src/vmm_mad/remotes/lxd/poll
+++ b/src/vmm_mad/remotes/lxd/poll
@@ -20,7 +20,9 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 
 require 'container'
 require 'client'
+
 require_relative '../lib/poll_common'
+require_relative '../../scripts_common'
 
 require 'base64'
 
@@ -134,13 +136,21 @@ module LXD
 
         def lxc_path(vm_name)
             path = 'lxc/' + vm_name
-            path = "#{ENV['LXC_CGROUP_PREFIX']}#{path}" if ENV['LXC_CGROUP_PREFIX']
+            cgroup = ENV['LXC_CGROUP_PREFIX']
+
+            return "#{cgroup}#{path}" if cgroup
+
+            path
         end
 
         def get_memory(vm_name)
-            stat = File.read('/sys/fs/cgroup/memory/' + lxc_path(vm_name) + '/memory.usage_in_bytes').to_i
+            stat = File.read("/sys/fs/cgroup/memory/#{lxc_path(vm_name)}"\
+            '/memory.usage_in_bytes').to_i
+
             stat / 1024
-        rescue StandardError
+        rescue => e
+            OpenNebula.log e
+
             0
         end
 
@@ -158,9 +168,6 @@ module LXD
             [netrx, nettx]
         end
 
-        # Gathers process information from a set of VMs.
-        #   @param vm_names [Array] of vms indexed by name. Value is a hash with :pid
-        #   @return  [Hash] with ps information
         def get_cpu(vm_names)
             multiplier = `grep -c processor /proc/cpuinfo`.to_i * 100
 


### PR DESCRIPTION
`lxc_path` function always returned `nil` after merging [this](https://github.com/OpenNebula/one/pull/2840/files), triggering the rescue blocks and returning 0 for CPU and RAM monitoring functions.

Added some error logging in order to avoid silent fails like this one.

Merge with https://github.com/OpenNebula/docs/pull/969