### PR TITLE
F #3124: Add DROP_CACHES option to kvmrc

### DIFF
--- a/share/pkgs/CentOS/opennebula.sudoers
+++ b/share/pkgs/CentOS/opennebula.sudoers
@@ -10,5 +10,6 @@ Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm
 Cmnd_Alias ONE_CEPH = /usr/bin/rbd
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_HA = /usr/bin/systemctl start opennebula-flow, /usr/bin/systemctl stop opennebula-flow, /usr/bin/systemctl start opennebula-gate, /usr/bin/systemctl stop opennebula-gate, /usr/sbin/service opennebula-flow start, /usr/sbin/service opennebula-flow stop, /usr/sbin/service opennebula-gate start, /usr/sbin/service opennebula-gate stop
+Cmnd_Alias ONE_SYSCTL = /usr/sbin/sysctl vm.drop_caches=1
 
-oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA
+oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA, ONE_SYSCTL

--- a/share/pkgs/Debian7/opennebula.sudoers
+++ b/share/pkgs/Debian7/opennebula.sudoers
@@ -10,5 +10,6 @@ Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm
 Cmnd_Alias ONE_CEPH = /usr/bin/rbd
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_HA = /bin/systemctl start opennebula-flow, /bin/systemctl stop opennebula-flow, /bin/systemctl start opennebula-gate, /bin/systemctl stop opennebula-gate, /usr/sbin/service opennebula-flow start, /usr/sbin/service opennebula-flow stop, /usr/sbin/service opennebula-gate start, /usr/sbin/service opennebula-gate stop
+Cmnd_Alias ONE_SYSCTL = /sbin/sysctl vm.drop_caches=1
 
-oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA
+oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA, ONE_SYSCTL

--- a/share/pkgs/Debian8/opennebula.sudoers
+++ b/share/pkgs/Debian8/opennebula.sudoers
@@ -10,5 +10,6 @@ Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm
 Cmnd_Alias ONE_CEPH = /usr/bin/rbd
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_HA = /bin/systemctl start opennebula-flow, /bin/systemctl stop opennebula-flow, /bin/systemctl start opennebula-gate, /bin/systemctl stop opennebula-gate, /usr/sbin/service opennebula-flow start, /usr/sbin/service opennebula-flow stop, /usr/sbin/service opennebula-gate start, /usr/sbin/service opennebula-gate stop
+Cmnd_Alias ONE_SYSCTL = /sbin/sysctl vm.drop_caches=1
 
-oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA
+oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA, ONE_SYSCTL

--- a/share/pkgs/Ubuntu/opennebula.sudoers
+++ b/share/pkgs/Ubuntu/opennebula.sudoers
@@ -10,5 +10,6 @@ Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm
 Cmnd_Alias ONE_CEPH = /usr/bin/rbd
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_HA = /bin/systemctl start opennebula-flow, /bin/systemctl stop opennebula-flow, /bin/systemctl start opennebula-gate, /bin/systemctl stop opennebula-gate, /usr/sbin/service opennebula-flow start, /usr/sbin/service opennebula-flow stop, /usr/sbin/service opennebula-gate start, /usr/sbin/service opennebula-gate stop
+Cmnd_Alias ONE_SYSCTL = /sbin/sysctl vm.drop_caches=1
 
-oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA
+oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_CEPH, ONE_MARKET, ONE_HA, ONE_SYSCTL

--- a/share/pkgs/openSUSE/opennebula.sudoers
+++ b/share/pkgs/openSUSE/opennebula.sudoers
@@ -9,5 +9,6 @@ Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl
 Cmnd_Alias ONE_XEN = /usr/sbin/xentop, /usr/sbin/xl, /usr/sbin/xm
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_HA = /usr/bin/systemctl start opennebula-flow, /usr/bin/systemctl stop opennebula-flow, /usr/bin/systemctl start opennebula-gate, /usr/bin/systemctl stop opennebula-gate, /sbin/service opennebula-flow start, /sbin/service opennebula-flow stop, /sbin/service opennebula-gate start, /sbin/service opennebula-gate stop
+Cmnd_Alias ONE_SYSCTL = /usr/sbin/sysctl vm.drop_caches=1
 
-oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_MARKET, ONE_HA
+oneadmin ALL=(ALL) NOPASSWD: ONE_MISC, ONE_NET, ONE_LVM, ONE_ISCSI, ONE_OVS, ONE_XEN, ONE_MARKET, ONE_HA, ONE_SYSCTL

--- a/src/vmm_mad/remotes/kvm/deploy
+++ b/src/vmm_mad/remotes/kvm/deploy
@@ -25,6 +25,10 @@ DEP_FILE_LOCATION=$(dirname $DEP_FILE)
 mkdir -p $DEP_FILE_LOCATION
 cat > $DEP_FILE
 
+if [ "x$DROP_CACHES" = "xyes" ]; then
+    sudo sysctl vm.drop_caches=1 >/dev/null
+fi
+
 DATA=`virsh --connect $LIBVIRT_URI create $DEP_FILE`
 
 if [ "x$?" = "x0" ]; then

--- a/src/vmm_mad/remotes/kvm/kvmrc
+++ b/src/vmm_mad/remotes/kvm/kvmrc
@@ -26,6 +26,12 @@ export LIBVIRT_MD_KEY=one
 # Seconds to wait after shutdown until timeout
 export SHUTDOWN_TIMEOUT=300
 
+# Sometimes using writethrough cache may produce 'Cannot allocate memory'
+# errors durting the VM allocation. Uncomment this line to drop caches each
+# time before starting the VM, this would allow to free up memory and guarantee
+# the needed capacity to fit the virtual machine on the host.
+#export DROP_CACHES=yes
+
 # Uncomment this line to force VM cancellation after shutdown timeout
 #export FORCE_DESTROY=yes
 


### PR DESCRIPTION
fixes https://github.com/OpenNebula/one/issues/3124

This is another implementation of https://github.com/OpenNebula/one/pull/3126.
From my experience the method
```
echo 1 > /proc/sys/vm/drop_caches
```
is working much better than
```
echo 1 > /proc/sys/vm/compact_memory
```