### PR TITLE
B #4334: fix reserved networks count

### DIFF
--- a/src/onedb/fsck/quotas.rb
+++ b/src/onedb/fsck/quotas.rb
@@ -463,11 +463,12 @@ module OneDBFsck
         @db.fetch(queries[2]) do |vnet_row|
             vnet_doc = nokogiri_doc(vnet_row[:body])
 
-            vnet_doc.xpath('VNET/AR_POOL').each do |ar|
-                parent_id = ar.xpath('AR/PARENT_NETWORK_AR_ID')
-                parent_id = parent_id.text unless parent_id.nil?
+            parent_id = vnet_doc.root.xpath('PARENT_NETWORK_ID')
+            parent_id = parent_id.text unless parent_id.nil?
 
-                next if parent_id.nil? || parent_id.empty?
+            next if parent_id.nil? || parent_id.empty?
+
+            vnet_doc.xpath('VNET/AR_POOL').each do |ar|
 
                 vnet_usage[parent_id] = 0 if vnet_usage[parent_id].nil?
 


### PR DESCRIPTION
Use `PARENT_NETWORK_ID` instead of `AR/PARENT_NETWORK_AR_ID` to find parent network id

fixes https://github.com/OpenNebula/one/issues/4334