### PR TITLE
M #-: vCenter IM process check fix

### DIFF
--- a/src/im_mad/im_exec/one_im_sh
+++ b/src/im_mad/im_exec/one_im_sh
@@ -39,7 +39,7 @@ if [ "${BASH_ARGV##* }" = "vcenter" ]; then
     VMON_PATH="$VAR_LOCATION/remotes/im/lib/vcenter_monitor.rb"
 
     # Sanitize previous instances
-    VMON_PIDS=$(ps axuww | grep "ruby $VMON_PATH" | grep -v grep | awk '{print $2}')
+    VMON_PIDS=$(ps axuww | grep "ruby[^ ]* $VMON_PATH" | grep -v grep | awk '{print $2}')
 
     if [ -n "$VMON_PIDS" ]; then
         kill $VMON_PIDS
@@ -54,7 +54,7 @@ if [ "${BASH_ARGV##* }" = "vcenter" ]; then
 
     sleep 3
 
-    VMON_PIDS=$(ps axuww | grep "ruby $VMON_PATH" | grep -v grep | awk '{print $2}')
+    VMON_PIDS=$(ps axuww | grep "ruby[^ ]* $VMON_PATH" | grep -v grep | awk '{print $2}')
 
     if [ -z "$VMON_PIDS" ]; then
         echo "Cannot start vcenter_monitor service"


### PR DESCRIPTION
Some platforms has "ruby" just a wrapper to particular interpreter:
```
\_ /usr/lib/one/mads/onemonitord -c monitord.conf
    \_ /usr/bin/ruby-mri /usr/lib/one/mads/one_im_exec.rb -r 3 -t 15 -w 90 firecracker
    \_ /usr/bin/ruby-mri /usr/lib/one/mads/one_im_exec.rb -r 3 -t 15 -w 90 kvm
    \_ /usr/bin/ruby-mri /usr/lib/one/mads/one_im_exec.rb -r 3 -t 15 -w 90 lxd
    \_ /usr/bin/ruby-mri /usr/lib/one/mads/one_im_exec.rb -l -c -t 15 -r 0 vcenter
        \_ /usr/bin/ruby-mri /var/lib/one/remotes/im/lib/vcenter_monitor.rb
```