### PR TITLE
B #4329: use default encoding if not found

### DIFF
--- a/src/onedb/onedb_backend.rb
+++ b/src/onedb/onedb_backend.rb
@@ -375,7 +375,8 @@ class BackEndMySQL < OneDBBacKEnd
         when 'ascii'
             'ASCII'
         else
-            'NONE'
+            # if no encoding found, use the default one
+            NOKOGIRI_ENCODING
         end
     end
 


### PR DESCRIPTION
Applies to 5.10 too