### PR TITLE
B #5606: GOCA - ACL rule zone parameter

### DIFF
--- a/src/oca/go/src/goca/acl.go
+++ b/src/oca/go/src/goca/acl.go
@@ -18,6 +18,7 @@ package goca
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/acl"
 )
@@ -51,8 +52,22 @@ func (ac *ACLsController) Info() (*acl.Pool, error) {
 // * user: User component of the new rule. A string containing a hex number.
 // * resource: Resource component of the new rule. A string containing a hex number.
 // * rights: Rights component of the new rule. A string containing a hex number.
-func (ac *ACLsController) CreateRule(user, resource, rights string) (int, error) {
-	response, err := ac.c.Client.Call("one.acl.addrule", user, resource, rights)
+// * zone: Optional zone component of the new rule. A string containing a hex number.
+func (ac *ACLsController) CreateRule(user, resource, rights string, zone ...string) (int, error) {
+
+	if len(zone) > 1 {
+		return -1, fmt.Errorf("CreateRule: %d extra parameters passed", len(zone)-1)
+	}
+
+	parameters := []interface{}{
+		"one.acl.addrule", user, resource, rights,
+	}
+
+	for _, z := range zone {
+		parameters = append(parameters, z)
+	}
+
+	response, err := ac.c.Client.Call(parameters...)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
This PR enable the zone optional parameter for ACL rule creation in GOCA

It would be nice to have it merged for all versions from 5.12.