### PR TITLE
M #-: Add IP Spoofing support for NIC_ALIAS

### DIFF
--- a/src/vmm_mad/exec/one_vmm_exec.rb
+++ b/src/vmm_mad/exec/one_vmm_exec.rb
@@ -970,7 +970,7 @@ class ExecDriver < VirtualMachineDriver
                     ]
                 }
             ]
-        elsif nic_alias && external
+        elsif nic_alias
             steps = [
                 # Execute pre-attach networking setup
                 {
@@ -1070,6 +1070,15 @@ class ExecDriver < VirtualMachineDriver
                 {
                     :driver       => :vnm,
                     :action       => :clean
+                }
+            ]
+        elsif nic_alias
+            steps = [
+                # Execute post-boot networking setup
+                {
+                    :driver       => :vnm,
+                    :action       => :post,
+                    :parameters   => [:deploy_id]
                 }
             ]
         else

--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -334,6 +334,14 @@ module SGIPTables
             vars[:set_sg_out] = "#{vars[:chain]}-#{sg_id}-o"
         end
 
+        vars[:nic_aliases] = []
+
+        unless nic[:alias_ids].nil?
+            nic[:alias_ids].split(',').each do |id|
+                vars[:nic_aliases] << vm.nic_alias(id)
+            end
+        end
+
         vars
     end
 
@@ -426,6 +434,10 @@ module SGIPTables
 
             [:ip, :vrouter_ip].each do |key|
                 ipv4s << nic[key] if !nic[key].nil? && !nic[key].empty?
+                vars[:nic_aliases].each do |nic_alias|
+                    ipv4s << nic_alias[key] \
+                        if !nic_alias[key].nil? && !nic_alias[key].empty?
+                end
             end
 
             if !ipv4s.empty?
@@ -453,6 +465,10 @@ module SGIPTables
 
             [:ip6, :ip6_global, :ip6_link, :ip6_ula].each do |key|
                 ipv6s << nic[key] if !nic[key].nil? && !nic[key].empty?
+                vars[:nic_aliases].each do |nic_alias|
+                    ipv6s << nic_alias[key] \
+                        if !nic_alias[key].nil? && !nic_alias[key].empty?
+                end
             end
 
             if !ipv6s.empty?

--- a/src/vnm_mad/remotes/lib/sg_driver.rb
+++ b/src/vnm_mad/remotes/lib/sg_driver.rb
@@ -79,10 +79,18 @@ module VNMMAD
             SGIPTables.global_bootstrap
 
             attach_nic_id = @vm['TEMPLATE/NIC[ATTACH="YES"]/NIC_ID'] if !do_all
+            attach_nic_alias_id = nil
+            if !do_all
+                attach_nic_alias_id = @vm['TEMPLATE/NIC_ALIAS[ATTACH="YES"]/NIC_ID']
+                attach_nic_alias_parent_id =
+                    @vm["TEMPLATE/NIC_ALIAS[NIC_ID=#{attach_nic_alias_id}]/PARENT_ID"]
+            end
 
             # Process the rules
             process do |nic|
                 next if attach_nic_id && attach_nic_id != nic[:nic_id]
+                next if attach_nic_alias_id && \
+                        attach_nic_alias_parent_id != nic[:nic_id]
 
                 if nic[:security_groups].nil?
                     nic[:security_groups] = "0"
@@ -123,9 +131,17 @@ module VNMMAD
 
             begin
                 attach_nic_id = @vm['TEMPLATE/NIC[ATTACH="YES"]/NIC_ID'] if !do_all
+                attach_nic_alias_id = nil
+                if !do_all
+                    attach_nic_alias_id = @vm['TEMPLATE/NIC_ALIAS[ATTACH="YES"]/NIC_ID']
+                    attach_nic_alias_parent_id =
+                        @vm["TEMPLATE/NIC_ALIAS[NIC_ID=#{attach_nic_alias_id}]/PARENT_ID"]
+                end
 
                 @vm.nics.each do |nic|
                     next if attach_nic_id && attach_nic_id != nic[:nic_id]
+                    next if attach_nic_alias_id && \
+                            attach_nic_alias_parent_id != nic[:nic_id]
 
                     SGIPTables.nic_deactivate(@vm, nic)
                 end


### PR DESCRIPTION
Add IP addresses of a NIC_ALIAS to the corresponding ipset if the parent
NIC belongs to the "Bridged & Security Groups" network mode (fw) when a
VM is instantiated or a NIC_ALIAS attached.

Signed-off-by: Ricardo Diaz <rdiaz@opennebula.io>