### PR TITLE
B #4047: allow resize for disks with snapshots

### DIFF
--- a/src/rm/RequestManagerVirtualMachine.cc
+++ b/src/rm/RequestManagerVirtualMachine.cc
@@ -3248,15 +3248,6 @@ void VirtualMachineDiskResize::request_execute(
         return;
     }
 
-    if ( disk->has_snapshots() )
-    {
-        att.resp_msg = "Cannot resize a disk with snapshots";
-        failure_response(ACTION, att);
-
-        vm->unlock();
-
-        return;
-    }
 
     /* ------------- Get information about the disk and image --------------- */
     bool img_ds_quota, vm_ds_quota;


### PR DESCRIPTION
This change has been tested on Linstor datastore using linstor_un
driver (master). It makes the datastore driver decide whether it
allows resizing of disks which have snapshots. Also, refs #1260.
