### PR TITLE
Unable to set :memory_dumps to false at vCenter Driver

### DIFF
--- a/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
+++ b/src/vmm_mad/remotes/lib/vcenter_driver/virtual_machine.rb
@@ -3032,7 +3032,7 @@ module VCenterDriver
         # Create a snapshot for the VM
         def create_snapshot(snap_id, snap_name)
             memory_dumps = true
-            memory_dumps = CONFIG[:memory_dumps] if CONFIG[:memory_dumps]
+            memory_dumps = CONFIG[:memory_dumps] unless CONFIG[:memory_dumps].nil?
 
             snapshot_hash = {
                 :name        => snap_id,


### PR DESCRIPTION
Hi, recently we were trying to set `memory_dumps` to `false` for snapshots creation using `/var/lib/one/remotes/etc/vmm/vcenter/vcenterrc`. But found out it doesn't make any effect. And more than that method definition has following lines at the beginning:
```ruby
memory_dumps = true
memory_dumps = CONFIG[:memory_dumps] if CONFIG[:memory_dumps]
```
Which makes no sense, because config value is going to be used only if its `true`.
If that's was `.nil?` check, then maybe my edit would fit.