### PR TITLE
B #4047: allow resize for disks with snapshots

### DIFF
--- a/src/rm/RequestManagerVirtualMachine.cc
+++ b/src/rm/RequestManagerVirtualMachine.cc
@@ -3250,12 +3250,22 @@ void VirtualMachineDiskResize::request_execute(
 
     if ( disk->has_snapshots() )
     {
-        att.resp_msg = "Cannot resize a disk with snapshots";
-        failure_response(ACTION, att);
+        string st;
+        int ds_id = vm->get_ds_id();
+        Datastore * ds = nd.get_dspool()->get_ro(ds_id);
 
-        vm->unlock();
+        ds->get_template_attribute("ALLOW_DISK_RESIZE_WITH_SNAPSHOT", st);
 
-        return;
+        if ((st.empty() || st == "NO" || st == "no") ||
+            (st != "YES" && st != "yes"))
+        {
+            att.resp_msg = "Driver does not support resizing a disk with snapshots";
+            failure_response(ACTION, att);
+
+            vm->unlock();
+
+            return;
+        }
     }
 
     /* ------------- Get information about the disk and image --------------- */


### PR DESCRIPTION
This patch introduces a TM_MAD_CONF attribute
ALLOW_DISK_RESIZE_WITH_SNAPSHOT which specifies whether the driver
supports resizing of disks if they have snapshots. The attribute value
should be "YES" or "yes" to allow resize operation. Default is to deny
operation if the attribute is not present or is set as "NO" or "no".

+refs: OpenNebula#1260

Signed-off-by: Chirag Anand <anand.chirag@gmail.com>