### PR TITLE
M #-: Fix Sunstone dependency on grunt<1.1.0

### DIFF
--- a/src/sunstone/public/build.sh
+++ b/src/sunstone/public/build.sh
@@ -19,7 +19,7 @@ clean() {
 
 dependencies() {
     npm install bower
-    npm install 'grunt@<1.1.0'
+    npm install grunt
     npm install grunt-cli
 
     export PATH=$PATH:$PWD/node_modules/.bin

--- a/src/sunstone/public/package.json
+++ b/src/sunstone/public/package.json
@@ -2,7 +2,7 @@
   "name": "opennebula-sunstone",
   "version": "0.0.1",
   "devDependencies": {
-    "grunt": "^1.0.1",
+    "grunt": "<1.1.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-requirejs": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",


### PR DESCRIPTION
Previous change fixing Grunt to <1.1.0 was not enough, as the dependency on new one is introduced directly by Sunstone. So, it's more effective to pin the version in package file.

Applies to
- master
- one-5.10