### PR TITLE
B #5518: GOCA PCIDevices support 

### DIFF
--- a/src/oca/go/src/goca/schemas/host/host.go
+++ b/src/oca/go/src/goca/schemas/host/host.go
@@ -65,7 +65,7 @@ type Share struct {
 
 	RunningVMs int          `xml:"RUNNING_VMS,omitempty"`
 	Datastores []Datastores `xml:"DATASTORES>DS,omitempty"`
-	PCIDevices interface{}  `xml:"PCI_DEVICES>PCI,omitempty"`
+	PCIDevices []PCIDevices  `xml:"PCI_DEVICES>PCI,omitempty"`
 }
 
 type Datastores struct {
@@ -73,4 +73,22 @@ type Datastores struct {
 	UsedMB  int `xml:"USED_MB,omitempty"`
 	FreeMB  int `xml:"FREE_MB,omitempty"`
 	TotalMB int `xml:"TOTAL_MB,omitempty"`
+}
+
+type PCIDevices struct {
+	Address      string `xml:"ADDRESS,omitempty"`
+	Bus          string `xml:"BUS,omitempty"`
+	Class        string `xml:"CLASS,omitempty"`
+	ClassName    string `xml:"CLASS_NAME,omitempty"`
+	Device       string `xml:"DEVICE,omitempty"`
+	DeviceName   string `xml:"DEVICE_NAME,omitempty"`
+	Domain       string `xml:"DOMAIN,omitempty"`
+	Function     string `xml:"FUNCTION,omitempty"`
+	NumaNode     string `xml:"NUMA_NODE,omitempty"`
+	ShortAddress string `xml:"SHORT_ADDRESS,omitempty"`
+	Slot         string `xml:"SLOT,omitempty"`
+	Type         string `xml:"TYPE,omitempty"`
+	Vendor       string `xml:"VENDOR,omitempty"`
+	VendorName   string `xml:"VENDOR_NAME,omitempty"`
+	VMID         int    `xml:"VMID,omitempty"`
 }


### PR DESCRIPTION
Replaced the empty interface with struct for PCIDevices in GOCA

**pci.rb** uses lspci to gather all fields so they are all strings initially.

In **HostSharePCI.h** some fields are converted to numbers:
```c++
  unsigned int vendor_id;
  unsigned int device_id;
  unsigned int class_id;

  int vmid;
```
        
The remaining fields are of type **VectorAttribute** so could be represented as any compatible type.
       
NumaNode has to be a string because when it is a negative number in sys/.../numa_node file it is converted to the '-' character by **pci.rb**
        
In GOCA when calling ``one.host.info`` Vendor, Class and Device are all hex strings so the default Golang XML unmarshall function can't convert them to the uint type.

Based on this I think the chosen data types are the best fit, additionally it is convenient for debugging to leave the data in the same format as lspci.