### PR TITLE
B-4921: GOCA -small fixes on VM disk snapshot methods

### DIFF
--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -332,9 +332,13 @@ func (vc *VMDiskController) Saveas(imageName, imageType string, snapID int) (int
 }
 
 // SnapshotCreate will create a snapshot of the disk image
-func (vc *VMDiskController) SnapshotCreate(description string) error {
-	_, err := vc.c.Client.Call("one.vm.disksnapshotcreate", vc.entityID, vc.ID, description)
-	return err
+func (vc *VMDiskController) SnapshotCreate(description string) (int, error) {
+	response, err := vc.c.Client.Call("one.vm.disksnapshotcreate", vc.entityID, vc.ID, description)
+	if err != nil {
+		return -1, err
+	}
+
+	return response.BodyInt(), err
 }
 
 // SnapshotDelete will delete a snapshot

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -325,7 +325,7 @@ func (vc *VMController) Resize(template string, enforce bool) error {
 func (vc *VMDiskController) Saveas(imageName, imageType string, snapID int) (int, error) {
 	response, err := vc.c.Client.Call("one.vm.disksaveas", vc.entityID, vc.ID, imageName, imageType, snapID)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	return response.BodyInt(), nil


### PR DESCRIPTION
Fix two issues:
- methods that create resources should returns -1 as an error ID
- one.vm.disksnapshotcreate should return the ID of the new snapshot