### PR TITLE
Stop at the first match for LDAP match_user_regex option

### DIFF
--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -274,6 +274,7 @@ def get_server_order(opts, user)
                 user = m[1] if m[1]
 
                 order << to_array(server)
+                break
             end
         end
 


### PR DESCRIPTION
When a match is made, the username is changed. It's then inappropriate to attempt further matches because we're not using the original username.

If multiple matches were made with the original username, there could be no single modified username to return. An alternative would be to return pairs of server and modified username.

Fixes #5513.