### PR TITLE
F #4669: QoL scheduling for LXD apps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -417,6 +417,7 @@ VAR_DIRS="$VAR_LOCATION/remotes \
           $VAR_LOCATION/remotes/market/http \
           $VAR_LOCATION/remotes/market/one \
           $VAR_LOCATION/remotes/market/s3 \
+          $VAR_LOCATION/remotes/market/common \
           $VAR_LOCATION/remotes/market/linuxcontainers \
           $VAR_LOCATION/remotes/market/turnkeylinux \
           $VAR_LOCATION/remotes/datastore/iscsi_libvirt \
@@ -621,6 +622,7 @@ INSTALL_FILES=(
     MARKETPLACE_DRIVER_ETC_HTTP_SCRIPTS:$VAR_LOCATION/remotes/etc/market/http
     MARKETPLACE_DRIVER_ONE_SCRIPTS:$VAR_LOCATION/remotes/market/one
     MARKETPLACE_DRIVER_S3_SCRIPTS:$VAR_LOCATION/remotes/market/s3
+    MARKETPLACE_DRIVER_COMMON_SCRIPTS:$VAR_LOCATION/remotes/market/common
     MARKETPLACE_DRIVER_LXC_SCRIPTS:$VAR_LOCATION/remotes/market/linuxcontainers
     MARKETPLACE_DRIVER_TK_SCRIPTS:$VAR_LOCATION/remotes/market/turnkeylinux
     IPAM_DRIVER_DUMMY_SCRIPTS:$VAR_LOCATION/remotes/ipam/dummy
@@ -1868,6 +1870,8 @@ MARKETPLACE_DRIVER_S3_SCRIPTS="src/market_mad/remotes/s3/import \
             src/market_mad/remotes/s3/delete \
             src/market_mad/remotes/s3/monitor \
             src/market_mad/remotes/s3/S3.rb"
+
+MARKETPLACE_DRIVER_COMMON_SCRIPTS="src/market_mad/remotes/common/lxd.rb"
 
 MARKETPLACE_DRIVER_LXC_SCRIPTS="src/market_mad/remotes/linuxcontainers/import \
             src/market_mad/remotes/linuxcontainers/delete \

--- a/src/market_mad/remotes/common/lxd.rb
+++ b/src/market_mad/remotes/common/lxd.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/ruby
+
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2019, OpenNebula Project, OpenNebula Systems                #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+# -------------------------------------------------------------------------- #
+
+# Utilities for LXD based marketplaces
+module LXDMarket
+
+    class << self
+
+        # TODO: Make configurable
+        def template
+            unindent(<<-EOS)
+        HYPERVISOR = \"lxd\"
+        SCHED_REQUIREMENTS = \"HYPERVISOR=\\\"lxd\\\"\"
+        CPU = \"1\"
+        MEMORY = \"768\"
+        LXD_SECURITY_PRIVILEGED = \"true\"
+        GRAPHICS = [
+            LISTEN  =\"0.0.0.0\",
+            TYPE  =\"vnc\"
+        ]
+        CONTEXT = [
+            NETWORK  =\"YES\",
+            SSH_PUBLIC_KEY  =\"$USER[SSH_PUBLIC_KEY]\",
+            SET_HOSTNAME  =\"$NAME\"
+        ]"
+            EOS
+        end
+
+        def unindent(str)
+            m = str.match(/^(\s*)/)
+            spaces = m[1].size
+            str.gsub!(/^ {#{spaces}}/, '')
+        end
+
+    end
+
+end

--- a/src/market_mad/remotes/linuxcontainers/monitor
+++ b/src/market_mad/remotes/linuxcontainers/monitor
@@ -24,6 +24,8 @@ require 'rexml/document'
 require 'time'
 require 'digest/md5'
 
+require_relative '../common/lxd'
+
 #-------------------------------------------------------------------------------
 #
 #-------------------------------------------------------------------------------
@@ -41,22 +43,6 @@ class LinuxContainersMarket
         :tested_apps => %w[alpine centos debian ubuntu fedora devuan],
         :skip_untested => 'yes'
     }
-
-    # TODO: Make configurable
-    TEMPLATE = "
-HYPERVISOR = \"lxd\"
-CPU = \"1\"
-MEMORY = \"768\"
-LXD_SECURITY_PRIVILEGED = \"yes\"
-GRAPHICS = [
-    LISTEN  =\"0.0.0.0\",
-    TYPE  =\"vnc\"
-]
-CONTEXT = [
-    NETWORK  =\"YES\",
-    SSH_PUBLIC_KEY  =\"$USER[SSH_PUBLIC_KEY]\",
-    SET_HOSTNAME  =\"$NAME\"
-]"
 
     #---------------------------------------------------------------------------
     # Configuration varibales
@@ -170,7 +156,8 @@ CONTEXT = [
                 tmpl64 = ''
                 print_var(tmpl64, 'DRIVER', 'raw')
 
-                data = { 'APPTEMPLATE64' => tmpl64, 'VMTEMPLATE64' => TEMPLATE }
+                data = { 'APPTEMPLATE64' => tmpl64,
+                         'VMTEMPLATE64' => LXDMarket.template }
                 data.each do |key, val|
                     print_var(tmpl, key, Base64.strict_encode64(val))
                 end

--- a/src/market_mad/remotes/turnkeylinux/monitor
+++ b/src/market_mad/remotes/turnkeylinux/monitor
@@ -41,11 +41,7 @@ require 'rexml/document'
 require 'nokogiri'
 require 'digest/md5'
 
-def unindent(str)
-    m = str.match(/^(\s*)/)
-    spaces = m[1].size
-    str.gsub!(/^ {#{spaces}}/, '')
-end
+require_relative '../common/lxd'
 
 #-------------------------------------------------------------------------------
 #  This class is used to query the TurnkeyLinux repository
@@ -63,22 +59,6 @@ class TurnkeyLinux
         :format   => 'raw',
         :agent    => 'OpenNebula'
     }
-
-    TEMPLATE = unindent(<<-EOS)
-        HYPERVISOR = \"lxd\"
-        CPU = \"1\"
-        MEMORY = \"768\"
-        LXD_SECURITY_PRIVILEGED = \"true\"
-        GRAPHICS = [
-            LISTEN  =\"0.0.0.0\",
-            TYPE  =\"vnc\"
-        ]
-        CONTEXT = [
-            NETWORK  =\"YES\",
-            SSH_PUBLIC_KEY  =\"$USER[SSH_PUBLIC_KEY]\",
-            SET_HOSTNAME  =\"$NAME\"
-        ]"
-    EOS
 
     #---------------------------------------------------------------------------
     # Configuration varibales
@@ -185,7 +165,8 @@ class TurnkeyLinux
             tmpl64 = ''
             print_var(tmpl64, 'DRIVER', 'raw')
 
-            data = { 'APPTEMPLATE64' => tmpl64, 'VMTEMPLATE64' => TEMPLATE }
+            data = { 'APPTEMPLATE64' => tmpl64,
+                     'VMTEMPLATE64' => LXDMarket.template }
             data.each do |key, val|
                 print_var(tmpl, key, Base64.strict_encode64(val))
             end


### PR DESCRIPTION
- Added a lib for LXD markets. ATM, generates the template, but there is a lot of repeated code in turnkey and linuxcontainers.org market that can be pushed onto the lib and called as functions.

- Added SCHED_REQUIREMENTS to the template Apps

Closes #4669 
Merge with https://github.com/OpenNebula/docs/pull/1116