### PR TITLE
B #5382: Fix Firecracker ignores INITRD

### DIFF
--- a/src/vmm_mad/remotes/lib/firecracker/opennebula_vm.rb
+++ b/src/vmm_mad/remotes/lib/firecracker/opennebula_vm.rb
@@ -153,6 +153,12 @@ class FirecrackerVM < OpenNebulaVM
     def boot_source(hash)
         hash['kernel_image_path'] = 'kernel'
         hash['boot_args'] = @xml['//TEMPLATE/OS/KERNEL_CMD']
+
+        initrd = @xml['//TEMPLATE/OS/INITRD']
+
+        return if (initrd.nil? || initrd.empty?)
+
+        hash['initrd_path'] = File.basename(initrd, '/')
     end
 
     def machine_config(hash)


### PR DESCRIPTION
Check the INITRD attribute in the XML and add initrd_path property to boot-source if it exists.