### PR TITLE
B OpenNebula#5079: Fix IPv6 Addresses in vRouters with IP spoofing

### DIFF
--- a/src/vnm_mad/remotes/lib/security_groups_iptables.rb
+++ b/src/vnm_mad/remotes/lib/security_groups_iptables.rb
@@ -509,7 +509,7 @@ module SGIPTables
 
             ipv6s = Array.new
 
-            [:ip6, :ip6_global, :ip6_link, :ip6_ula].each do |key|
+            [:ip6, :ip6_global, :ip6_link, :ip6_ula, :vrouter_ip6, :vrouter_ip6_global, :vrouter_ip6_link, :vrouter_ip6_ula].each do |key|
                 ipv6s << nic[key] if !nic[key].nil? && !nic[key].empty?
 
                 vars[:nics_alias].each do |nic_alias|


### PR DESCRIPTION
While using the virtual router framework, it was discovered that traffic to IPv6 virtual / floating IPs was being blocked by ip6tables. Upon further investigation, IPv6 vRouter IPs were not being properly added to the ipset. This commit remediates this issue.

Signed-off-by: Kenny Van Alstyne <kenny.vanalstyne@softiron.com>