### PR TITLE
M #-: better English wording

### DIFF
--- a/src/sunstone/public/app/tabs/templates-tab/form-panels/create/wizard-tabs/hybrid/azure.hbs
+++ b/src/sunstone/public/app/tabs/templates-tab/form-panels/create/wizard-tabs/hybrid/azure.hbs
@@ -66,7 +66,7 @@
   <div class="medium-6 columns">
     <label>
       {{tr "Virtual Network name"}}
-      {{{tip (tr "Name of the virtual network, which is already created in Azure. If not given virtual network will be created based on VNET_* attributes below or using defaults.")}}}
+      {{{tip (tr "Name of the virtual network which is already created in Azure. If not given, virtual network will be created based on VNET_* attributes below or using defaults.")}}}
       <input wizard_field="VIRTUAL_NETWORK_NAME" type="text">
     </label>
   </div>


### PR DESCRIPTION
I'm not an English expert, neither a native speaker but a comma `,` before `which` hurts me a lot.
In the opposite, the comma should be present to separate the condition to the action.