### PR TITLE
F #1473: Add oneadmin's SSH config

### DIFF
--- a/share/pkgs/ssh/config
+++ b/share/pkgs/ssh/config
@@ -1,4 +1,4 @@
-# Default configuration placed by opennebula-common
+# Initial default configuration placed by opennebula-common
 # package. Latest default configurations are located in
 # /usr/share/one/ssh/.
 

--- a/share/pkgs/ssh/config
+++ b/share/pkgs/ssh/config
@@ -1,15 +1,9 @@
-# This file is provided by 'opennebula-common' package
-
-# workaround for SSH version <7.6
-Match !exec "ssh-keygen -F %h"
-  StrictHostKeyChecking no
-  ControlMaster auto
-  ControlPath ~/.ssh-%C
-  ControlPersist 5s
+# This file is provided by 'opennebula-common' package in:
+#   /usr/share/one/ssh/
 
 Host *
   # since SSH version 7.6+
-  # StrictHostKeyChecking accept-new
+  StrictHostKeyChecking accept-new
   ControlMaster auto
   ControlPath ~/.ssh-%C
   ControlPersist 5s

--- a/share/pkgs/ssh/config
+++ b/share/pkgs/ssh/config
@@ -3,7 +3,7 @@
 # /usr/share/one/ssh/.
 
 #####################################################################
-# WARNING: This configuration file is for OpenSSH 7.6 and newer!
+# WARNING: This configuration file is ONLY for OpenSSH 7.6 and newer!
 #####################################################################
 
 Host *

--- a/share/pkgs/ssh/config
+++ b/share/pkgs/ssh/config
@@ -1,0 +1,16 @@
+# This file is provided by 'opennebula-common' package
+
+# workaround for SSH version <7.6
+Match !exec "ssh-keygen -F %h"
+  StrictHostKeyChecking no
+  ControlMaster auto
+  ControlPath ~/.ssh-%C
+  ControlPersist 5s
+
+Host *
+  # since SSH version 7.6+
+  # StrictHostKeyChecking accept-new
+  ControlMaster auto
+  ControlPath ~/.ssh-%C
+  ControlPersist 5s
+

--- a/share/pkgs/ssh/config
+++ b/share/pkgs/ssh/config
@@ -1,5 +1,10 @@
-# This file is provided by 'opennebula-common' package in:
-#   /usr/share/one/ssh/
+# Default configuration placed by opennebula-common
+# package. Latest default configurations are located in
+# /usr/share/one/ssh/.
+
+#####################################################################
+# WARNING: This configuration file is for OpenSSH 7.6 and newer!
+#####################################################################
 
 Host *
   # since SSH version 7.6+
@@ -7,4 +12,3 @@ Host *
   ControlMaster auto
   ControlPath ~/.ssh-%C
   ControlPersist 5s
-

--- a/share/pkgs/ssh/config-7.6+
+++ b/share/pkgs/ssh/config-7.6+
@@ -1,0 +1,9 @@
+# This file is provided by 'opennebula-common' package
+
+Host *
+  # since SSH version 7.6+
+  StrictHostKeyChecking accept-new
+  ControlMaster auto
+  ControlPath ~/.ssh-%C
+  ControlPersist 5s
+

--- a/share/pkgs/ssh/config-7.6+
+++ b/share/pkgs/ssh/config-7.6+
@@ -1,9 +1,0 @@
-# This file is provided by 'opennebula-common' package
-
-Host *
-  # since SSH version 7.6+
-  StrictHostKeyChecking accept-new
-  ControlMaster auto
-  ControlPath ~/.ssh-%C
-  ControlPersist 5s
-

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -1,8 +1,17 @@
-# This file is provided by 'opennebula-common' package in:
-#   /usr/share/one/ssh/
+# Default configuration placed by opennebula-common
+# package. Latest default configurations are located in
+# /usr/share/one/ssh/.
 
-# workaround for SSH version <7.6 which does not support:
+#####################################################################
+# WARNING: This configuration file is ONLY for OpenSSH before 7.6!
+#####################################################################
+
+# Workaround for OpenSSH version <7.6 which does not support:
 #   StrictHostKeyChecking accept-new
+#
+# We check if remote host key is not already in the known hosts and
+# if NOT, we expect this is the very first access and silently accept
+# the key. All other accesses already use strict host key checking.
 Match !exec "ssh-keygen -F %h"
   StrictHostKeyChecking no
   ControlMaster auto
@@ -14,4 +23,3 @@ Host *
   ControlMaster auto
   ControlPath ~/.ssh-%C
   ControlPersist 5s
-

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -1,4 +1,4 @@
-# Default configuration placed by opennebula-common
+# Initial default configuration placed by opennebula-common
 # package. Latest default configurations are located in
 # /usr/share/one/ssh/.
 

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -3,7 +3,7 @@
 # /usr/share/one/ssh/.
 
 #####################################################################
-# WARNING: This configuration file is ONLY for OpenSSH before 7.6!
+# WARNING: This configuration file is for OpenSSH before 7.6!
 #####################################################################
 
 # Workaround for OpenSSH version <7.6 which does not support:

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -1,0 +1,17 @@
+# This file is provided by 'opennebula-common' package in:
+#   /usr/share/one/ssh/
+
+# workaround for SSH version <7.6 which does not support:
+#   StrictHostKeyChecking accept-new
+Match !exec "ssh-keygen -F %h"
+  StrictHostKeyChecking no
+  ControlMaster auto
+  ControlPath ~/.ssh-%C
+  ControlPersist 5s
+
+Host *
+  StrictHostKeyChecking yes
+  ControlMaster auto
+  ControlPath ~/.ssh-%C
+  ControlPersist 5s
+

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -10,8 +10,8 @@
 #   StrictHostKeyChecking accept-new
 #
 # We check if remote host key is not already in the known hosts and
-# if NOT, we expect this is the very first access and silently accept
-# the key. All other accesses already use strict host key checking.
+# if NOT, we expect this is the very first access and accept the key.
+# All further accesses already use strict host key checking.
 Match !exec "ssh-keygen -F %h"
   StrictHostKeyChecking no
   ControlMaster auto

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -12,7 +12,7 @@
 # We check if remote host key is not already in the known hosts and
 # if NOT, we expect this is the very first access and accept the key.
 # All further accesses already use strict host key checking.
-Match !exec "ssh-keygen -F %h || ssh-keygen -F %h -f /etc/ssh/ssh_known_hosts"
+Match !exec "ssh-keygen -F %h 2>/dev/null || ssh-keygen -F %h -f /etc/ssh/ssh_known_hosts 2>/dev/null"
   StrictHostKeyChecking no
   ControlMaster auto
   ControlPath ~/.ssh-%C

--- a/share/pkgs/ssh/config-pre7.6
+++ b/share/pkgs/ssh/config-pre7.6
@@ -12,7 +12,7 @@
 # We check if remote host key is not already in the known hosts and
 # if NOT, we expect this is the very first access and accept the key.
 # All further accesses already use strict host key checking.
-Match !exec "ssh-keygen -F %h"
+Match !exec "ssh-keygen -F %h || ssh-keygen -F %h -f /etc/ssh/ssh_known_hosts"
   StrictHostKeyChecking no
   ControlMaster auto
   ControlPath ~/.ssh-%C

--- a/src/mad/ruby/ssh_stream.rb
+++ b/src/mad/ruby/ssh_stream.rb
@@ -189,7 +189,7 @@ class SshStream
 
     def ssh_cmd
         if @forward
-            SSH_CMD + ' -o ForwardAgent=yes'
+            SSH_CMD + ' -o ForwardAgent=yes -o ControlMaster=no -o ControlPath=none'
         else
             SSH_CMD
         end

--- a/src/mad/sh/scripts_common.sh
+++ b/src/mad/sh/scripts_common.sh
@@ -46,10 +46,10 @@ READLINK=${READLINK:-readlink}
 RM=${RM:-rm}
 CP=${CP:-cp}
 SCP=${SCP:-scp}
-SCP_FWD=${SCP_FWD:-scp -o ForwardAgent=yes}
+SCP_FWD=${SCP_FWD:-scp -o ForwardAgent=yes -o ControlMaster=no -o ControlPath=none}
 SED=${SED:-sed}
 SSH=${SSH:-ssh}
-SSH_FWD=${SSH_FWD:-ssh -o ForwardAgent=yes}
+SSH_FWD=${SSH_FWD:-ssh -o ForwardAgent=yes -o ControlMaster=no -o ControlPath=none}
 SUDO=${SUDO:-sudo -n}
 SYNC=${SYNC:-sync}
 TAR=${TAR:-tar}


### PR DESCRIPTION
- add two configs for OpenSSH <7.6 and >=7.6
- enable SSH session sharing via master socket
- disable SSH session sharing when ssh-agent is forwarded

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>