### PR TITLE
B #5000: RAW data should accept several <devices /> entries

### DIFF
--- a/share/schemas/libvirt/domaincommon.rng
+++ b/share/schemas/libvirt/domaincommon.rng
@@ -63,9 +63,9 @@
         <optional>
           <ref name="idmap"/>
         </optional>
-        <optional>
+        <zeroOrMore>
           <ref name="devices"/>
-        </optional>
+        </zeroOrMore>
         <zeroOrMore>
           <ref name="seclabel"/>
         </zeroOrMore>


### PR DESCRIPTION
* share/schemas/libvirt/domaincommon.rng: make the element `devices` a `zeroOrMore` element.