### PR TITLE
F #4089: Fix Turnkey link

### DIFF
--- a/src/market_mad/remotes/turnkeylinux/monitor
+++ b/src/market_mad/remotes/turnkeylinux/monitor
@@ -157,7 +157,7 @@ class TurnkeyLinux
                 'REGTIME'     => regt,
                 'SIZE'        => @options[:sizemb],
                 'DESCRIPTION' => "Based on #{image[0]}-#{image[1]}",
-                'LINK' => "#{@options[:url]}/#{@options[:platform]}/#{path}"
+                'LINK'        => "#{@options[:url]}/#{@options[:platform]}"
             }
 
             tmpl = ''


### PR DESCRIPTION
Fixes Turnkey monitoring fail

```
9JRD48VUlEPjA8L1VJRD48R0lEPjA8L0dJRD48VU5BTUU+b25lYWRtaW48L1VOQU1FPjxHTkFNRT5vbmVhZG1pbjwvR05BTUU+PE5BTUU+VHVybktleSBMaW51eCBDb250YWluZXJzPC9OQU1FPjxNQVJLRVRfTUFEPjwhW0NEQVRBW3R1cm5rZXlsaW51eF1dPjwvTUFSS0VUX01BRD48Wk9ORV9JRD48IVtDREFUQVswXV0+PC9aT05FX0lEPjxUT1RBTF9NQj4wPC9UT1RBTF9NQj48RlJFRV9NQj4wPC9GUkVFX01CPjxVU0VEX01CPjA8L1VTRURfTUI+PE1BUktFVFBMQUNFQVBQUz48L01BUktFVFBMQUNFQVBQUz48UEVSTUlTU0lPTlM+PE9XTkVSX1U+MTwvT1dORVJfVT48T1dORVJfTT4xPC9PV05FUl9NPjxPV05FUl9BPjE8L09XTkVSX0E+PEdST1VQX1U+MTwvR1JPVVBfVT48R1JPVVBfTT4wPC9HUk9VUF9NPjxHUk9VUF9BPjA8L0dST1VQX0E+PE9USEVSX1U+MTwvT1RIRVJfVT48T1RIRVJfTT4wPC9PVEhFUl9NPjxPVEhFUl9BPjA8L09USEVSX0E+PC9QRVJNSVNTSU9OUz48VEVNUExBVEU+PERFU0NSSVBUSU9OPjwhW0NEQVRBW1R1cm5LZXkgbGludXggaXMgYSBmcmVlIHNvZnR3YXJlIHJlcG9zaXRvcnkgYmFzZWQgb24gRGViaWFuIGltYWdlcyBob3N0ZWQgYXQgdHVybmtleWxpbnV4Lm9yZ11dPjwvREVTQ1JJUFRJT04+PE1BUktFVF9NQUQ+PCFbQ0RBVEFbdHVybmtleWxpbnV4XV0+PC9NQVJLRVRfTUFEPjwvVEVNUExBVEU+PC9NQVJLRVRQTEFDRT48L01BUktFVF9EUklWRVJfQUNUSU9OX0RBVEE+ 2
Mon May 18 18:48:39 2020 [Z0][MKP][I]: /var/lib/one/remotes/market/turnkeylinux/monitor:160:in `block in appliances': undefined local variable or method `path' for #<TurnkeyLinux:0x0000564f0e843a10> (NameError)
```

Introduced on https://github.com/OpenNebula/one/commit/acf6454c6e616780cfa213be44173800a89bcc6c