### PR TITLE
B #4793: Update tm_mad/shared/monitor

### DIFF
--- a/src/tm_mad/shared/monitor
+++ b/src/tm_mad/shared/monitor
@@ -116,7 +116,7 @@ if [ $MONITOR_VM_DISKS -eq 1 ]; then
 
     monitor_b64="\$(echo \$monitor | ruby -e "require 'zlib';\
         puts Zlib::Deflate.deflate(STDIN.read)" | base64 -w 0)"
-    echo MONITOR_VM SUCCESS 0 \$monitor_b64 | nc -u -w0 127.0.0.1 4124
+    echo MONITOR_VM SUCCESS 0 \$monitor_b64 | nc -u -w${NETCAT_WAIT:-0} "${MONITOR_ADDRESS:-127.0.0.1}" 4124
 fi
 
 EOF


### PR DESCRIPTION
MONITOR_ADDRESS could differ from _127.0.0.1_ in _/etc/monitord.conf_
The default netcat (NC) on centos7.8 is _nmap-ncat_ which do not accept '0' for _--wait_
(_Ncat: Invalid -w timeout (must be greater than 0). QUITTING._)

The proposed change defines them as shell variables, not sure where to configure them to match the configuration in /etc/monitord.conf, though.

Also, needs a dependency on 'nc' in the packaging...

Signed-off-by: Anton Todorov <a.todorov@storpool.com>