### PR TITLE
F #3859: On close kill driver after timeout

### DIFF
--- a/src/monitor/include/Driver.h
+++ b/src/monitor/include/Driver.h
@@ -187,16 +187,23 @@ void Driver<E>::stop_driver()
     close(from_drv);
     close(to_drv);
 
-    for (int i=0; i < 10; ++i)
+    bool success = false;
+    for (int i=0; i < 7; ++i)
     {
         int status;
 
         if ( waitpid(pid, &status, WNOHANG) != 0 )
         {
+            success = true;
             break;
         }
 
         sleep(1);
+    }
+
+    if (!success)
+    {
+        kill(pid, SIGKILL);
     }
 }
 


### PR DESCRIPTION
Kill driver after timout and
The timeout for driver termination reduced to 7 secs. There is 10 sec timeout in /bin/one, we want the driver timeout to hit first