### PR TITLE
F #-: Update vmm_exec_kvm defaults

### DIFF
--- a/src/vmm_mad/exec/vmm_exec_kvm.conf
+++ b/src/vmm_mad/exec/vmm_exec_kvm.conf
@@ -32,11 +32,11 @@
 
 #VCPU = 1
 
-OS       = [ arch = "x86_64" ]
+OS       = [ ARCH = "x86_64", MACHINE = "pc" ]
 FEATURES = [ PAE = "no", ACPI = "yes", APIC = "no", HYPERV = "no", GUEST_AGENT = "no",
              VIRTIO_SCSI_QUEUES = "0" ]
 #CPU_MODEL = [ MODEL = "host-passthrough"]
-DISK     = [ driver = "raw" , cache = "none"]
+DISK     = [ DRIVER = "raw", CACHE = "none"]
 
 #NIC     = [ filter = "clean-traffic", model="virtio" ]
 #RAW     = "<devices><serial type=\"pty\"><source path=\"/dev/pts/5\"/><target port=\"0\"/></serial><console type=\"pty\" tty=\"/dev/pts/5\"><source path=\"/dev/pts/5\"/><target port=\"0\"/></console></devices>"


### PR DESCRIPTION
I would suggest enabling `machine = pc` by default for qemu, to avoid situations where it is not possible to migrate virtual machines from ubnutu and centos to another OS, since they has own non standardized machine models defined to use by default, eg:

```bash
# qemu-system-x86_64 -machine help
Supported machines are:
microvm              microvm (i386)
pc-i440fx-zesty      Ubuntu 17.04 PC (i440FX + PIIX, 1996)
pc-i440fx-yakkety    Ubuntu 16.10 PC (i440FX + PIIX, 1996)
pc-i440fx-xenial     Ubuntu 16.04 PC (i440FX + PIIX, 1996)
pc-i440fx-wily       Ubuntu 15.04 PC (i440FX + PIIX, 1996)
pc-i440fx-trusty     Ubuntu 14.04 PC (i440FX + PIIX, 1996)
ubuntu               Ubuntu 20.04 PC (i440FX + PIIX, 1996) (alias of pc-i440fx-focal)
pc-i440fx-focal      Ubuntu 20.04 PC (i440FX + PIIX, 1996) (default)
pc-i440fx-focal-hpb  Ubuntu 20.04 PC (i440FX + PIIX +host-phys-bits=true, 1996)
pc-i440fx-eoan       Ubuntu 19.10 PC (i440FX + PIIX, 1996)
pc-i440fx-eoan-hpb   Ubuntu 19.10 PC (i440FX + PIIX +host-phys-bits=true, 1996)
pc-i440fx-disco      Ubuntu 19.04 PC (i440FX + PIIX, 1996)
pc-i440fx-disco-hpb  Ubuntu 19.04 PC (i440FX + PIIX +host-phys-bits=true, 1996)
pc-i440fx-cosmic     Ubuntu 18.10 PC (i440FX + PIIX, 1996)
pc-i440fx-cosmic-hpb Ubuntu 18.10 PC (i440FX + PIIX +host-phys-bits=true, 1996)
pc-i440fx-bionic     Ubuntu 18.04 PC (i440FX + PIIX, 1996)
pc-i440fx-bionic-hpb Ubuntu 18.04 PC (i440FX + PIIX, +host-phys-bits=true, 1996)
pc-i440fx-artful     Ubuntu 17.10 PC (i440FX + PIIX, 1996)
pc                   Standard PC (i440FX + PIIX, 1996) (alias of pc-i440fx-4.2)
pc-i440fx-4.2        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-4.1        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-4.0        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-3.1        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-3.0        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.9        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.8        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.7        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.6        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.5        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.4        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.3        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.2        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.12       Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.11       Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.10       Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.1        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-2.0        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-1.7        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-1.6        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-1.5        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-1.4        Standard PC (i440FX + PIIX, 1996)
pc-1.3               Standard PC (i440FX + PIIX, 1996)
pc-1.2               Standard PC (i440FX + PIIX, 1996)
pc-1.1               Standard PC (i440FX + PIIX, 1996)
pc-1.0               Standard PC (i440FX + PIIX, 1996)
pc-0.15              Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-0.14              Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-0.13              Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-0.12              Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-q35-zesty         Ubuntu 17.04 PC (Q35 + ICH9, 2009)
pc-q35-yakkety       Ubuntu 16.10 PC (Q35 + ICH9, 2009)
pc-q35-xenial        Ubuntu 16.04 PC (Q35 + ICH9, 2009)
ubuntu-q35           Ubuntu 20.04 PC (Q35 + ICH9, 2009) (alias of pc-q35-focal)
pc-q35-focal         Ubuntu 20.04 PC (Q35 + ICH9, 2009)
pc-q35-focal-hpb     Ubuntu 20.04 PC (Q35 + ICH9, +host-phys-bits=true, 2009)
pc-q35-eoan          Ubuntu 19.10 PC (Q35 + ICH9, 2009)
pc-q35-eoan-hpb      Ubuntu 19.10 PC (Q35 + ICH9, +host-phys-bits=true, 2009)
pc-q35-disco         Ubuntu 19.04 PC (Q35 + ICH9, 2009)
pc-q35-disco-hpb     Ubuntu 19.04 PC (Q35 + ICH9, +host-phys-bits=true, 2009)
pc-q35-cosmic        Ubuntu 18.10 PC (Q35 + ICH9, 2009)
pc-q35-cosmic-hpb    Ubuntu 18.10 PC (Q35 + ICH9, +host-phys-bits=true, 2009)
pc-q35-bionic        Ubuntu 18.04 PC (Q35 + ICH9, 2009)
pc-q35-bionic-hpb    Ubuntu 18.04 PC (Q35 + ICH9, +host-phys-bits=true, 2009)
pc-q35-artful        Ubuntu 17.10 PC (Q35 + ICH9, 2009)
q35                  Standard PC (Q35 + ICH9, 2009) (alias of pc-q35-4.2)
pc-q35-4.2           Standard PC (Q35 + ICH9, 2009)
pc-q35-4.1           Standard PC (Q35 + ICH9, 2009)
pc-q35-4.0.1         Standard PC (Q35 + ICH9, 2009)
pc-q35-4.0           Standard PC (Q35 + ICH9, 2009)
pc-q35-3.1           Standard PC (Q35 + ICH9, 2009)
pc-q35-3.0           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.9           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.8           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.7           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.6           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.5           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.4           Standard PC (Q35 + ICH9, 2009)
pc-q35-2.12          Standard PC (Q35 + ICH9, 2009)
pc-q35-2.11          Standard PC (Q35 + ICH9, 2009)
pc-q35-2.10          Standard PC (Q35 + ICH9, 2009)
isapc                ISA-only PC
none                 empty machine
```