### PR TITLE
M #-: Fix to grunt<1.1.0

### DIFF
--- a/src/sunstone/public/build.sh
+++ b/src/sunstone/public/build.sh
@@ -19,7 +19,7 @@ clean() {
 
 dependencies() {
     npm install bower
-    npm install grunt
+    npm install 'grunt@<1.1.0'
     npm install grunt-cli
 
     export PATH=$PATH:$PWD/node_modules/.bin


### PR DESCRIPTION
New **grunt** 1.1.0 introduces dependency on newer **mkdirp** module, which  is not compatible with Node.js in the build system.

```
opennebula-5.10.4/src/sunstone/public/node_modules/mkdirp/lib/opts-arg.js:7
    opts = { mode: 0o777 & (~process.umask()), fs, ...opts }
                                                   ^^^
SyntaxError: Unexpected token ...
  at createScript (vm.js:56:10)
  at Object.runInThisContext (vm.js:97:10)
  at Module._compile (module.js:549:28)
  at Object.Module._extensions..js (module.js:586:10)
  at Module.load (/var/lib/jenkins/jobs/new-init/workspace/tmp.NBe8nTFP2g/opennebula-5.10.4/src/sunstone/public/node_modules/coffeescript/lib/coffee-script/register.js:45:36)
```

Applies to
- master
- one-5.10

(and possibly other stable branches where cherry-pick fits)