### PR TITLE
B #4304: Distribution gems affects OpenNebula

### DIFF
--- a/share/hooks/alias_ip/alias_ip.rb
+++ b/share/hooks/alias_ip/alias_ip.rb
@@ -32,6 +32,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/share/hooks/ft/host_error.rb
+++ b/share/hooks/ft/host_error.rb
@@ -51,6 +51,7 @@ FENCE_HOST = File.dirname(__FILE__) + '/fence_host.sh'
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/share/hooks/vcenter/create_vcenter_net.rb
+++ b/share/hooks/vcenter/create_vcenter_net.rb
@@ -33,6 +33,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/share/hooks/vcenter/delete_vcenter_net.rb
+++ b/share/hooks/vcenter/delete_vcenter_net.rb
@@ -32,6 +32,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/one_auth_mad.rb
+++ b/src/authm_mad/one_auth_mad.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/dummy/authenticate
+++ b/src/authm_mad/remotes/dummy/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/ldap/authenticate
+++ b/src/authm_mad/remotes/ldap/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/plain/authenticate
+++ b/src/authm_mad/remotes/plain/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/server_cipher/authenticate
+++ b/src/authm_mad/remotes/server_cipher/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/server_x509/authenticate
+++ b/src/authm_mad/remotes/server_x509/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/ssh/authenticate
+++ b/src/authm_mad/remotes/ssh/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/authm_mad/remotes/x509/authenticate
+++ b/src/authm_mad/remotes/x509/authenticate
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneacct
+++ b/src/cli/oneacct
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneacl
+++ b/src/cli/oneacl
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onecluster
+++ b/src/cli/onecluster
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onedatastore
+++ b/src/cli/onedatastore
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneflow
+++ b/src/cli/oneflow
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneflow-template
+++ b/src/cli/oneflow-template
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onegroup
+++ b/src/cli/onegroup
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onehook
+++ b/src/cli/onehook
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onehost
+++ b/src/cli/onehost
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneimage
+++ b/src/cli/oneimage
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onemarket
+++ b/src/cli/onemarket
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onemarketapp
+++ b/src/cli/onemarketapp
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneprovision
+++ b/src/cli/oneprovision
@@ -34,6 +34,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onesecgroup
+++ b/src/cli/onesecgroup
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneshowback
+++ b/src/cli/oneshowback
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onetemplate
+++ b/src/cli/onetemplate
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/oneuser
+++ b/src/cli/oneuser
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevcenter
+++ b/src/cli/onevcenter
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevdc
+++ b/src/cli/onevdc
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevm
+++ b/src/cli/onevm
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevmgroup
+++ b/src/cli/onevmgroup
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevnet
+++ b/src/cli/onevnet
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevntemplate
+++ b/src/cli/onevntemplate
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onevrouter
+++ b/src/cli/onevrouter
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cli/onezone
+++ b/src/cli/onezone
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-allocate-address
+++ b/src/cloud/ec2/bin/econe-allocate-address
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-associate-address
+++ b/src/cloud/ec2/bin/econe-associate-address
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-attach-volume
+++ b/src/cloud/ec2/bin/econe-attach-volume
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-create-keypair
+++ b/src/cloud/ec2/bin/econe-create-keypair
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-create-volume
+++ b/src/cloud/ec2/bin/econe-create-volume
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-delete-keypair
+++ b/src/cloud/ec2/bin/econe-delete-keypair
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-delete-volume
+++ b/src/cloud/ec2/bin/econe-delete-volume
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-describe-addresses
+++ b/src/cloud/ec2/bin/econe-describe-addresses
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-describe-images
+++ b/src/cloud/ec2/bin/econe-describe-images
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-describe-instances
+++ b/src/cloud/ec2/bin/econe-describe-instances
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-describe-keypairs
+++ b/src/cloud/ec2/bin/econe-describe-keypairs
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-describe-volumes
+++ b/src/cloud/ec2/bin/econe-describe-volumes
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-detach-volume
+++ b/src/cloud/ec2/bin/econe-detach-volume
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-disassociate-address
+++ b/src/cloud/ec2/bin/econe-disassociate-address
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-reboot-instances
+++ b/src/cloud/ec2/bin/econe-reboot-instances
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-register
+++ b/src/cloud/ec2/bin/econe-register
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-release-address
+++ b/src/cloud/ec2/bin/econe-release-address
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-run-instances
+++ b/src/cloud/ec2/bin/econe-run-instances
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-start-instances
+++ b/src/cloud/ec2/bin/econe-start-instances
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-stop-instances
+++ b/src/cloud/ec2/bin/econe-stop-instances
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-terminate-instances
+++ b/src/cloud/ec2/bin/econe-terminate-instances
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/bin/econe-upload
+++ b/src/cloud/ec2/bin/econe-upload
@@ -27,6 +27,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/cloud/ec2/lib/econe-server.rb
+++ b/src/cloud/ec2/lib/econe-server.rb
@@ -42,6 +42,7 @@ VIEWS_LOCATION     = RUBY_LIB_LOCATION + '/cloud/econe/views'
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/datastore_mad/one_datastore.rb
+++ b/src/datastore_mad/one_datastore.rb
@@ -33,6 +33,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/datastore_mad/remotes/vcenter/clone
+++ b/src/datastore_mad/remotes/vcenter/clone
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter/cp
+++ b/src/datastore_mad/remotes/vcenter/cp
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter/export
+++ b/src/datastore_mad/remotes/vcenter/export
@@ -30,7 +30,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter/mkfs
+++ b/src/datastore_mad/remotes/vcenter/mkfs
@@ -30,7 +30,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter/monitor
+++ b/src/datastore_mad/remotes/vcenter/monitor
@@ -30,7 +30,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter/rm
+++ b/src/datastore_mad/remotes/vcenter/rm
@@ -30,7 +30,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter/stat
+++ b/src/datastore_mad/remotes/vcenter/stat
@@ -30,7 +30,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/datastore_mad/remotes/vcenter_downloader.rb
+++ b/src/datastore_mad/remotes/vcenter_downloader.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/datastore_mad/remotes/vcenter_uploader.rb
+++ b/src/datastore_mad/remotes/vcenter_uploader.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/flow/oneflow-server.rb
+++ b/src/flow/oneflow-server.rb
@@ -39,6 +39,7 @@ CONFIGURATION_FILE = ETC_LOCATION + '/oneflow-server.conf'
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/hem/onehem-server.rb
+++ b/src/hem/onehem-server.rb
@@ -40,6 +40,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/hm_mad/one_hm.rb
+++ b/src/hm_mad/one_hm.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/im_exec/one_im_exec.rb
+++ b/src/im_mad/im_exec/one_im_exec.rb
@@ -32,6 +32,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/az-probes.d/host/monitor/probe_host_monitor.rb
+++ b/src/im_mad/remotes/az-probes.d/host/monitor/probe_host_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/az-probes.d/host/system/probe_host_system.rb
+++ b/src/im_mad/remotes/az-probes.d/host/system/probe_host_system.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/az-probes.d/vm/monitor/probe_vm_monitor.rb
+++ b/src/im_mad/remotes/az-probes.d/vm/monitor/probe_vm_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/az-probes.d/vm/status/probe_vm_status.rb
+++ b/src/im_mad/remotes/az-probes.d/vm/status/probe_vm_status.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/dummy-probes.d/vm/monitor/monitor.rb
+++ b/src/im_mad/remotes/dummy-probes.d/vm/monitor/monitor.rb
@@ -29,6 +29,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/ec2-probes.d/host/monitor/probe_host_monitor.rb
+++ b/src/im_mad/remotes/ec2-probes.d/host/monitor/probe_host_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/ec2-probes.d/host/system/probe_host_system.rb
+++ b/src/im_mad/remotes/ec2-probes.d/host/system/probe_host_system.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/ec2-probes.d/vm/monitor/probe_vm_monitor.rb
+++ b/src/im_mad/remotes/ec2-probes.d/vm/monitor/probe_vm_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/ec2-probes.d/vm/status/probe_vm_status.rb
+++ b/src/im_mad/remotes/ec2-probes.d/vm/status/probe_vm_status.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/lib/nsx.rb
+++ b/src/im_mad/remotes/lib/nsx.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/lib/probe_db.rb
+++ b/src/im_mad/remotes/lib/probe_db.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/lib/vcenter.rb
+++ b/src/im_mad/remotes/lib/vcenter.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/one-probes.d/host/monitor/probe_host_monitor.rb
+++ b/src/im_mad/remotes/one-probes.d/host/monitor/probe_host_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/one-probes.d/host/system/probe_host_system.rb
+++ b/src/im_mad/remotes/one-probes.d/host/system/probe_host_system.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/one-probes.d/vm/monitor/probe_vm_monitor.rb
+++ b/src/im_mad/remotes/one-probes.d/vm/monitor/probe_vm_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/one-probes.d/vm/status/probe_vm_status.rb
+++ b/src/im_mad/remotes/one-probes.d/vm/status/probe_vm_status.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/packet-probes.d/host/monitor/probe_host_monitor.rb
+++ b/src/im_mad/remotes/packet-probes.d/host/monitor/probe_host_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/packet-probes.d/host/system/probe_host_system.rb
+++ b/src/im_mad/remotes/packet-probes.d/host/system/probe_host_system.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/packet-probes.d/vm/monitor/probe_vm_monitor.rb
+++ b/src/im_mad/remotes/packet-probes.d/vm/monitor/probe_vm_monitor.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/packet-probes.d/vm/status/probe_vm_status.rb
+++ b/src/im_mad/remotes/packet-probes.d/vm/status/probe_vm_status.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/im_mad/remotes/vcenter-probes.d/host/system/nsx.rb
+++ b/src/im_mad/remotes/vcenter-probes.d/host/system/nsx.rb
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/ipamm_mad/one_ipam.rb
+++ b/src/ipamm_mad/one_ipam.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/ipamm_mad/remotes/packet/allocate_address
+++ b/src/ipamm_mad/remotes/packet/allocate_address
@@ -54,6 +54,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << PACKET_LOCATION

--- a/src/ipamm_mad/remotes/packet/free_address
+++ b/src/ipamm_mad/remotes/packet/free_address
@@ -48,6 +48,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << PACKET_LOCATION

--- a/src/ipamm_mad/remotes/packet/get_address
+++ b/src/ipamm_mad/remotes/packet/get_address
@@ -61,6 +61,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << PACKET_LOCATION

--- a/src/ipamm_mad/remotes/packet/register_address_range
+++ b/src/ipamm_mad/remotes/packet/register_address_range
@@ -82,6 +82,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << PACKET_LOCATION

--- a/src/ipamm_mad/remotes/packet/unregister_address_range
+++ b/src/ipamm_mad/remotes/packet/unregister_address_range
@@ -46,6 +46,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << PACKET_LOCATION

--- a/src/market_mad/one_market.rb
+++ b/src/market_mad/one_market.rb
@@ -33,6 +33,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/market_mad/remotes/s3/delete
+++ b/src/market_mad/remotes/s3/delete
@@ -36,6 +36,7 @@ UTILS_PATH = File.join(File.dirname(__FILE__), '../../datastore')
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/market_mad/remotes/s3/import
+++ b/src/market_mad/remotes/s3/import
@@ -36,6 +36,7 @@ UTILS_PATH = File.join(File.dirname(__FILE__), '../../datastore')
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/market_mad/remotes/s3/monitor
+++ b/src/market_mad/remotes/s3/monitor
@@ -36,6 +36,7 @@ UTILS_PATH = File.join(File.dirname(__FILE__), '../../datastore')
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/market_mad/remotes/turnkeylinux/monitor
+++ b/src/market_mad/remotes/turnkeylinux/monitor
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/onedb/onedb
+++ b/src/onedb/onedb
@@ -46,6 +46,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/onedb/vcenter_one54_pre.rb
+++ b/src/onedb/vcenter_one54_pre.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/onegate/onegate-server.rb
+++ b/src/onegate/onegate-server.rb
@@ -39,6 +39,7 @@ CONFIGURATION_FILE = ETC_LOCATION + "/onegate-server.conf"
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/pm_mad/remotes/dummy/deploy
+++ b/src/pm_mad/remotes/dummy/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/ec2/cancel
+++ b/src/pm_mad/remotes/ec2/cancel
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/ec2/deploy
+++ b/src/pm_mad/remotes/ec2/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/ec2/poll
+++ b/src/pm_mad/remotes/ec2/poll
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/ec2/reboot
+++ b/src/pm_mad/remotes/ec2/reboot
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/ec2/reset
+++ b/src/pm_mad/remotes/ec2/reset
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/ec2/shutdown
+++ b/src/pm_mad/remotes/ec2/shutdown
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/packet/cancel
+++ b/src/pm_mad/remotes/packet/cancel
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/packet/deploy
+++ b/src/pm_mad/remotes/packet/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/packet/poll
+++ b/src/pm_mad/remotes/packet/poll
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/packet/reboot
+++ b/src/pm_mad/remotes/packet/reboot
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/packet/reset
+++ b/src/pm_mad/remotes/packet/reset
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/pm_mad/remotes/packet/shutdown
+++ b/src/pm_mad/remotes/packet/shutdown
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/sunstone/bin/novnc-server
+++ b/src/sunstone/bin/novnc-server
@@ -42,6 +42,7 @@ SUNSTONE_ROOT_DIR         = File.dirname(__FILE__)
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/sunstone/routes/nsx.rb
+++ b/src/sunstone/routes/nsx.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/sunstone/sunstone-server.rb
+++ b/src/sunstone/sunstone-server.rb
@@ -47,6 +47,7 @@ SUNSTONE_ROOT_DIR = File.dirname(__FILE__)
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/tm_mad/one_tm.rb
+++ b/src/tm_mad/one_tm.rb
@@ -32,6 +32,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/tm_mad/vcenter/clone
+++ b/src/tm_mad/vcenter/clone
@@ -34,7 +34,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/tm_mad/vcenter/cpds
+++ b/src/tm_mad/vcenter/cpds
@@ -33,7 +33,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/tm_mad/vcenter/delete
+++ b/src/tm_mad/vcenter/delete
@@ -33,7 +33,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/tm_mad/vcenter/mkimage
+++ b/src/tm_mad/vcenter/mkimage
@@ -34,7 +34,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/tm_mad/vcenter/mv
+++ b/src/tm_mad/vcenter/mv
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/tm_mad/vcenter/mvds
+++ b/src/tm_mad/vcenter/mvds
@@ -34,7 +34,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/tm_mad/vcenter/resize
+++ b/src/tm_mad/vcenter/resize
@@ -28,7 +28,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/dummy/one_vmm_dummy.rb
+++ b/src/vmm_mad/dummy/one_vmm_dummy.rb
@@ -30,6 +30,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/exec/one_vmm_exec.rb
+++ b/src/vmm_mad/exec/one_vmm_exec.rb
@@ -34,6 +34,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/az_driver.rb
+++ b/src/vmm_mad/remotes/az/az_driver.rb
@@ -35,6 +35,7 @@ AZ_DATABASE_PATH  = "#{VAR_LOCATION}/remotes/im/az.d/az-cache.db"
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/cancel
+++ b/src/vmm_mad/remotes/az/cancel
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/deploy
+++ b/src/vmm_mad/remotes/az/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/poll
+++ b/src/vmm_mad/remotes/az/poll
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/reboot
+++ b/src/vmm_mad/remotes/az/reboot
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/restore
+++ b/src/vmm_mad/remotes/az/restore
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/az/shutdown
+++ b/src/vmm_mad/remotes/az/shutdown
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/cancel
+++ b/src/vmm_mad/remotes/ec2/cancel
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/deploy
+++ b/src/vmm_mad/remotes/ec2/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/ec2_driver.rb
+++ b/src/vmm_mad/remotes/ec2/ec2_driver.rb
@@ -35,6 +35,7 @@ EC2_DATABASE_PATH  = "#{VAR_LOCATION}/remotes/im/ec2.d/ec2-cache.db"
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/poll
+++ b/src/vmm_mad/remotes/ec2/poll
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/reboot
+++ b/src/vmm_mad/remotes/ec2/reboot
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/restore
+++ b/src/vmm_mad/remotes/ec2/restore
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/ec2/shutdown
+++ b/src/vmm_mad/remotes/ec2/shutdown
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/lib/nsx_driver/nsx_client.rb
+++ b/src/vmm_mad/remotes/lib/nsx_driver/nsx_client.rb
@@ -31,6 +31,7 @@ module NSXDriver
 
     if File.directory?(GEMS_LOCATION)
         Gem.use_paths(GEMS_LOCATION)
+        $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
     end
 
     $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/lib/nsx_driver/nsx_constants.rb
+++ b/src/vmm_mad/remotes/lib/nsx_driver/nsx_constants.rb
@@ -31,6 +31,7 @@ module NSXDriver
 
     if File.directory?(GEMS_LOCATION)
         Gem.use_paths(GEMS_LOCATION)
+        $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
     end
 
     $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/lib/nsx_driver/nsxt_client.rb
+++ b/src/vmm_mad/remotes/lib/nsx_driver/nsxt_client.rb
@@ -31,6 +31,7 @@ module NSXDriver
 
     if File.directory?(GEMS_LOCATION)
         Gem.use_paths(GEMS_LOCATION)
+        $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
     end
 
     $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/lib/nsx_driver/nsxv_client.rb
+++ b/src/vmm_mad/remotes/lib/nsx_driver/nsxv_client.rb
@@ -31,6 +31,7 @@ module NSXDriver
 
     if File.directory?(GEMS_LOCATION)
         Gem.use_paths(GEMS_LOCATION)
+        $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
     end
 
     $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
@@ -35,6 +35,7 @@ module VCenterDriver
 
     if File.directory?(GEMS_LOCATION)
         Gem.use_paths(GEMS_LOCATION)
+        $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
     end
 
     $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/nsx/nsx_driver.rb
+++ b/src/vmm_mad/remotes/nsx/nsx_driver.rb
@@ -38,6 +38,7 @@ ENV['LANG'] = 'C'
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << LIB_LOCATION + '/ruby'

--- a/src/vmm_mad/remotes/one/cancel
+++ b/src/vmm_mad/remotes/one/cancel
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/deploy
+++ b/src/vmm_mad/remotes/one/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/opennebula_driver.rb
+++ b/src/vmm_mad/remotes/one/opennebula_driver.rb
@@ -33,6 +33,7 @@ require 'yaml'
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/poll
+++ b/src/vmm_mad/remotes/one/poll
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/reboot
+++ b/src/vmm_mad/remotes/one/reboot
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/reset
+++ b/src/vmm_mad/remotes/one/reset
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/restore
+++ b/src/vmm_mad/remotes/one/restore
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/save
+++ b/src/vmm_mad/remotes/one/save
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/one/shutdown
+++ b/src/vmm_mad/remotes/one/shutdown
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/packet/cancel
+++ b/src/vmm_mad/remotes/packet/cancel
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/packet/deploy
+++ b/src/vmm_mad/remotes/packet/deploy
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/packet/packet_driver.rb
+++ b/src/vmm_mad/remotes/packet/packet_driver.rb
@@ -32,6 +32,7 @@ PACKET_DATABASE_PATH = "#{VAR_LOCATION}/remotes/im/packet.d/packet-cache.db"
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << PACKET_LOCATION

--- a/src/vmm_mad/remotes/packet/poll
+++ b/src/vmm_mad/remotes/packet/poll
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/packet/reboot
+++ b/src/vmm_mad/remotes/packet/reboot
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/packet/reset
+++ b/src/vmm_mad/remotes/packet/reset
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/packet/shutdown
+++ b/src/vmm_mad/remotes/packet/shutdown
@@ -28,6 +28,7 @@ end
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << RUBY_LIB_LOCATION

--- a/src/vmm_mad/remotes/vcenter/attach_disk
+++ b/src/vmm_mad/remotes/vcenter/attach_disk
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/attach_nic
+++ b/src/vmm_mad/remotes/vcenter/attach_nic
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/cancel
+++ b/src/vmm_mad/remotes/vcenter/cancel
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/deploy
+++ b/src/vmm_mad/remotes/vcenter/deploy
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/detach_nic
+++ b/src/vmm_mad/remotes/vcenter/detach_nic
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/migrate
+++ b/src/vmm_mad/remotes/vcenter/migrate
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/poll
+++ b/src/vmm_mad/remotes/vcenter/poll
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/reboot
+++ b/src/vmm_mad/remotes/vcenter/reboot
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/reconfigure
+++ b/src/vmm_mad/remotes/vcenter/reconfigure
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/reset
+++ b/src/vmm_mad/remotes/vcenter/reset
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/restore
+++ b/src/vmm_mad/remotes/vcenter/restore
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/save
+++ b/src/vmm_mad/remotes/vcenter/save
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/shutdown
+++ b/src/vmm_mad/remotes/vcenter/shutdown
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/snapshot_create
+++ b/src/vmm_mad/remotes/vcenter/snapshot_create
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/snapshot_delete
+++ b/src/vmm_mad/remotes/vcenter/snapshot_delete
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/snapshot_revert
+++ b/src/vmm_mad/remotes/vcenter/snapshot_revert
@@ -26,7 +26,10 @@ else
     GEMS_LOCATION     ||= ONE_LOCATION + '/share/gems'
 end
 
-Gem.use_paths(GEMS_LOCATION) if File.directory?(GEMS_LOCATION)
+if File.directory?(GEMS_LOCATION)
+    Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
+end
 
 $LOAD_PATH << RUBY_LIB_LOCATION
 $LOAD_PATH << File.dirname(__FILE__)

--- a/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
+++ b/src/vmm_mad/remotes/vcenter/vcenter_driver.rb
@@ -38,6 +38,7 @@ ENV['LANG'] = 'C'
 
 if File.directory?(GEMS_LOCATION)
     Gem.use_paths(GEMS_LOCATION)
+    $LOAD_PATH.reject! {|l| l =~ /(vendor|site)_ruby/ }
 end
 
 $LOAD_PATH << LIB_LOCATION + '/ruby/vendors/rbvmomi/lib'


### PR DESCRIPTION
Remove vendor_ruby and site_ruby directories from $LOAD_PATH, so
that distribution gems installed directly into loadable path
without need to use rubygems are not loaded by require.