### PR TITLE
M #-: Grant ipforwarding in every recontext

### DIFF
--- a/share/start-scripts/cron_start_script
+++ b/share/start-scripts/cron_start_script
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+sysctl -w net.ipv4.ip_forward=1
+
 script_name="$(echo $FILES_DS | sed -n 's/.*:\x27\(.*\)\x27/\1/p')"
 
 map_vnets_script_dst="/usr/local/bin/${script_name}"
@@ -8,6 +10,7 @@ then
   # Already installed
   exit 1
 fi
+
 
 map_vnets_script_src="$MOUNT_DIR/${script_name}"
 


### PR DESCRIPTION
net.ipv4.ip_forward is always set to 1 in every recontextualization if
cron_start_script used as start script.

Signed-off-by: Ricardo Diaz <rdiaz@opennebula.systems>