### PR TITLE
B #5258: Onegate ruby client do not terminate a VM (nor other similar operations)

### DIFF
--- a/share/onegate/onegate
+++ b/share/onegate/onegate
@@ -673,7 +673,7 @@ when "vm"
          "release",
          # Compatibility with 4.x
          "delete",
-         "shutdown",
+         "shutdown"
         if ARGV[2]
             action_hash = {
                 "action" => {


### PR DESCRIPTION
To solve the bug #5258: Onegate ruby client do not terminate a VM (nor other similar operations)