### PR TITLE
B #5483: Add 'flow' folder to LIB_OCA_CLIENT_DIRS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -540,7 +540,8 @@ ONEFLOW_DIRS="$ONEFLOW_LOCATION/lib \
               $ONEFLOW_LOCATION/lib/models"
 
 LIB_OCA_CLIENT_DIRS="$LIB_LOCATION/ruby \
-                 $LIB_LOCATION/ruby/opennebula"
+                 $LIB_LOCATION/ruby/opennebula \
+                 $LIB_LOCATION/ruby/opennebula/flow"
 
 LIB_CLI_CLIENT_DIRS="$LIB_LOCATION/ruby/cli \
                      $LIB_LOCATION/ruby/cli/one_helper"
@@ -2407,8 +2408,7 @@ RUBY_OPENNEBULA_LIB_FILES="src/oca/ruby/opennebula/acl_pool.rb \
                             src/oca/ruby/opennebula/hook_log.rb \
                             src/oca/ruby/opennebula/flow.rb"
 
-RUBY_OPENNEBULA_LIB_FLOW_FILES="src/oca/ruby/opennebula/flow \
-                                 src/oca/ruby/opennebula/flow/grammar.rb \
+RUBY_OPENNEBULA_LIB_FLOW_FILES="src/oca/ruby/opennebula/flow/grammar.rb \
                                  src/oca/ruby/opennebula/flow/service_pool.rb \
                                  src/oca/ruby/opennebula/flow/service_template_pool.rb \
                                  src/oca/ruby/opennebula/flow/service_template.rb \

--- a/install.sh
+++ b/install.sh
@@ -2407,7 +2407,8 @@ RUBY_OPENNEBULA_LIB_FILES="src/oca/ruby/opennebula/acl_pool.rb \
                             src/oca/ruby/opennebula/hook_log.rb \
                             src/oca/ruby/opennebula/flow.rb"
 
-RUBY_OPENNEBULA_LIB_FLOW_FILES="src/oca/ruby/opennebula/flow/grammar.rb \
+RUBY_OPENNEBULA_LIB_FLOW_FILES="src/oca/ruby/opennebula/flow \
+                                 src/oca/ruby/opennebula/flow/grammar.rb \
                                  src/oca/ruby/opennebula/flow/service_pool.rb \
                                  src/oca/ruby/opennebula/flow/service_template_pool.rb \
                                  src/oca/ruby/opennebula/flow/service_template.rb \


### PR DESCRIPTION
There is a an issue in install.sh when run on Mac OS, instead of creating the folder 'src/oca/ruby/opennebula/flow', the files that follow in the RUBY_OPENNEBULA_LIB_FLOW_FILES list get written in turn to a FILE with the path 'src/oca/ruby/opennebula/flow'. This is due to a subtle difference in the way the 'cp' command works in linux and Mac OS.