### PR TITLE
M #-: Configurable timeout for SQLite DB

### DIFF
--- a/include/SqliteDB.h
+++ b/include/SqliteDB.h
@@ -45,7 +45,7 @@ class SqliteDB : public SqlDB
 {
 public:
 
-    SqliteDB(const string& db_name);
+    SqliteDB(const string& db_name, int timeout);
 
     ~SqliteDB();
 
@@ -107,7 +107,7 @@ class SqliteDB : public SqlDB
 {
 public:
 
-    SqliteDB(const string& db_name)
+    SqliteDB(const string& db_name, int timeout)
     {
         throw runtime_error("Aborting oned, Sqlite support not compiled!");
     }

--- a/share/etc/oned.conf
+++ b/share/etc/oned.conf
@@ -36,6 +36,8 @@
 #   compare_binary: (mysql) compare strings using BINARY clause
 #                   makes name searches case sensitive.
 #   encoding: charset to use for the db connections
+#   timeout : (sqlite) timeout in ms for acquiring lock to DB,
+#             should be at least 100 ms
 #
 #  VNC_PORTS: VNC port pool for automatic VNC port assignment, if possible the
 #  port will be set to ``START`` + ``VMID``
@@ -71,7 +73,8 @@ MONITORING_INTERVAL_DB_UPDATE = 0
 SCRIPTS_REMOTE_DIR=/var/tmp/one
 
 
-DB = [ BACKEND = "sqlite" ]
+DB = [ BACKEND = "sqlite",
+       TIMEOUT = 2500 ]
 
 # Sample configuration for MySQL
 # DB = [ BACKEND = "mysql",

--- a/src/monitor/src/monitor/Monitor.cc
+++ b/src/monitor/src/monitor/Monitor.cc
@@ -100,7 +100,10 @@ void Monitor::start()
 
     if (db_backend == "sqlite")
     {
-        sqlDB.reset(new SqliteDB(get_var_location() + "one.db"));
+        int    timeout;
+        _db->vector_value("TIMEOUT", timeout, 2500);
+
+        sqlDB.reset(new SqliteDB(get_var_location() + "one.db", timeout));
     }
     else
     {

--- a/src/nebula/Nebula.cc
+++ b/src/nebula/Nebula.cc
@@ -389,6 +389,7 @@ void Nebula::start(bool bootstrap_only)
         string db_name;
         string encoding;
         string compare_binary;
+        int    timeout;
         int    connections;
 
         const VectorAttribute * _db = nebula_configuration->get("DB");
@@ -404,12 +405,13 @@ void Nebula::start(bool bootstrap_only)
             _db->vector_value<string>("DB_NAME", db_name, "opennebula");
             _db->vector_value<string>("ENCODING", encoding, "");
             _db->vector_value<string>("COMPARE_BINARY", compare_binary, "NO");
+            _db->vector_value("TIMEOUT", timeout, 2500);
             _db->vector_value("CONNECTIONS", connections, 25);
         }
 
         if ( db_backend_type == "sqlite" )
         {
-            db_backend = new SqliteDB(var_location + "one.db");
+            db_backend = new SqliteDB(var_location + "one.db", timeout);
         }
         else if ( db_backend_type == "mysql" )
         {


### PR DESCRIPTION
Not sure if it's still time to make changes to oned.conf for 5.12. If not, I can remove the configuration and use only the sqlite3_busy_timeout() for setting timeout.
Default value 2500 is same as in old SQLITE_BUSY handling, but works much better. I don't have any SQLITE_BUSY error even with 100 ms timeout