### PR TITLE
F #5688: add request context to client calls

### DIFF
--- a/src/oca/go/src/goca/acl.go
+++ b/src/oca/go/src/goca/acl.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 
@@ -34,7 +35,11 @@ func (c *Controller) ACLs() *ACLsController {
 // Info returns an acl pool. A connection to OpenNebula is
 // performed.
 func (ac *ACLsController) Info() (*acl.Pool, error) {
-	response, err := ac.c.Client.Call("one.acl.info")
+	return ac.InfoContext(context.Background())
+}
+
+func (ac *ACLsController) InfoContext(ctx context.Context) (*acl.Pool, error) {
+	response, err := ac.c.Client.CallContext(ctx, "one.acl.info")
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +59,10 @@ func (ac *ACLsController) Info() (*acl.Pool, error) {
 // * rights: Rights component of the new rule. A string containing a hex number.
 // * zone: Optional zone component of the new rule. A string containing a hex number.
 func (ac *ACLsController) CreateRule(user, resource, rights string, zone ...string) (int, error) {
+	return ac.CreateRuleContext(context.Background(), user, resource, rights, zone...)
+}
 
+func (ac *ACLsController) CreateRuleContext(ctx context.Context, user, resource, rights string, zone ...string) (int, error) {
 	if len(zone) > 1 {
 		return -1, fmt.Errorf("CreateRule: %d extra parameters passed", len(zone)-1)
 	}
@@ -67,7 +75,7 @@ func (ac *ACLsController) CreateRule(user, resource, rights string, zone ...stri
 		parameters = append(parameters, z)
 	}
 
-	response, err := ac.c.Client.Call("one.acl.addrule", parameters...)
+	response, err := ac.c.Client.CallContext(ctx, "one.acl.addrule", parameters...)
 	if err != nil {
 		return -1, err
 	}
@@ -77,6 +85,10 @@ func (ac *ACLsController) CreateRule(user, resource, rights string, zone ...stri
 
 // DeleteRule deletes an ACL rule.
 func (ac *ACLsController) DeleteRule(aclID int) error {
-	_, err := ac.c.Client.Call("one.acl.delrule", aclID)
+	return ac.DeleteRuleContext(context.Background(), aclID)
+}
+
+func (ac *ACLsController) DeleteRuleContext(ctx context.Context, aclID int) error {
+	_, err := ac.c.Client.CallContext(ctx, "one.acl.delrule", aclID)
 	return err
 }

--- a/src/oca/go/src/goca/acl.go
+++ b/src/oca/go/src/goca/acl.go
@@ -38,6 +38,8 @@ func (ac *ACLsController) Info() (*acl.Pool, error) {
 	return ac.InfoContext(context.Background())
 }
 
+// InfoContext returns an acl pool. A connection to OpenNebula is
+// performed.
 func (ac *ACLsController) InfoContext(ctx context.Context) (*acl.Pool, error) {
 	response, err := ac.c.Client.CallContext(ctx, "one.acl.info")
 	if err != nil {
@@ -62,6 +64,12 @@ func (ac *ACLsController) CreateRule(user, resource, rights string, zone ...stri
 	return ac.CreateRuleContext(context.Background(), user, resource, rights, zone...)
 }
 
+// CreateRuleContext adds a new ACL rule.
+// * ctx: context for cancelation
+// * user: User component of the new rule. A string containing a hex number.
+// * resource: Resource component of the new rule. A string containing a hex number.
+// * rights: Rights component of the new rule. A string containing a hex number.
+// * zone: Optional zone component of the new rule. A string containing a hex number.
 func (ac *ACLsController) CreateRuleContext(ctx context.Context, user, resource, rights string, zone ...string) (int, error) {
 	if len(zone) > 1 {
 		return -1, fmt.Errorf("CreateRule: %d extra parameters passed", len(zone)-1)
@@ -88,6 +96,7 @@ func (ac *ACLsController) DeleteRule(aclID int) error {
 	return ac.DeleteRuleContext(context.Background(), aclID)
 }
 
+// DeleteRuleContext deletes an ACL rule.
 func (ac *ACLsController) DeleteRuleContext(ctx context.Context, aclID int) error {
 	_, err := ac.c.Client.CallContext(ctx, "one.acl.delrule", aclID)
 	return err

--- a/src/oca/go/src/goca/backupjob.go
+++ b/src/oca/go/src/goca/backupjob.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -42,9 +43,14 @@ func (c *Controller) BackupJob(id int) *BackupJobController {
 
 // ByName returns an Backup Job ID from name
 func (c *BackupJobsController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+// ByNameContext returns an Backup Job ID from name
+func (c *BackupJobsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	bjPool, err := c.Info(args...)
+	bjPool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}
@@ -69,13 +75,18 @@ func (c *BackupJobsController) ByName(name string, args ...int) (int, error) {
 
 // Info returns a new Backup Job pool. It accepts the scope of the query.
 func (bjc *BackupJobsController) Info(args ...int) (*backupjob.Pool, error) {
+	return bjc.InfoContext(context.Background(), args...)
+}
+
+// InfoContext returns a new Backup Job pool. It accepts the scope of the query.
+func (bjc *BackupJobsController) InfoContext(ctx context.Context, args ...int) (*backupjob.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := bjc.c.Client.Call("one.backupjobpool.info", fArgs...)
+	response, err := bjc.c.Client.CallContext(ctx, "one.backupjobpool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +102,12 @@ func (bjc *BackupJobsController) Info(args ...int) (*backupjob.Pool, error) {
 
 // Info connects to OpenNebula and fetches the information of the Backup Job
 func (bjc *BackupJobController) Info() (*backupjob.BackupJob, error) {
-	response, err := bjc.c.Client.Call("one.backupjob.info", bjc.ID)
+	return bjc.InfoContext(context.Background())
+}
+
+// InfoContext connects to OpenNebula and fetches the information of the Backup Job
+func (bjc *BackupJobController) InfoContext(ctx context.Context) (*backupjob.BackupJob, error) {
+	response, err := bjc.c.Client.CallContext(ctx, "one.backupjob.info", bjc.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +122,13 @@ func (bjc *BackupJobController) Info() (*backupjob.BackupJob, error) {
 // Create allocates a new Backup Job based on the template string provided. It
 // returns the Backup Job ID.
 func (bjc *BackupJobsController) Create(template string) (int, error) {
-	response, err := bjc.c.Client.Call("one.backupjob.allocate", template)
+	return bjc.CreateContext(context.Background(), template)
+}
+
+// CreateContext allocates a new Backup Job based on the template string provided. It
+// returns the Backup Job ID.
+func (bjc *BackupJobsController) CreateContext(ctx context.Context, template string) (int, error) {
+	response, err := bjc.c.Client.CallContext(ctx, "one.backupjob.allocate", template)
 	if err != nil {
 		return -1, err
 	}
@@ -117,78 +139,142 @@ func (bjc *BackupJobsController) Create(template string) (int, error) {
 // Update adds Backup Job content.
 // * tpl: The new Backup Job content. Syntax can be the usual attribute=value or XML.
 func (bjc *BackupJobController) Update(tpl string) error {
-	_, err := bjc.c.Client.Call("one.backupjob.update", bjc.ID, tpl)
+	return bjc.UpdateContext(context.Background(), tpl)
+}
+
+// UpdateContext adds Backup Job content.
+// * tpl: The new Backup Job content. Syntax can be the usual attribute=value or XML.
+func (bjc *BackupJobController) UpdateContext(ctx context.Context, tpl string) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.update", bjc.ID, tpl)
 	return err
 }
 
 // Chown changes the owner/group of the Backup Job. If uid or gid is -1 it will not
 // change
 func (bjc *BackupJobController) Chown(uid, gid int) error {
-	_, err := bjc.c.Client.Call("one.backupjob.chown", bjc.ID, uid, gid)
+	return bjc.ChownContext(context.Background(), uid, gid)
+}
+
+// ChownContext changes the owner/group of the Backup Job. If uid or gid is -1 it will not
+// change
+func (bjc *BackupJobController) ChownContext(ctx context.Context, uid, gid int) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.chown", bjc.ID, uid, gid)
 	return err
 }
 
 // Chmod changes the permissions of the Backup Job. If any perm is -1 it will not
 // change
 func (bjc *BackupJobController) Chmod(perm shared.Permissions) error {
+	return bjc.ChmodContext(context.Background(), perm)
+}
+
+// ChmodContext changes the permissions of the Backup Job. If any perm is -1 it will not
+// change
+func (bjc *BackupJobController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{bjc.ID}, perm.ToArgs()...)
 
-	_, err := bjc.c.Client.Call("one.backupjob.chmod", args...)
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.chmod", args...)
 	return err
 }
 
 // Rename changes the name of the image
 func (bjc *BackupJobController) Rename(newName string) error {
-	_, err := bjc.c.Client.Call("one.backupjob.rename", bjc.ID, newName)
+	return bjc.RenameContext(context.Background(), newName)
+}
+
+// RenameContext changes the name of the image
+func (bjc *BackupJobController) RenameContext(ctx context.Context, newName string) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.rename", bjc.ID, newName)
 	return err
 }
 
 // Lock locks the Backup Job following lock level. See levels in locks.go.
 func (bjc *BackupJobController) Lock(level shared.LockLevel) error {
-	_, err := bjc.c.Client.Call("one.backupjob.lock", bjc.ID, level)
+	return bjc.LockContext(context.Background(), level)
+}
+
+// LockContext locks the Backup Job following lock level. See levels in locks.go.
+func (bjc *BackupJobController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.lock", bjc.ID, level)
 	return err
 }
 
 // Unlock unlocks the BackupJob.
 func (bjc *BackupJobController) Unlock() error {
-	_, err := bjc.c.Client.Call("one.backupjob.unlock", bjc.ID)
+	return bjc.UnlockContext(context.Background())
+}
+
+// UnlockContext unlocks the BackupJob.
+func (bjc *BackupJobController) UnlockContext(ctx context.Context) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.unlock", bjc.ID)
 	return err
 }
 
 // Delete will remove the Backup Job from OpenNebula, which will remove it from the
 // backend.
 func (bjc *BackupJobController) Delete() error {
-	_, err := bjc.c.Client.Call("one.backupjob.delete", bjc.ID)
+	return bjc.DeleteContext(context.Background())
+}
+
+// DeleteContext will remove the Backup Job from OpenNebula, which will remove it from the
+// backend.
+func (bjc *BackupJobController) DeleteContext(ctx context.Context) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.delete", bjc.ID)
 	return err
 }
 
 // Backup runs the Backup Job
 func (bjc *BackupJobController) Backup() error {
-	_, err := bjc.c.Client.Call("one.backupjob.backup", bjc.ID)
+	return bjc.BackupContext(context.Background())
+}
+
+// BackupContext runs the Backup Job
+func (bjc *BackupJobController) BackupContext(ctx context.Context) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.backup", bjc.ID)
 	return err
 }
 
 // Cancel ongoing Backup Job execution
 func (bjc *BackupJobController) Cancel() error {
-	_, err := bjc.c.Client.Call("one.backupjob.cancel", bjc.ID)
+	return bjc.CancelContext(context.Background())
+}
+
+// CancelContext ongoing Backup Job execution
+func (bjc *BackupJobController) CancelContext(ctx context.Context) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.cancel", bjc.ID)
 	return err
 }
 
 // Retry backup for failed Virtual Machine
 func (bjc *BackupJobController) Retry() error {
-	_, err := bjc.c.Client.Call("one.backupjob.retry", bjc.ID)
+	return bjc.RetryContext(context.Background())
+}
+
+// RetryContext backup for failed Virtual Machine
+func (bjc *BackupJobController) RetryContext(ctx context.Context) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.retry", bjc.ID)
 	return err
 }
 
-// Set priority for Backup Job, only admin can set priority over 50
+// Priority set priority for Backup Job, only admin can set priority over 50
 func (bjc *BackupJobController) Priority(prio int) error {
-	_, err := bjc.c.Client.Call("one.backupjob.priority", bjc.ID, prio)
+	return bjc.PriorityContext(context.Background(), prio)
+}
+
+// PriorityContext set priority for Backup Job, only admin can set priority over 50
+func (bjc *BackupJobController) PriorityContext(ctx context.Context, prio int) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.priority", bjc.ID, prio)
 	return err
 }
 
 // SchedAdd creates a new Scheduled Action for the Backup Job
 func (bjc *BackupJobController) SchedAdd(description string) (int, error) {
-	response, err := bjc.c.Client.Call("one.backupjob.schedadd", bjc.ID, description)
+	return bjc.SchedAddContext(context.Background(), description)
+}
+
+// SchedAddContext creates a new Scheduled Action for the Backup Job
+func (bjc *BackupJobController) SchedAddContext(ctx context.Context, description string) (int, error) {
+	response, err := bjc.c.Client.CallContext(ctx, "one.backupjob.schedadd", bjc.ID, description)
 	if err != nil {
 		return -1, err
 	}
@@ -198,7 +284,12 @@ func (bjc *BackupJobController) SchedAdd(description string) (int, error) {
 
 // SchedUpdate updates a Scheduled Action for the Backup Job
 func (bjc *BackupJobController) SchedUpdate(saID int, description string) (int, error) {
-	response, err := bjc.c.Client.Call("one.backupjob.schedupdate", bjc.ID, saID, description)
+	return bjc.SchedUpdateContext(context.Background(), saID, description)
+}
+
+// SchedUpdateContext updates a Scheduled Action for the Backup Job
+func (bjc *BackupJobController) SchedUpdateContext(ctx context.Context, saID int, description string) (int, error) {
+	response, err := bjc.c.Client.CallContext(ctx, "one.backupjob.schedupdate", bjc.ID, saID, description)
 	if err != nil {
 		return -1, err
 	}
@@ -208,6 +299,11 @@ func (bjc *BackupJobController) SchedUpdate(saID int, description string) (int, 
 
 // SchedDelete deletes a Scheduled Action
 func (bjc *BackupJobController) SchedDelete(saID int) error {
-	_, err := bjc.c.Client.Call("one.backupjob.scheddelete", bjc.ID, saID)
+	return bjc.SchedDeleteContext(context.Background(), saID)
+}
+
+// SchedDeleteContext deletes a Scheduled Action
+func (bjc *BackupJobController) SchedDeleteContext(ctx context.Context, saID int) error {
+	_, err := bjc.c.Client.CallContext(ctx, "one.backupjob.scheddelete", bjc.ID, saID)
 	return err
 }

--- a/src/oca/go/src/goca/client.go
+++ b/src/oca/go/src/goca/client.go
@@ -18,6 +18,7 @@ package goca
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -116,6 +117,10 @@ func NewClient(conf OneConfig, httpClient *http.Client) *Client {
 
 // Call is an XML-RPC wrapper. It returns a pointer to response and an error.
 func (c *Client) Call(method string, args ...interface{}) (*Response, error) {
+	return c.CallContext(context.Background(), method, args)
+}
+
+func (c *Client) CallContext(ctx context.Context, method string, args ...interface{}) (*Response, error) {
 	var (
 		ok bool
 
@@ -136,7 +141,7 @@ func (c *Client) Call(method string, args ...interface{}) (*Response, error) {
 			&errs.ClientError{Code: errs.ClientReqBuild, Msg: "xmlrpc request encoding", Err: err}
 	}
 
-	req, err := http.NewRequest("POST", c.url, bytes.NewBuffer(buf))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.url, bytes.NewBuffer(buf))
 	if err != nil {
 		return nil,
 			&errs.ClientError{Code: errs.ClientReqBuild, Msg: "http request build", Err: err}

--- a/src/oca/go/src/goca/client.go
+++ b/src/oca/go/src/goca/client.go
@@ -120,6 +120,7 @@ func (c *Client) Call(method string, args ...interface{}) (*Response, error) {
 	return c.CallContext(context.Background(), method, args)
 }
 
+// CallContext is an XML-RPC wrapper. It returns a pointer to response and an error and can be canceled through the passed context
 func (c *Client) CallContext(ctx context.Context, method string, args ...interface{}) (*Response, error) {
 	var (
 		ok bool

--- a/src/oca/go/src/goca/client.go
+++ b/src/oca/go/src/goca/client.go
@@ -115,11 +115,6 @@ func NewClient(conf OneConfig, httpClient *http.Client) *Client {
 	}
 }
 
-// Call is an XML-RPC wrapper. It returns a pointer to response and an error.
-func (c *Client) Call(method string, args ...interface{}) (*Response, error) {
-	return c.CallContext(context.Background(), method, args)
-}
-
 // CallContext is an XML-RPC wrapper. It returns a pointer to response and an error and can be canceled through the passed context
 func (c *Client) CallContext(ctx context.Context, method string, args ...interface{}) (*Response, error) {
 	var (

--- a/src/oca/go/src/goca/cluster.go
+++ b/src/oca/go/src/goca/cluster.go
@@ -43,9 +43,13 @@ func (c *Controller) Cluster(id int) *ClusterController {
 
 // ByName returns a Cluster ID from name
 func (c *ClustersController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *ClustersController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	clusterPool, err := c.Info(false)
+	clusterPool, err := c.InfoContext(ctx, false)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/cluster.go
+++ b/src/oca/go/src/goca/cluster.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,7 +71,11 @@ func (c *ClustersController) ByName(name string) (int, error) {
 // Info returns a cluster pool. A connection to OpenNebula is
 // performed.
 func (cc *ClustersController) Info(decrypt bool) (*cluster.Pool, error) {
-	response, err := cc.c.Client.Call("one.clusterpool.info", decrypt)
+	return cc.InfoContext(context.Background(), decrypt)
+}
+
+func (cc *ClustersController) InfoContext(ctx context.Context, decrypt bool) (*cluster.Pool, error) {
+	response, err := cc.c.Client.CallContext(ctx, "one.clusterpool.info", decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +91,11 @@ func (cc *ClustersController) Info(decrypt bool) (*cluster.Pool, error) {
 
 // Info retrieves information for the cluster.
 func (cc *ClusterController) Info() (*cluster.Cluster, error) {
-	response, err := cc.c.Client.Call("one.cluster.info", cc.ID)
+	return cc.InfoContext(context.Background())
+}
+
+func (cc *ClusterController) InfoContext(ctx context.Context) (*cluster.Cluster, error) {
+	response, err := cc.c.Client.CallContext(ctx, "one.cluster.info", cc.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +109,11 @@ func (cc *ClusterController) Info() (*cluster.Cluster, error) {
 
 // Create allocates a new cluster. It returns the new cluster ID.
 func (cc *ClustersController) Create(name string) (int, error) {
-	response, err := cc.c.Client.Call("one.cluster.allocate", name)
+	return cc.CreateContext(context.Background(), name)
+}
+
+func (cc *ClustersController) CreateContext(ctx context.Context, name string) (int, error) {
+	response, err := cc.c.Client.CallContext(ctx, "one.cluster.allocate", name)
 	if err != nil {
 		return -1, err
 	}
@@ -110,7 +123,11 @@ func (cc *ClustersController) Create(name string) (int, error) {
 
 // Delete deletes the given cluster from the pool.
 func (cc *ClusterController) Delete() error {
-	_, err := cc.c.Client.Call("one.cluster.delete", cc.ID)
+	return cc.DeleteContext(context.Background())
+}
+
+func (cc *ClusterController) DeleteContext(ctx context.Context) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.delete", cc.ID)
 	return err
 }
 
@@ -119,55 +136,87 @@ func (cc *ClusterController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (cc *ClusterController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := cc.c.Client.Call("one.cluster.update", cc.ID, tpl, uType)
+	return cc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (cc *ClusterController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.update", cc.ID, tpl, uType)
 	return err
 }
 
 // AddHost adds a host to the given cluster.
 // * hostID: The host ID.
 func (cc *ClusterController) AddHost(hostID int) error {
-	_, err := cc.c.Client.Call("one.cluster.addhost", cc.ID, int(hostID))
+	return cc.AddHostContext(context.Background(), hostID)
+}
+
+func (cc *ClusterController) AddHostContext(ctx context.Context, hostID int) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.addhost", cc.ID, int(hostID))
 	return err
 }
 
 // DelHost removes a host from the given cluster.
 // * hostID: The host ID.
 func (cc *ClusterController) DelHost(hostID int) error {
-	_, err := cc.c.Client.Call("one.cluster.delhost", cc.ID, int(hostID))
+	return cc.DelHostContext(context.Background(), hostID)
+}
+
+func (cc *ClusterController) DelHostContext(ctx context.Context, hostID int) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.delhost", cc.ID, int(hostID))
 	return err
 }
 
 // AddDatastore adds a datastore to the given cluster.
 // * dsID: The datastore ID.
 func (cc *ClusterController) AddDatastore(dsID int) error {
-	_, err := cc.c.Client.Call("one.cluster.adddatastore", cc.ID, int(dsID))
+	return cc.AddDatastoreContext(context.Background(), dsID)
+}
+
+func (cc *ClusterController) AddDatastoreContext(ctx context.Context, dsID int) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.adddatastore", cc.ID, int(dsID))
 	return err
 }
 
 // DelDatastore removes a datastore from the given cluster.
 // * dsID: The datastore ID.
 func (cc *ClusterController) DelDatastore(dsID int) error {
-	_, err := cc.c.Client.Call("one.cluster.deldatastore", cc.ID, int(dsID))
+	return cc.DelDatastoreContext(context.Background(), dsID)
+}
+
+func (cc *ClusterController) DelDatastoreContext(ctx context.Context, dsID int) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.deldatastore", cc.ID, int(dsID))
 	return err
 }
 
 // AddVnet adds a vnet to the given cluster.
 // * vnetID: The vnet ID.
 func (cc *ClusterController) AddVnet(vnetID int) error {
-	_, err := cc.c.Client.Call("one.cluster.addvnet", cc.ID, int(vnetID))
+	return cc.AddVnetContext(context.Background(), vnetID)
+}
+
+func (cc *ClusterController) AddVnetContext(ctx context.Context, vnetID int) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.addvnet", cc.ID, int(vnetID))
 	return err
 }
 
 // DelVnet removes a vnet from the given cluster.
 // * vnetID: The vnet ID.
 func (cc *ClusterController) DelVnet(vnetID int) error {
-	_, err := cc.c.Client.Call("one.cluster.delvnet", cc.ID, int(vnetID))
+	return cc.DelVnetContext(context.Background(), vnetID)
+}
+
+func (cc *ClusterController) DelVnetContext(ctx context.Context, vnetID int) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.delvnet", cc.ID, int(vnetID))
 	return err
 }
 
 // Rename renames a cluster.
 // * newName: The new name.
 func (cc *ClusterController) Rename(newName string) error {
-	_, err := cc.c.Client.Call("one.cluster.rename", cc.ID, newName)
+	return cc.RenameContext(context.Background(), newName)
+}
+
+func (cc *ClusterController) RenameContext(ctx context.Context, newName string) error {
+	_, err := cc.c.Client.CallContext(ctx, "one.cluster.rename", cc.ID, newName)
 	return err
 }

--- a/src/oca/go/src/goca/cluster.go
+++ b/src/oca/go/src/goca/cluster.go
@@ -46,6 +46,7 @@ func (c *ClustersController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a Cluster ID from name
 func (c *ClustersController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -78,6 +79,8 @@ func (cc *ClustersController) Info(decrypt bool) (*cluster.Pool, error) {
 	return cc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext returns a cluster pool. A connection to OpenNebula is
+// performed.
 func (cc *ClustersController) InfoContext(ctx context.Context, decrypt bool) (*cluster.Pool, error) {
 	response, err := cc.c.Client.CallContext(ctx, "one.clusterpool.info", decrypt)
 	if err != nil {
@@ -98,6 +101,7 @@ func (cc *ClusterController) Info() (*cluster.Cluster, error) {
 	return cc.InfoContext(context.Background())
 }
 
+// InfoContext retrieves information for the cluster.
 func (cc *ClusterController) InfoContext(ctx context.Context) (*cluster.Cluster, error) {
 	response, err := cc.c.Client.CallContext(ctx, "one.cluster.info", cc.ID)
 	if err != nil {
@@ -116,6 +120,7 @@ func (cc *ClustersController) Create(name string) (int, error) {
 	return cc.CreateContext(context.Background(), name)
 }
 
+// CreateContext allocates a new cluster. It returns the new cluster ID.
 func (cc *ClustersController) CreateContext(ctx context.Context, name string) (int, error) {
 	response, err := cc.c.Client.CallContext(ctx, "one.cluster.allocate", name)
 	if err != nil {
@@ -130,6 +135,8 @@ func (cc *ClusterController) Delete() error {
 	return cc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given cluster from the pool.
+// * ctx: context for cancelation
 func (cc *ClusterController) DeleteContext(ctx context.Context) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.delete", cc.ID)
 	return err
@@ -143,6 +150,11 @@ func (cc *ClusterController) Update(tpl string, uType parameters.UpdateType) err
 	return cc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds cluster content.
+//   - ctx: context for cancelation
+//   - tpl: The new cluster contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (cc *ClusterController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.update", cc.ID, tpl, uType)
 	return err
@@ -154,6 +166,9 @@ func (cc *ClusterController) AddHost(hostID int) error {
 	return cc.AddHostContext(context.Background(), hostID)
 }
 
+// AddHostContext adds a host to the given cluster.
+// * ctx: context for cancelation
+// * hostID: The host ID.
 func (cc *ClusterController) AddHostContext(ctx context.Context, hostID int) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.addhost", cc.ID, int(hostID))
 	return err
@@ -165,6 +180,9 @@ func (cc *ClusterController) DelHost(hostID int) error {
 	return cc.DelHostContext(context.Background(), hostID)
 }
 
+// DelHostContext removes a host from the given cluster.
+// * ctx: context for cancelation
+// * hostID: The host ID.
 func (cc *ClusterController) DelHostContext(ctx context.Context, hostID int) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.delhost", cc.ID, int(hostID))
 	return err
@@ -176,6 +194,9 @@ func (cc *ClusterController) AddDatastore(dsID int) error {
 	return cc.AddDatastoreContext(context.Background(), dsID)
 }
 
+// AddDatastoreContext adds a datastore to the given cluster.
+// * ctx: context for cancelation
+// * dsID: The datastore ID.
 func (cc *ClusterController) AddDatastoreContext(ctx context.Context, dsID int) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.adddatastore", cc.ID, int(dsID))
 	return err
@@ -187,6 +208,9 @@ func (cc *ClusterController) DelDatastore(dsID int) error {
 	return cc.DelDatastoreContext(context.Background(), dsID)
 }
 
+// DelDatastoreContext removes a datastore from the given cluster.
+// * ctx: context for cancelation
+// * dsID: The datastore ID.
 func (cc *ClusterController) DelDatastoreContext(ctx context.Context, dsID int) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.deldatastore", cc.ID, int(dsID))
 	return err
@@ -198,6 +222,9 @@ func (cc *ClusterController) AddVnet(vnetID int) error {
 	return cc.AddVnetContext(context.Background(), vnetID)
 }
 
+// AddVnetContext adds a vnet to the given cluster.
+// * ctx: context for cancelation
+// * vnetID: The vnet ID.
 func (cc *ClusterController) AddVnetContext(ctx context.Context, vnetID int) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.addvnet", cc.ID, int(vnetID))
 	return err
@@ -209,6 +236,9 @@ func (cc *ClusterController) DelVnet(vnetID int) error {
 	return cc.DelVnetContext(context.Background(), vnetID)
 }
 
+// DelVnetContext removes a vnet from the given cluster.
+// * ctx: context for cancelation
+// * vnetID: The vnet ID.
 func (cc *ClusterController) DelVnetContext(ctx context.Context, vnetID int) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.delvnet", cc.ID, int(vnetID))
 	return err
@@ -220,6 +250,9 @@ func (cc *ClusterController) Rename(newName string) error {
 	return cc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a cluster.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (cc *ClusterController) RenameContext(ctx context.Context, newName string) error {
 	_, err := cc.c.Client.CallContext(ctx, "one.cluster.rename", cc.ID, newName)
 	return err

--- a/src/oca/go/src/goca/controller.go
+++ b/src/oca/go/src/goca/controller.go
@@ -16,9 +16,12 @@
 
 package goca
 
+import "context"
+
 // RPCCaller is the interface to satisfy in order to be usable by the controller
 type RPCCaller interface {
 	Call(method string, args ...interface{}) (*Response, error)
+	CallContext(ctx context.Context, method string, args ...interface{}) (*Response, error)
 }
 
 // HTTPCaller is the analogous to RPCCaller but for http endpoints
@@ -78,7 +81,11 @@ func NewGenericController(cone RPCCaller, cflow HTTPCaller) *Controller {
 
 // SystemVersion returns the current OpenNebula Version
 func (c *Controller) SystemVersion() (string, error) {
-	response, err := c.Client.Call("one.system.version")
+	return c.SystemVersionContext(context.Background())
+}
+
+func (c *Controller) SystemVersionContext(ctx context.Context) (string, error) {
+	response, err := c.Client.CallContext(ctx, "one.system.version")
 	if err != nil {
 		return "", err
 	}
@@ -88,7 +95,11 @@ func (c *Controller) SystemVersion() (string, error) {
 
 // SystemConfig returns the current OpenNebula config
 func (c *Controller) SystemConfig() (string, error) {
-	response, err := c.Client.Call("one.system.config")
+	return c.SystemConfigContext(context.Background())
+}
+
+func (c *Controller) SystemConfigContext(ctx context.Context) (string, error) {
+	response, err := c.Client.CallContext(ctx, "one.system.config")
 	if err != nil {
 		return "", err
 	}

--- a/src/oca/go/src/goca/controller.go
+++ b/src/oca/go/src/goca/controller.go
@@ -84,6 +84,7 @@ func (c *Controller) SystemVersion() (string, error) {
 	return c.SystemVersionContext(context.Background())
 }
 
+// SystemVersionContext returns the current OpenNebula Version
 func (c *Controller) SystemVersionContext(ctx context.Context) (string, error) {
 	response, err := c.Client.CallContext(ctx, "one.system.version")
 	if err != nil {
@@ -98,6 +99,7 @@ func (c *Controller) SystemConfig() (string, error) {
 	return c.SystemConfigContext(context.Background())
 }
 
+// SystemConfigContext returns the current OpenNebula config
 func (c *Controller) SystemConfigContext(ctx context.Context) (string, error) {
 	response, err := c.Client.CallContext(ctx, "one.system.config")
 	if err != nil {

--- a/src/oca/go/src/goca/controller.go
+++ b/src/oca/go/src/goca/controller.go
@@ -20,7 +20,6 @@ import "context"
 
 // RPCCaller is the interface to satisfy in order to be usable by the controller
 type RPCCaller interface {
-	Call(method string, args ...interface{}) (*Response, error)
 	CallContext(ctx context.Context, method string, args ...interface{}) (*Response, error)
 }
 

--- a/src/oca/go/src/goca/datastore.go
+++ b/src/oca/go/src/goca/datastore.go
@@ -44,9 +44,13 @@ func (c *Controller) Datastore(id int) *DatastoreController {
 
 // ByName returns a Datastore ID from name
 func (c *Controller) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *Controller) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	datastorePool, err := (&DatastoresController{c}).Info()
+	datastorePool, err := (&DatastoresController{c}).InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/datastore.go
+++ b/src/oca/go/src/goca/datastore.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -71,7 +72,11 @@ func (c *Controller) ByName(name string) (int, error) {
 // Info returns a datastore pool. A connection to OpenNebula is
 // performed.
 func (dc *DatastoresController) Info() (*datastore.Pool, error) {
-	response, err := dc.c.Client.Call("one.datastorepool.info")
+	return dc.InfoContext(context.Background())
+}
+
+func (dc *DatastoresController) InfoContext(ctx context.Context) (*datastore.Pool, error) {
+	response, err := dc.c.Client.CallContext(ctx, "one.datastorepool.info")
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +92,11 @@ func (dc *DatastoresController) Info() (*datastore.Pool, error) {
 
 // Info retrieves information for the datastore.
 func (dc *DatastoreController) Info(decrypt bool) (*datastore.Datastore, error) {
-	response, err := dc.c.Client.Call("one.datastore.info", dc.ID, decrypt)
+	return dc.InfoContext(context.Background(), decrypt)
+}
+
+func (dc *DatastoreController) InfoContext(ctx context.Context, decrypt bool) (*datastore.Datastore, error) {
+	response, err := dc.c.Client.CallContext(ctx, "one.datastore.info", dc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +113,11 @@ func (dc *DatastoreController) Info(decrypt bool) (*datastore.Datastore, error) 
 // * tpl: template of the datastore
 // * clusterID: The cluster ID. If it is -1, the default one will be used.
 func (dc *DatastoresController) Create(tpl string, clusterID int) (int, error) {
-	response, err := dc.c.Client.Call("one.datastore.allocate", tpl, clusterID)
+	return dc.CreateContext(context.Background(), tpl, clusterID)
+}
+
+func (dc *DatastoresController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
+	response, err := dc.c.Client.CallContext(ctx, "one.datastore.allocate", tpl, clusterID)
 	if err != nil {
 		return -1, err
 	}
@@ -114,7 +127,11 @@ func (dc *DatastoresController) Create(tpl string, clusterID int) (int, error) {
 
 // Delete deletes the given datastore from the pool.
 func (dc *DatastoreController) Delete() error {
-	_, err := dc.c.Client.Call("one.datastore.delete", dc.ID)
+	return dc.DeleteContext(context.Background())
+}
+
+func (dc *DatastoreController) DeleteContext(ctx context.Context) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.datastore.delete", dc.ID)
 	return err
 }
 
@@ -123,14 +140,22 @@ func (dc *DatastoreController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (dc *DatastoreController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := dc.c.Client.Call("one.datastore.update", dc.ID, tpl, uType)
+	return dc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (dc *DatastoreController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.datastore.update", dc.ID, tpl, uType)
 	return err
 }
 
 // Chmod changes the permission bits of a datastore.
 func (dc *DatastoreController) Chmod(perm *shared.Permissions) error {
+	return dc.ChmodContext(context.Background(), perm)
+}
+
+func (dc *DatastoreController) ChmodContext(ctx context.Context, perm *shared.Permissions) error {
 	args := append([]interface{}{dc.ID}, perm.ToArgs()...)
-	_, err := dc.c.Client.Call("one.datastore.chmod", args...)
+	_, err := dc.c.Client.CallContext(ctx, "one.datastore.chmod", args...)
 	return err
 }
 
@@ -138,20 +163,32 @@ func (dc *DatastoreController) Chmod(perm *shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (dc *DatastoreController) Chown(userID, groupID int) error {
-	_, err := dc.c.Client.Call("one.datastore.chown", dc.ID, userID, groupID)
+	return dc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (dc *DatastoreController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.datastore.chown", dc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a datastore.
 // * newName: The new name.
 func (dc *DatastoreController) Rename(newName string) error {
-	_, err := dc.c.Client.Call("one.datastore.rename", dc.ID, newName)
+	return dc.RenameContext(context.Background(), newName)
+}
+
+func (dc *DatastoreController) RenameContext(ctx context.Context, newName string) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.datastore.rename", dc.ID, newName)
 	return err
 }
 
 // Enable enables or disables a datastore.
 // * enable: True for enabling
 func (dc *DatastoreController) Enable(enable bool) error {
-	_, err := dc.c.Client.Call("one.datastore.enable", dc.ID, enable)
+	return dc.EnableContext(context.Background(), enable)
+}
+
+func (dc *DatastoreController) EnableContext(ctx context.Context, enable bool) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.datastore.enable", dc.ID, enable)
 	return err
 }

--- a/src/oca/go/src/goca/datastore.go
+++ b/src/oca/go/src/goca/datastore.go
@@ -47,6 +47,7 @@ func (c *Controller) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a Datastore ID from name
 func (c *Controller) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -79,6 +80,8 @@ func (dc *DatastoresController) Info() (*datastore.Pool, error) {
 	return dc.InfoContext(context.Background())
 }
 
+// InfoContext returns a datastore pool. A connection to OpenNebula is
+// performed.
 func (dc *DatastoresController) InfoContext(ctx context.Context) (*datastore.Pool, error) {
 	response, err := dc.c.Client.CallContext(ctx, "one.datastorepool.info")
 	if err != nil {
@@ -99,6 +102,7 @@ func (dc *DatastoreController) Info(decrypt bool) (*datastore.Datastore, error) 
 	return dc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the datastore.
 func (dc *DatastoreController) InfoContext(ctx context.Context, decrypt bool) (*datastore.Datastore, error) {
 	response, err := dc.c.Client.CallContext(ctx, "one.datastore.info", dc.ID, decrypt)
 	if err != nil {
@@ -120,6 +124,10 @@ func (dc *DatastoresController) Create(tpl string, clusterID int) (int, error) {
 	return dc.CreateContext(context.Background(), tpl, clusterID)
 }
 
+// CreateContext allocates a new datastore. It returns the new datastore ID.
+// * ctx: context for cancelation
+// * tpl: template of the datastore
+// * clusterID: The cluster ID. If it is -1, the default one will be used.
 func (dc *DatastoresController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
 	response, err := dc.c.Client.CallContext(ctx, "one.datastore.allocate", tpl, clusterID)
 	if err != nil {
@@ -134,19 +142,25 @@ func (dc *DatastoreController) Delete() error {
 	return dc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given datastore from the pool.
 func (dc *DatastoreController) DeleteContext(ctx context.Context) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.datastore.delete", dc.ID)
 	return err
 }
 
 // Update replaces the datastore contents.
-// * tpl: The new datastore contents. Syntax can be the usual attribute=value or XML.
-// * uType: Update type: Replace: Replace the whole template.
-//   Merge: Merge new template with the existing one.
+//   - tpl: The new datastore contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (dc *DatastoreController) Update(tpl string, uType parameters.UpdateType) error {
 	return dc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext replaces the datastore contents.
+//   - ctx: context for cancelation
+//   - tpl: The new datastore contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (dc *DatastoreController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.datastore.update", dc.ID, tpl, uType)
 	return err
@@ -157,6 +171,7 @@ func (dc *DatastoreController) Chmod(perm *shared.Permissions) error {
 	return dc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a datastore.
 func (dc *DatastoreController) ChmodContext(ctx context.Context, perm *shared.Permissions) error {
 	args := append([]interface{}{dc.ID}, perm.ToArgs()...)
 	_, err := dc.c.Client.CallContext(ctx, "one.datastore.chmod", args...)
@@ -170,6 +185,10 @@ func (dc *DatastoreController) Chown(userID, groupID int) error {
 	return dc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a datastore.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (dc *DatastoreController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.datastore.chown", dc.ID, userID, groupID)
 	return err
@@ -181,6 +200,9 @@ func (dc *DatastoreController) Rename(newName string) error {
 	return dc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a datastore.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (dc *DatastoreController) RenameContext(ctx context.Context, newName string) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.datastore.rename", dc.ID, newName)
 	return err
@@ -192,6 +214,9 @@ func (dc *DatastoreController) Enable(enable bool) error {
 	return dc.EnableContext(context.Background(), enable)
 }
 
+// Enable enables or disables a datastore.
+// * ctx: context for cancelation
+// * enable: True for enabling
 func (dc *DatastoreController) EnableContext(ctx context.Context, enable bool) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.datastore.enable", dc.ID, enable)
 	return err

--- a/src/oca/go/src/goca/document.go
+++ b/src/oca/go/src/goca/document.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -74,14 +75,17 @@ func (dc *DocumentsController) ByName(name string, args ...int) (int, error) {
 // Info returns a document pool. A connection to OpenNebula is
 // performed.
 func (dc *DocumentsController) Info(args ...int) (*document.Pool, error) {
+	return dc.InfoContext(context.Background(), args...)
+}
 
+func (dc *DocumentsController) InfoContext(ctx context.Context, args ...int) (*document.Pool, error) {
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 	fArgs = append(fArgs, dc.dType)
 
-	response, err := dc.c.Client.Call("one.documentpool.info", fArgs...)
+	response, err := dc.c.Client.CallContext(ctx, "one.documentpool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +101,11 @@ func (dc *DocumentsController) Info(args ...int) (*document.Pool, error) {
 
 // Info retrieves information for the document.
 func (dc *DocumentController) Info(decrypt bool) (*document.Document, error) {
-	response, err := dc.c.Client.Call("one.document.info", dc.ID, decrypt)
+	return dc.InfoContext(context.Background(), decrypt)
+}
+
+func (dc *DocumentController) InfoContext(ctx context.Context, decrypt bool) (*document.Document, error) {
+	response, err := dc.c.Client.CallContext(ctx, "one.document.info", dc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +120,11 @@ func (dc *DocumentController) Info(decrypt bool) (*document.Document, error) {
 
 // Create allocates a new document. It returns the new document ID.
 func (dc *DocumentsController) Create(tpl string) (int, error) {
-	response, err := dc.c.Client.Call("one.document.allocate", tpl)
+	return dc.CreateContext(context.Background(), tpl)
+}
+
+func (dc *DocumentsController) CreateContext(ctx context.Context, tpl string) (int, error) {
+	response, err := dc.c.Client.CallContext(ctx, "one.document.allocate", tpl)
 	if err != nil {
 		return -1, err
 	}
@@ -123,13 +135,21 @@ func (dc *DocumentsController) Create(tpl string) (int, error) {
 // Clone clones an existing document.
 // * newName: Name for the new document.
 func (dc *DocumentController) Clone(newName string) error {
-	_, err := dc.c.Client.Call("one.document.clone", dc.ID, newName)
+	return dc.CloneContext(context.Background(), newName)
+}
+
+func (dc *DocumentController) CloneContext(ctx context.Context, newName string) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.clone", dc.ID, newName)
 	return err
 }
 
 // Delete deletes the given document from the pool.
 func (dc *DocumentController) Delete() error {
-	_, err := dc.c.Client.Call("one.document.delete", dc.ID)
+	return dc.DeleteContext(context.Background())
+}
+
+func (dc *DocumentController) DeleteContext(ctx context.Context) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.delete", dc.ID)
 	return err
 }
 
@@ -138,14 +158,22 @@ func (dc *DocumentController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (dc *DocumentController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := dc.c.Client.Call("one.document.update", dc.ID, tpl, uType)
+	return dc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (dc *DocumentController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.update", dc.ID, tpl, uType)
 	return err
 }
 
 // Chmod changes the permission bits of a document.
 func (dc *DocumentController) Chmod(perm shared.Permissions) error {
+	return dc.ChmodContext(context.Background(), perm)
+}
+
+func (dc *DocumentController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{dc.ID}, perm.ToArgs()...)
-	_, err := dc.c.Client.Call("one.document.chmod", args...)
+	_, err := dc.c.Client.CallContext(ctx, "one.document.chmod", args...)
 	return err
 }
 
@@ -153,25 +181,41 @@ func (dc *DocumentController) Chmod(perm shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (dc *DocumentController) Chown(userID, groupID int) error {
-	_, err := dc.c.Client.Call("one.document.chown", dc.ID, userID, groupID)
+	return dc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (dc *DocumentController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.chown", dc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a document.
 // * newName: The new name.
 func (dc *DocumentController) Rename(newName string) error {
-	_, err := dc.c.Client.Call("one.document.rename", dc.ID, newName)
+	return dc.RenameContext(context.Background(), newName)
+}
+
+func (dc *DocumentController) RenameContext(ctx context.Context, newName string) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.rename", dc.ID, newName)
 	return err
 }
 
 // Lock locks the document following lock level. See levels in locks.go.
 func (dc *DocumentController) Lock(level shared.LockLevel) error {
-	_, err := dc.c.Client.Call("one.document.lock", dc.ID, level)
+	return dc.LockContext(context.Background(), level)
+}
+
+func (dc *DocumentController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.lock", dc.ID, level)
 	return err
 }
 
 // Unlock unlocks the document.
 func (dc *DocumentController) Unlock() error {
-	_, err := dc.c.Client.Call("one.document.unlock", dc.ID)
+	return dc.UnlockContext(context.Background())
+}
+
+func (dc *DocumentController) UnlockContext(ctx context.Context) error {
+	_, err := dc.c.Client.CallContext(ctx, "one.document.unlock", dc.ID)
 	return err
 }

--- a/src/oca/go/src/goca/document.go
+++ b/src/oca/go/src/goca/document.go
@@ -47,9 +47,13 @@ func (c *Controller) Document(id int) *DocumentController {
 
 // ByName returns a Document ID from name
 func (dc *DocumentsController) ByName(name string, args ...int) (int, error) {
+	return dc.ByNameContext(context.Background(), name, args...)
+}
+
+func (dc *DocumentsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	documentPool, err := dc.Info(args...)
+	documentPool, err := dc.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/document.go
+++ b/src/oca/go/src/goca/document.go
@@ -50,6 +50,7 @@ func (dc *DocumentsController) ByName(name string, args ...int) (int, error) {
 	return dc.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns a Document ID from name
 func (dc *DocumentsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -82,6 +83,8 @@ func (dc *DocumentsController) Info(args ...int) (*document.Pool, error) {
 	return dc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a document pool. A connection to OpenNebula is
+// performed.
 func (dc *DocumentsController) InfoContext(ctx context.Context, args ...int) (*document.Pool, error) {
 	fArgs, err := handleArgs(args)
 	if err != nil {
@@ -108,6 +111,7 @@ func (dc *DocumentController) Info(decrypt bool) (*document.Document, error) {
 	return dc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the document.
 func (dc *DocumentController) InfoContext(ctx context.Context, decrypt bool) (*document.Document, error) {
 	response, err := dc.c.Client.CallContext(ctx, "one.document.info", dc.ID, decrypt)
 	if err != nil {
@@ -127,6 +131,7 @@ func (dc *DocumentsController) Create(tpl string) (int, error) {
 	return dc.CreateContext(context.Background(), tpl)
 }
 
+// CreateContext allocates a new document. It returns the new document ID.
 func (dc *DocumentsController) CreateContext(ctx context.Context, tpl string) (int, error) {
 	response, err := dc.c.Client.CallContext(ctx, "one.document.allocate", tpl)
 	if err != nil {
@@ -142,6 +147,9 @@ func (dc *DocumentController) Clone(newName string) error {
 	return dc.CloneContext(context.Background(), newName)
 }
 
+// CloneContext clones an existing document.
+// * ctx: context for cancelation
+// * newName: Name for the new document.
 func (dc *DocumentController) CloneContext(ctx context.Context, newName string) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.document.clone", dc.ID, newName)
 	return err
@@ -152,6 +160,7 @@ func (dc *DocumentController) Delete() error {
 	return dc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given document from the pool.
 func (dc *DocumentController) DeleteContext(ctx context.Context) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.document.delete", dc.ID)
 	return err
@@ -165,6 +174,11 @@ func (dc *DocumentController) Update(tpl string, uType parameters.UpdateType) er
 	return dc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds document content.
+//   - ctx: context for cancelation
+//   - tpl: The new document contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (dc *DocumentController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.document.update", dc.ID, tpl, uType)
 	return err
@@ -175,6 +189,7 @@ func (dc *DocumentController) Chmod(perm shared.Permissions) error {
 	return dc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a document.
 func (dc *DocumentController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{dc.ID}, perm.ToArgs()...)
 	_, err := dc.c.Client.CallContext(ctx, "one.document.chmod", args...)
@@ -188,6 +203,10 @@ func (dc *DocumentController) Chown(userID, groupID int) error {
 	return dc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a document.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (dc *DocumentController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.document.chown", dc.ID, userID, groupID)
 	return err
@@ -199,6 +218,9 @@ func (dc *DocumentController) Rename(newName string) error {
 	return dc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a document.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (dc *DocumentController) RenameContext(ctx context.Context, newName string) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.document.rename", dc.ID, newName)
 	return err
@@ -209,6 +231,7 @@ func (dc *DocumentController) Lock(level shared.LockLevel) error {
 	return dc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the document following lock level. See levels in locks.go.
 func (dc *DocumentController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := dc.c.Client.CallContext(ctx, "one.document.lock", dc.ID, level)
 	return err

--- a/src/oca/go/src/goca/group.go
+++ b/src/oca/go/src/goca/group.go
@@ -43,9 +43,13 @@ func (c *Controller) Group(id int) *GroupController {
 
 // ByName returns a Group ID from name
 func (c *GroupsController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *GroupsController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	groupPool, err := c.Info()
+	groupPool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/group.go
+++ b/src/oca/go/src/goca/group.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,7 +71,11 @@ func (c *GroupsController) ByName(name string) (int, error) {
 // Info returns a group pool. A connection to OpenNebula is
 // performed.
 func (gc *GroupsController) Info() (*group.Pool, error) {
-	response, err := gc.c.Client.Call("one.grouppool.info")
+	return gc.InfoContext(context.Background())
+}
+
+func (gc *GroupsController) InfoContext(ctx context.Context) (*group.Pool, error) {
+	response, err := gc.c.Client.CallContext(ctx, "one.grouppool.info")
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +91,11 @@ func (gc *GroupsController) Info() (*group.Pool, error) {
 
 // Info retrieves information for the group.
 func (gc *GroupController) Info(decrypt bool) (*group.Group, error) {
-	response, err := gc.c.Client.Call("one.group.info", gc.ID, decrypt)
+	return gc.InfoContext(context.Background(), decrypt)
+}
+
+func (gc *GroupController) InfoContext(ctx context.Context, decrypt bool) (*group.Group, error) {
+	response, err := gc.c.Client.CallContext(ctx, "one.group.info", gc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +109,11 @@ func (gc *GroupController) Info(decrypt bool) (*group.Group, error) {
 
 // Create allocates a new group. It returns the new group ID.
 func (gc *GroupsController) Create(name string) (int, error) {
-	response, err := gc.c.Client.Call("one.group.allocate", name)
+	return gc.CreateContext(context.Background(), name)
+}
+
+func (gc *GroupsController) CreateContext(ctx context.Context, name string) (int, error) {
+	response, err := gc.c.Client.CallContext(ctx, "one.group.allocate", name)
 	if err != nil {
 		return -1, err
 	}
@@ -110,7 +123,11 @@ func (gc *GroupsController) Create(name string) (int, error) {
 
 // Delete deletes the given group from the pool.
 func (gc *GroupController) Delete() error {
-	_, err := gc.c.Client.Call("one.group.delete", gc.ID)
+	return gc.DeleteContext(context.Background())
+}
+
+func (gc *GroupController) DeleteContext(ctx context.Context) error {
+	_, err := gc.c.Client.CallContext(ctx, "one.group.delete", gc.ID)
 	return err
 }
 
@@ -119,27 +136,43 @@ func (gc *GroupController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (gc *GroupController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := gc.c.Client.Call("one.group.update", gc.ID, tpl, uType)
+	return gc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (gc *GroupController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := gc.c.Client.CallContext(ctx, "one.group.update", gc.ID, tpl, uType)
 	return err
 }
 
 // AddAdmin adds a User to the Group administrators set
 // * userID: The user ID.
 func (gc *GroupController) AddAdmin(userID int) error {
-	_, err := gc.c.Client.Call("one.group.addadmin", gc.ID, int(userID))
+	return gc.AddAdminContext(context.Background(), userID)
+}
+
+func (gc *GroupController) AddAdminContext(ctx context.Context, userID int) error {
+	_, err := gc.c.Client.CallContext(ctx, "one.group.addadmin", gc.ID, int(userID))
 	return err
 }
 
 // DelAdmin removes a User from the Group administrators set
 // * userID: The user ID.
 func (gc *GroupController) DelAdmin(userID int) error {
-	_, err := gc.c.Client.Call("one.group.deladmin", gc.ID, int(userID))
+	return gc.DelAdminContext(context.Background(), userID)
+}
+
+func (gc *GroupController) DelAdminContext(ctx context.Context, userID int) error {
+	_, err := gc.c.Client.CallContext(ctx, "one.group.deladmin", gc.ID, int(userID))
 	return err
 }
 
 // Quota sets the group quota limits.
 // * tpl: The new quota template contents. Syntax can be the usual attribute=value or XML.
 func (gc *GroupController) Quota(tpl string) error {
-	_, err := gc.c.Client.Call("one.group.quota", gc.ID, tpl)
+	return gc.QuotaContext(context.Background(), tpl)
+}
+
+func (gc *GroupController) QuotaContext(ctx context.Context, tpl string) error {
+	_, err := gc.c.Client.CallContext(ctx, "one.group.quota", gc.ID, tpl)
 	return err
 }

--- a/src/oca/go/src/goca/group.go
+++ b/src/oca/go/src/goca/group.go
@@ -46,6 +46,7 @@ func (c *GroupsController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a Group ID from name
 func (c *GroupsController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -78,6 +79,8 @@ func (gc *GroupsController) Info() (*group.Pool, error) {
 	return gc.InfoContext(context.Background())
 }
 
+// InfoContext returns a group pool. A connection to OpenNebula is
+// performed.
 func (gc *GroupsController) InfoContext(ctx context.Context) (*group.Pool, error) {
 	response, err := gc.c.Client.CallContext(ctx, "one.grouppool.info")
 	if err != nil {
@@ -98,6 +101,7 @@ func (gc *GroupController) Info(decrypt bool) (*group.Group, error) {
 	return gc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the group.
 func (gc *GroupController) InfoContext(ctx context.Context, decrypt bool) (*group.Group, error) {
 	response, err := gc.c.Client.CallContext(ctx, "one.group.info", gc.ID, decrypt)
 	if err != nil {
@@ -116,6 +120,7 @@ func (gc *GroupsController) Create(name string) (int, error) {
 	return gc.CreateContext(context.Background(), name)
 }
 
+// CreateContext allocates a new group. It returns the new group ID.
 func (gc *GroupsController) CreateContext(ctx context.Context, name string) (int, error) {
 	response, err := gc.c.Client.CallContext(ctx, "one.group.allocate", name)
 	if err != nil {
@@ -130,6 +135,7 @@ func (gc *GroupController) Delete() error {
 	return gc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given group from the pool.
 func (gc *GroupController) DeleteContext(ctx context.Context) error {
 	_, err := gc.c.Client.CallContext(ctx, "one.group.delete", gc.ID)
 	return err
@@ -143,6 +149,11 @@ func (gc *GroupController) Update(tpl string, uType parameters.UpdateType) error
 	return gc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// Update adds group content.
+//   - ctx: context for cancelation
+//   - tpl: The new group contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (gc *GroupController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := gc.c.Client.CallContext(ctx, "one.group.update", gc.ID, tpl, uType)
 	return err
@@ -154,6 +165,9 @@ func (gc *GroupController) AddAdmin(userID int) error {
 	return gc.AddAdminContext(context.Background(), userID)
 }
 
+// AddAdmin adds a User to the Group administrators set
+// * ctx: context for cancelation
+// * userID: The user ID.
 func (gc *GroupController) AddAdminContext(ctx context.Context, userID int) error {
 	_, err := gc.c.Client.CallContext(ctx, "one.group.addadmin", gc.ID, int(userID))
 	return err
@@ -165,6 +179,9 @@ func (gc *GroupController) DelAdmin(userID int) error {
 	return gc.DelAdminContext(context.Background(), userID)
 }
 
+// DelAdmin removes a User from the Group administrators set
+// * ctx: context for cancelation
+// * userID: The user ID.
 func (gc *GroupController) DelAdminContext(ctx context.Context, userID int) error {
 	_, err := gc.c.Client.CallContext(ctx, "one.group.deladmin", gc.ID, int(userID))
 	return err
@@ -176,6 +193,9 @@ func (gc *GroupController) Quota(tpl string) error {
 	return gc.QuotaContext(context.Background(), tpl)
 }
 
+// Quota sets the group quota limits.
+// * ctx: context for cancelation
+// * tpl: The new quota template contents. Syntax can be the usual attribute=value or XML.
 func (gc *GroupController) QuotaContext(ctx context.Context, tpl string) error {
 	_, err := gc.c.Client.CallContext(ctx, "one.group.quota", gc.ID, tpl)
 	return err

--- a/src/oca/go/src/goca/hook.go
+++ b/src/oca/go/src/goca/hook.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,13 +71,17 @@ func (c *HooksController) ByName(name string) (int, error) {
 // Info returns a hook pool. A connection to OpenNebula is
 // performed
 func (hc *HooksController) Info(args ...int) (*hook.Pool, error) {
+	return hc.InfoContext(context.Background(), args...)
+}
+
+func (hc *HooksController) InfoContext(ctx context.Context, args ...int) (*hook.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := hc.c.Client.Call("one.hookpool.info", fArgs...)
+	response, err := hc.c.Client.CallContext(ctx, "one.hookpool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +96,11 @@ func (hc *HooksController) Info(args ...int) (*hook.Pool, error) {
 
 // Info retrieves information for the hook from ID
 func (hc *HookController) Info(decrypt bool) (*hook.Hook, error) {
-	response, err := hc.c.Client.Call("one.hook.info", hc.ID, decrypt)
+	return hc.InfoContext(context.Background(), decrypt)
+}
+
+func (hc *HookController) InfoContext(ctx context.Context, decrypt bool) (*hook.Hook, error) {
+	response, err := hc.c.Client.CallContext(ctx, "one.hook.info", hc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +116,11 @@ func (hc *HookController) Info(decrypt bool) (*hook.Hook, error) {
 // * name: name of the hook
 // * template: hook template.
 func (hc *HooksController) Create(template string) (int, error) {
-	response, err := hc.c.Client.Call("one.hook.allocate", template)
+	return hc.CreateContext(context.Background(), template)
+}
+
+func (hc *HooksController) CreateContext(ctx context.Context, template string) (int, error) {
+	response, err := hc.c.Client.CallContext(ctx, "one.hook.allocate", template)
 	if err != nil {
 		return -1, err
 	}
@@ -117,7 +130,11 @@ func (hc *HooksController) Create(template string) (int, error) {
 
 // Delete deletes the given hook from the pool
 func (hc *HookController) Delete() error {
-	_, err := hc.c.Client.Call("one.hook.delete", hc.ID)
+	return hc.DeleteContext(context.Background())
+}
+
+func (hc *HookController) DeleteContext(ctx context.Context) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.hook.delete", hc.ID)
 	return err
 }
 
@@ -126,31 +143,51 @@ func (hc *HookController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (hc *HookController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := hc.c.Client.Call("one.hook.update", hc.ID, tpl, uType)
+	return hc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (hc *HookController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.hook.update", hc.ID, tpl, uType)
 	return err
 }
 
 // Rename renames a hook.
 // * newName: The new name.
 func (hc *HookController) Rename(newName string) error {
-	_, err := hc.c.Client.Call("one.hook.rename", hc.ID, newName)
+	return hc.RenameContext(context.Background(), newName)
+}
+
+func (hc *HookController) RenameContext(ctx context.Context, newName string) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.hook.rename", hc.ID, newName)
 	return err
 }
 
 // Lock locks the hook following lock level. See levels in locks.go.
 func (hc *HookController) Lock(level shared.LockLevel) error {
-	_, err := hc.c.Client.Call("one.hook.lock", hc.ID, level)
+	return hc.LockContext(context.Background(), level)
+}
+
+func (hc *HookController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.hook.lock", hc.ID, level)
 	return err
 }
 
 // Unlock unlocks the hook.
 func (hc *HookController) Unlock() error {
-	_, err := hc.c.Client.Call("one.hook.unlock", hc.ID)
+	return hc.UnlockContext(context.Background())
+}
+
+func (hc *HookController) UnlockContext(ctx context.Context) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.hook.unlock", hc.ID)
 	return err
 }
 
 // Retry retry a hook execution
 func (hc *HookController) Retry(exec_id int) error {
-	_, err := hc.c.Client.Call("one.hook.retry", hc.ID, exec_id)
+	return hc.RetryContext(context.Background(), exec_id)
+}
+
+func (hc *HookController) RetryContext(ctx context.Context, exec_id int) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.hook.retry", hc.ID, exec_id)
 	return err
 }

--- a/src/oca/go/src/goca/hook.go
+++ b/src/oca/go/src/goca/hook.go
@@ -44,9 +44,13 @@ func (c *Controller) Hook(id int) *HookController {
 
 // ByName finds a Hook ID from name
 func (c *HooksController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *HooksController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	hookPool, err := c.Info()
+	hookPool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/hook.go
+++ b/src/oca/go/src/goca/hook.go
@@ -47,6 +47,7 @@ func (c *HooksController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext finds a Hook ID from name
 func (c *HooksController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -78,6 +79,8 @@ func (hc *HooksController) Info(args ...int) (*hook.Pool, error) {
 	return hc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a hook pool. A connection to OpenNebula is
+// performed
 func (hc *HooksController) InfoContext(ctx context.Context, args ...int) (*hook.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -103,6 +106,7 @@ func (hc *HookController) Info(decrypt bool) (*hook.Hook, error) {
 	return hc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the hook from ID
 func (hc *HookController) InfoContext(ctx context.Context, decrypt bool) (*hook.Hook, error) {
 	response, err := hc.c.Client.CallContext(ctx, "one.hook.info", hc.ID, decrypt)
 	if err != nil {
@@ -123,6 +127,10 @@ func (hc *HooksController) Create(template string) (int, error) {
 	return hc.CreateContext(context.Background(), template)
 }
 
+// Create allocates a new hook. It returns the new hook ID.
+// * ctx: context for cancelation
+// * name: name of the hook
+// * template: hook template.
 func (hc *HooksController) CreateContext(ctx context.Context, template string) (int, error) {
 	response, err := hc.c.Client.CallContext(ctx, "one.hook.allocate", template)
 	if err != nil {
@@ -137,6 +145,7 @@ func (hc *HookController) Delete() error {
 	return hc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given hook from the pool
 func (hc *HookController) DeleteContext(ctx context.Context) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.hook.delete", hc.ID)
 	return err
@@ -150,6 +159,11 @@ func (hc *HookController) Update(tpl string, uType parameters.UpdateType) error 
 	return hc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext replaces the hook content.
+//   - ctx: context for cancelation
+//   - tpl: The new hook contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (hc *HookController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.hook.update", hc.ID, tpl, uType)
 	return err
@@ -161,6 +175,9 @@ func (hc *HookController) Rename(newName string) error {
 	return hc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a hook.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (hc *HookController) RenameContext(ctx context.Context, newName string) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.hook.rename", hc.ID, newName)
 	return err
@@ -171,6 +188,7 @@ func (hc *HookController) Lock(level shared.LockLevel) error {
 	return hc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the hook following lock level. See levels in locks.go.
 func (hc *HookController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.hook.lock", hc.ID, level)
 	return err
@@ -181,6 +199,7 @@ func (hc *HookController) Unlock() error {
 	return hc.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the hook.
 func (hc *HookController) UnlockContext(ctx context.Context) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.hook.unlock", hc.ID)
 	return err
@@ -191,6 +210,7 @@ func (hc *HookController) Retry(exec_id int) error {
 	return hc.RetryContext(context.Background(), exec_id)
 }
 
+// RetryContext retry a hook execution
 func (hc *HookController) RetryContext(ctx context.Context, exec_id int) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.hook.retry", hc.ID, exec_id)
 	return err

--- a/src/oca/go/src/goca/hooklog.go
+++ b/src/oca/go/src/goca/hooklog.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 
 	"github.com/OpenNebula/one/src/oca/go/src/goca/schemas/hook"
@@ -36,7 +37,11 @@ func (c *Controller) HookLog() *HookLogController {
 // * hookId: Hook ID to filer for.
 // * rc: return code of the hook execution to filer for. (-1 error, 0 all, 1 success)
 func (hc *HookLogController) Info(minTs, maxTs, hookId, hook_rc int) (*hook.HookLog, error) {
-	response, err := hc.c.Client.Call("one.hooklog.info", minTs, maxTs, hookId, hook_rc)
+	return hc.InfoContext(context.Background(), minTs, maxTs, hookId, hook_rc)
+}
+
+func (hc *HookLogController) InfoContext(ctx context.Context, minTs, maxTs, hookId, hook_rc int) (*hook.HookLog, error) {
+	response, err := hc.c.Client.CallContext(ctx, "one.hooklog.info", minTs, maxTs, hookId, hook_rc)
 	if err != nil {
 		return nil, err
 	}

--- a/src/oca/go/src/goca/hooklog.go
+++ b/src/oca/go/src/goca/hooklog.go
@@ -40,6 +40,12 @@ func (hc *HookLogController) Info(minTs, maxTs, hookId, hook_rc int) (*hook.Hook
 	return hc.InfoContext(context.Background(), minTs, maxTs, hookId, hook_rc)
 }
 
+// InfoContext retrieves information for the hook from ID
+// * ctx: context for cancelation
+// * minTs: Min timestamp to filter for.
+// * maxTs: Max timestamp to filter for
+// * hookId: Hook ID to filer for.
+// * rc: return code of the hook execution to filer for. (-1 error, 0 all, 1 success)
 func (hc *HookLogController) InfoContext(ctx context.Context, minTs, maxTs, hookId, hook_rc int) (*hook.HookLog, error) {
 	response, err := hc.c.Client.CallContext(ctx, "one.hooklog.info", minTs, maxTs, hookId, hook_rc)
 	if err != nil {

--- a/src/oca/go/src/goca/host.go
+++ b/src/oca/go/src/goca/host.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -69,7 +70,11 @@ func (c *HostsController) ByName(name string) (int, error) {
 // Info returns a host pool. A connection to OpenNebula is
 // performed
 func (hc *HostsController) Info() (*host.Pool, error) {
-	response, err := hc.c.Client.Call("one.hostpool.info")
+	return hc.InfoContext(context.Background())
+}
+
+func (hc *HostsController) InfoContext(ctx context.Context) (*host.Pool, error) {
+	response, err := hc.c.Client.CallContext(ctx, "one.hostpool.info")
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +89,11 @@ func (hc *HostsController) Info() (*host.Pool, error) {
 
 // Info retrieves information for the host from ID
 func (hc *HostController) Info(decrypt bool) (*host.Host, error) {
-	response, err := hc.c.Client.Call("one.host.info", hc.ID, decrypt)
+	return hc.InfoContext(context.Background(), decrypt)
+}
+
+func (hc *HostController) InfoContext(ctx context.Context, decrypt bool) (*host.Host, error) {
+	response, err := hc.c.Client.CallContext(ctx, "one.host.info", hc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +111,11 @@ func (hc *HostController) Info(decrypt bool) (*host.Host, error) {
 // * vm: virtualization driver for the host
 // * clusterID: The cluster ID. If it is -1, the default one will be used.
 func (hc *HostsController) Create(name, im, vm string, clusterID int) (int, error) {
-	response, err := hc.c.Client.Call("one.host.allocate", name, im, vm, clusterID)
+	return hc.CreateContext(context.Background(), name, im, vm, clusterID)
+}
+
+func (hc *HostsController) CreateContext(ctx context.Context, name, im, vm string, clusterID int) (int, error) {
+	response, err := hc.c.Client.CallContext(ctx, "one.host.allocate", name, im, vm, clusterID)
 	if err != nil {
 		return -1, err
 	}
@@ -114,7 +127,11 @@ func (hc *HostsController) Create(name, im, vm string, clusterID int) (int, erro
 // num: Retrieve monitor records in the last num seconds.
 // 0 just the last record, -1 all records
 func (hc *HostsController) Monitoring(num int) (*host.PoolMonitoring, error) {
-	monitorData, err := hc.c.Client.Call("one.hostpool.monitoring", num)
+	return hc.MonitoringContext(context.Background(), num)
+}
+
+func (hc *HostsController) MonitoringContext(ctx context.Context, num int) (*host.PoolMonitoring, error) {
+	monitorData, err := hc.c.Client.CallContext(ctx, "one.hostpool.monitoring", num)
 	if err != nil {
 		return nil, err
 	}
@@ -130,14 +147,22 @@ func (hc *HostsController) Monitoring(num int) (*host.PoolMonitoring, error) {
 
 // Delete deletes the given host from the pool
 func (hc *HostController) Delete() error {
-	_, err := hc.c.Client.Call("one.host.delete", hc.ID)
+	return hc.DeleteContext(context.Background())
+}
+
+func (hc *HostController) DeleteContext(ctx context.Context) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.host.delete", hc.ID)
 	return err
 }
 
 // Status sets the status of the host
 // * status: 0: ENABLED, 1: DISABLED, 2: OFFLINE
 func (hc *HostController) Status(status int) error {
-	_, err := hc.c.Client.Call("one.host.status", hc.ID, status)
+	return hc.StatusContext(context.Background(), status)
+}
+
+func (hc *HostController) StatusContext(ctx context.Context, status int) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.host.status", hc.ID, status)
 	return err
 }
 
@@ -146,20 +171,32 @@ func (hc *HostController) Status(status int) error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (hc *HostController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := hc.c.Client.Call("one.host.update", hc.ID, tpl, uType)
+	return hc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (hc *HostController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.host.update", hc.ID, tpl, uType)
 	return err
 }
 
 // Rename renames a host.
 // * newName: The new name.
 func (hc *HostController) Rename(newName string) error {
-	_, err := hc.c.Client.Call("one.host.rename", hc.ID, newName)
+	return hc.RenameContext(context.Background(), newName)
+}
+
+func (hc *HostController) RenameContext(ctx context.Context, newName string) error {
+	_, err := hc.c.Client.CallContext(ctx, "one.host.rename", hc.ID, newName)
 	return err
 }
 
 // Monitoring returns the host monitoring records.
 func (hc *HostController) Monitoring() (*host.Monitoring, error) {
-	monitorData, err := hc.c.Client.Call("one.host.monitoring", hc.ID)
+	return hc.MonitoringContext(context.Background())
+}
+
+func (hc *HostController) MonitoringContext(ctx context.Context) (*host.Monitoring, error) {
+	monitorData, err := hc.c.Client.CallContext(ctx, "one.host.monitoring", hc.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/src/oca/go/src/goca/host.go
+++ b/src/oca/go/src/goca/host.go
@@ -43,9 +43,13 @@ func (c *Controller) Host(id int) *HostController {
 
 // ByName finds a Host ID from name
 func (c *HostsController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *HostsController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	hostPool, err := c.Info()
+	hostPool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/host.go
+++ b/src/oca/go/src/goca/host.go
@@ -46,6 +46,7 @@ func (c *HostsController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext finds a Host ID from name
 func (c *HostsController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -77,6 +78,8 @@ func (hc *HostsController) Info() (*host.Pool, error) {
 	return hc.InfoContext(context.Background())
 }
 
+// InfoContext returns a host pool. A connection to OpenNebula is
+// performed
 func (hc *HostsController) InfoContext(ctx context.Context) (*host.Pool, error) {
 	response, err := hc.c.Client.CallContext(ctx, "one.hostpool.info")
 	if err != nil {
@@ -96,6 +99,7 @@ func (hc *HostController) Info(decrypt bool) (*host.Host, error) {
 	return hc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the host from ID
 func (hc *HostController) InfoContext(ctx context.Context, decrypt bool) (*host.Host, error) {
 	response, err := hc.c.Client.CallContext(ctx, "one.host.info", hc.ID, decrypt)
 	if err != nil {
@@ -118,6 +122,12 @@ func (hc *HostsController) Create(name, im, vm string, clusterID int) (int, erro
 	return hc.CreateContext(context.Background(), name, im, vm, clusterID)
 }
 
+// Create allocates a new host. It returns the new host ID.
+// * ctx: context for cancelation
+// * name: name of the host
+// * im: information driver for the host
+// * vm: virtualization driver for the host
+// * clusterID: The cluster ID. If it is -1, the default one will be used.
 func (hc *HostsController) CreateContext(ctx context.Context, name, im, vm string, clusterID int) (int, error) {
 	response, err := hc.c.Client.CallContext(ctx, "one.host.allocate", name, im, vm, clusterID)
 	if err != nil {
@@ -134,6 +144,10 @@ func (hc *HostsController) Monitoring(num int) (*host.PoolMonitoring, error) {
 	return hc.MonitoringContext(context.Background(), num)
 }
 
+// MonitoringContext Returns the Hosts monitoring records
+// ctx: context for cancelation
+// num: Retrieve monitor records in the last num seconds.
+// 0 just the last record, -1 all records
 func (hc *HostsController) MonitoringContext(ctx context.Context, num int) (*host.PoolMonitoring, error) {
 	monitorData, err := hc.c.Client.CallContext(ctx, "one.hostpool.monitoring", num)
 	if err != nil {
@@ -154,6 +168,7 @@ func (hc *HostController) Delete() error {
 	return hc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given host from the pool
 func (hc *HostController) DeleteContext(ctx context.Context) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.host.delete", hc.ID)
 	return err
@@ -165,19 +180,27 @@ func (hc *HostController) Status(status int) error {
 	return hc.StatusContext(context.Background(), status)
 }
 
+// StatusContext sets the status of the host
+// * ctx: context for cancelation
+// * status: 0: ENABLED, 1: DISABLED, 2: OFFLINE
 func (hc *HostController) StatusContext(ctx context.Context, status int) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.host.status", hc.ID, status)
 	return err
 }
 
 // Update adds host content.
-// * tpl: The new host contents. Syntax can be the usual attribute=value or XML.
-// * uType: Update type: Replace: Replace the whole template.
-//   Merge: Merge new template with the existing one.
+//   - tpl: The new host contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (hc *HostController) Update(tpl string, uType parameters.UpdateType) error {
 	return hc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds host content.
+//   - ctx: context for cancelation
+//   - tpl: The new host contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (hc *HostController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.host.update", hc.ID, tpl, uType)
 	return err
@@ -189,6 +212,9 @@ func (hc *HostController) Rename(newName string) error {
 	return hc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a host.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (hc *HostController) RenameContext(ctx context.Context, newName string) error {
 	_, err := hc.c.Client.CallContext(ctx, "one.host.rename", hc.ID, newName)
 	return err
@@ -199,6 +225,7 @@ func (hc *HostController) Monitoring() (*host.Monitoring, error) {
 	return hc.MonitoringContext(context.Background())
 }
 
+// MonitoringContext returns the host monitoring records.
 func (hc *HostController) MonitoringContext(ctx context.Context) (*host.Monitoring, error) {
 	monitorData, err := hc.c.Client.CallContext(ctx, "one.host.monitoring", hc.ID)
 	if err != nil {

--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -78,13 +79,17 @@ func (c *ImagesController) ByName(name string, args ...int) (int, error) {
 
 // Info returns a new image pool. It accepts the scope of the query.
 func (ic *ImagesController) Info(args ...int) (*image.Pool, error) {
+	return ic.InfoContext(context.Background(), args...)
+}
+
+func (ic *ImagesController) InfoContext(ctx context.Context, args ...int) (*image.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := ic.c.Client.Call("one.imagepool.info", fArgs...)
+	response, err := ic.c.Client.CallContext(ctx, "one.imagepool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +105,11 @@ func (ic *ImagesController) Info(args ...int) (*image.Pool, error) {
 
 // Info connects to OpenNebula and fetches the information of the Image
 func (ic *ImageController) Info(decrypt bool) (*image.Image, error) {
-	response, err := ic.c.Client.Call("one.image.info", ic.ID, decrypt)
+	return ic.InfoContext(context.Background(), decrypt)
+}
+
+func (ic *ImageController) InfoContext(ctx context.Context, decrypt bool) (*image.Image, error) {
+	response, err := ic.c.Client.CallContext(ctx, "one.image.info", ic.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +124,11 @@ func (ic *ImageController) Info(decrypt bool) (*image.Image, error) {
 // Create allocates a new image based on the template string provided. It
 // returns the image ID.
 func (ic *ImagesController) Create(template string, dsid uint) (int, error) {
-	response, err := ic.c.Client.Call("one.image.allocate", template, dsid)
+	return ic.CreateContext(context.Background(), template, dsid)
+}
+
+func (ic *ImagesController) CreateContext(ctx context.Context, template string, dsid uint) (int, error) {
+	response, err := ic.c.Client.CallContext(ctx, "one.image.allocate", template, dsid)
 	if err != nil {
 		return -1, err
 	}
@@ -125,7 +138,11 @@ func (ic *ImagesController) Create(template string, dsid uint) (int, error) {
 
 // Clone clones an existing image. It returns the clone ID
 func (ic *ImageController) Clone(cloneName string, dsid int) (int, error) {
-	response, err := ic.c.Client.Call("one.image.clone", ic.ID, cloneName, dsid)
+	return ic.CloneContext(context.Background(), cloneName, dsid)
+}
+
+func (ic *ImageController) CloneContext(ctx context.Context, cloneName string, dsid int) (int, error) {
+	response, err := ic.c.Client.CallContext(ctx, "one.image.clone", ic.ID, cloneName, dsid)
 	if err != nil {
 		return -1, err
 	}
@@ -138,83 +155,135 @@ func (ic *ImageController) Clone(cloneName string, dsid int) (int, error) {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (ic *ImageController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := ic.c.Client.Call("one.image.update", ic.ID, tpl, uType)
+	return ic.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (ic *ImageController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.update", ic.ID, tpl, uType)
 	return err
 }
 
 // Chtype changes the type of the Image
 func (ic *ImageController) Chtype(newType string) error {
-	_, err := ic.c.Client.Call("one.image.chtype", ic.ID, newType)
+	return ic.ChtypeContext(context.Background(), newType)
+}
+
+func (ic *ImageController) ChtypeContext(ctx context.Context, newType string) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.chtype", ic.ID, newType)
 	return err
 }
 
 // Chown changes the owner/group of the image. If uid or gid is -1 it will not
 // change
 func (ic *ImageController) Chown(uid, gid int) error {
-	_, err := ic.c.Client.Call("one.image.chown", ic.ID, uid, gid)
+	return ic.ChownContext(context.Background(), uid, gid)
+}
+
+func (ic *ImageController) ChownContext(ctx context.Context, uid, gid int) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.chown", ic.ID, uid, gid)
 	return err
 }
 
 // Chmod changes the permissions of the image. If any perm is -1 it will not
 // change
 func (ic *ImageController) Chmod(perm shared.Permissions) error {
+	return ic.ChmodContext(context.Background(), perm)
+}
+
+func (ic *ImageController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{ic.ID}, perm.ToArgs()...)
 
-	_, err := ic.c.Client.Call("one.image.chmod", args...)
+	_, err := ic.c.Client.CallContext(ctx, "one.image.chmod", args...)
 	return err
 }
 
 // Rename changes the name of the image
 func (ic *ImageController) Rename(newName string) error {
-	_, err := ic.c.Client.Call("one.image.rename", ic.ID, newName)
+	return ic.RenameContext(context.Background(), newName)
+}
+
+func (ic *ImageController) RenameContext(ctx context.Context, newName string) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.rename", ic.ID, newName)
 	return err
 }
 
 // Delete will delete a snapshot from the image
 func (ic *ImageSnapshotController) Delete() error {
-	_, err := ic.c.Client.Call("one.image.snapshotdelete", ic.entityID, ic.ID)
+	return ic.DeleteContext(context.Background())
+}
+
+func (ic *ImageSnapshotController) DeleteContext(ctx context.Context) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.snapshotdelete", ic.entityID, ic.ID)
 	return err
 }
 
 // Revert reverts image state to a previous snapshot
 func (ic *ImageSnapshotController) Revert() error {
-	_, err := ic.c.Client.Call("one.image.snapshotrevert", ic.entityID, ic.ID)
+	return ic.RevertContext(context.Background())
+}
+
+func (ic *ImageSnapshotController) RevertContext(ctx context.Context) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.snapshotrevert", ic.entityID, ic.ID)
 	return err
 }
 
 // Flatten flattens the snapshot image and discards others
 func (ic *ImageSnapshotController) Flatten() error {
-	_, err := ic.c.Client.Call("one.image.snapshotflatten", ic.entityID, ic.ID)
+	return ic.FlattenContext(context.Background())
+}
+
+func (ic *ImageSnapshotController) FlattenContext(ctx context.Context) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.snapshotflatten", ic.entityID, ic.ID)
 	return err
 }
 
 // Enable enables (or disables) the image
 func (ic *ImageController) Enable(enable bool) error {
-	_, err := ic.c.Client.Call("one.image.enable", ic.ID, enable)
+	return ic.EnableContext(context.Background(), enable)
+}
+
+func (ic *ImageController) EnableContext(ctx context.Context, enable bool) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.enable", ic.ID, enable)
 	return err
 }
 
 // Persistent sets the image as persistent (or not)
 func (ic *ImageController) Persistent(persistent bool) error {
-	_, err := ic.c.Client.Call("one.image.persistent", ic.ID, persistent)
+	return ic.PersistentContext(context.Background(), persistent)
+}
+
+func (ic *ImageController) PersistentContext(ctx context.Context, persistent bool) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.persistent", ic.ID, persistent)
 	return err
 }
 
 // Lock locks the image following lock level. See levels in locks.go.
 func (ic *ImageController) Lock(level shared.LockLevel) error {
-	_, err := ic.c.Client.Call("one.image.lock", ic.ID, level)
+	return ic.LockContext(context.Background(), level)
+}
+
+func (ic *ImageController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.lock", ic.ID, level)
 	return err
 }
 
 // Unlock unlocks the image.
 func (ic *ImageController) Unlock() error {
-	_, err := ic.c.Client.Call("one.image.unlock", ic.ID)
+	return ic.UnlockContext(context.Background())
+}
+
+func (ic *ImageController) UnlockContext(ctx context.Context) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.unlock", ic.ID)
 	return err
 }
 
 // Delete will remove the image from OpenNebula, which will remove it from the
 // backend.
 func (ic *ImageController) Delete() error {
-	_, err := ic.c.Client.Call("one.image.delete", ic.ID)
+	return ic.DeleteContext(context.Background())
+}
+
+func (ic *ImageController) DeleteContext(ctx context.Context) error {
+	_, err := ic.c.Client.CallContext(ctx, "one.image.delete", ic.ID)
 	return err
 }

--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -52,9 +52,13 @@ func (ic *ImageController) Snapshot(id int) *ImageSnapshotController {
 
 // ByName returns an Image ID from name
 func (c *ImagesController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *ImagesController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	imagePool, err := c.Info(args...)
+	imagePool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/image.go
+++ b/src/oca/go/src/goca/image.go
@@ -55,6 +55,7 @@ func (c *ImagesController) ByName(name string, args ...int) (int, error) {
 	return c.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns an Image ID from name
 func (c *ImagesController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -86,6 +87,7 @@ func (ic *ImagesController) Info(args ...int) (*image.Pool, error) {
 	return ic.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a new image pool. It accepts the scope of the query.
 func (ic *ImagesController) InfoContext(ctx context.Context, args ...int) (*image.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -112,6 +114,7 @@ func (ic *ImageController) Info(decrypt bool) (*image.Image, error) {
 	return ic.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext connects to OpenNebula and fetches the information of the Image
 func (ic *ImageController) InfoContext(ctx context.Context, decrypt bool) (*image.Image, error) {
 	response, err := ic.c.Client.CallContext(ctx, "one.image.info", ic.ID, decrypt)
 	if err != nil {
@@ -131,6 +134,8 @@ func (ic *ImagesController) Create(template string, dsid uint) (int, error) {
 	return ic.CreateContext(context.Background(), template, dsid)
 }
 
+// CreateContext allocates a new image based on the template string provided. It
+// returns the image ID.
 func (ic *ImagesController) CreateContext(ctx context.Context, template string, dsid uint) (int, error) {
 	response, err := ic.c.Client.CallContext(ctx, "one.image.allocate", template, dsid)
 	if err != nil {
@@ -145,6 +150,7 @@ func (ic *ImageController) Clone(cloneName string, dsid int) (int, error) {
 	return ic.CloneContext(context.Background(), cloneName, dsid)
 }
 
+// CloneContext clones an existing image. It returns the clone ID
 func (ic *ImageController) CloneContext(ctx context.Context, cloneName string, dsid int) (int, error) {
 	response, err := ic.c.Client.CallContext(ctx, "one.image.clone", ic.ID, cloneName, dsid)
 	if err != nil {
@@ -162,6 +168,11 @@ func (ic *ImageController) Update(tpl string, uType parameters.UpdateType) error
 	return ic.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds image content.
+//   - ctx: context for cancelation
+//   - tpl: The new image contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (ic *ImageController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.update", ic.ID, tpl, uType)
 	return err
@@ -172,6 +183,7 @@ func (ic *ImageController) Chtype(newType string) error {
 	return ic.ChtypeContext(context.Background(), newType)
 }
 
+// ChtypeContext changes the type of the Image
 func (ic *ImageController) ChtypeContext(ctx context.Context, newType string) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.chtype", ic.ID, newType)
 	return err
@@ -183,6 +195,8 @@ func (ic *ImageController) Chown(uid, gid int) error {
 	return ic.ChownContext(context.Background(), uid, gid)
 }
 
+// ChownContext changes the owner/group of the image. If uid or gid is -1 it will not
+// change
 func (ic *ImageController) ChownContext(ctx context.Context, uid, gid int) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.chown", ic.ID, uid, gid)
 	return err
@@ -194,6 +208,8 @@ func (ic *ImageController) Chmod(perm shared.Permissions) error {
 	return ic.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permissions of the image. If any perm is -1 it will not
+// change
 func (ic *ImageController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{ic.ID}, perm.ToArgs()...)
 
@@ -206,6 +222,7 @@ func (ic *ImageController) Rename(newName string) error {
 	return ic.RenameContext(context.Background(), newName)
 }
 
+// RenameContext changes the name of the image
 func (ic *ImageController) RenameContext(ctx context.Context, newName string) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.rename", ic.ID, newName)
 	return err
@@ -216,6 +233,7 @@ func (ic *ImageSnapshotController) Delete() error {
 	return ic.DeleteContext(context.Background())
 }
 
+// DeleteContext will delete a snapshot from the image
 func (ic *ImageSnapshotController) DeleteContext(ctx context.Context) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.snapshotdelete", ic.entityID, ic.ID)
 	return err
@@ -226,6 +244,7 @@ func (ic *ImageSnapshotController) Revert() error {
 	return ic.RevertContext(context.Background())
 }
 
+// RevertContext reverts image state to a previous snapshot
 func (ic *ImageSnapshotController) RevertContext(ctx context.Context) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.snapshotrevert", ic.entityID, ic.ID)
 	return err
@@ -236,6 +255,7 @@ func (ic *ImageSnapshotController) Flatten() error {
 	return ic.FlattenContext(context.Background())
 }
 
+// FlattenContext flattens the snapshot image and discards others
 func (ic *ImageSnapshotController) FlattenContext(ctx context.Context) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.snapshotflatten", ic.entityID, ic.ID)
 	return err
@@ -246,6 +266,7 @@ func (ic *ImageController) Enable(enable bool) error {
 	return ic.EnableContext(context.Background(), enable)
 }
 
+// EnableContext enables (or disables) the image
 func (ic *ImageController) EnableContext(ctx context.Context, enable bool) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.enable", ic.ID, enable)
 	return err
@@ -256,6 +277,7 @@ func (ic *ImageController) Persistent(persistent bool) error {
 	return ic.PersistentContext(context.Background(), persistent)
 }
 
+// PersistentContext sets the image as persistent (or not)
 func (ic *ImageController) PersistentContext(ctx context.Context, persistent bool) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.persistent", ic.ID, persistent)
 	return err
@@ -266,6 +288,7 @@ func (ic *ImageController) Lock(level shared.LockLevel) error {
 	return ic.LockContext(context.Background(), level)
 }
 
+// LockContext locks the image following lock level. See levels in locks.go.
 func (ic *ImageController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.lock", ic.ID, level)
 	return err
@@ -276,6 +299,7 @@ func (ic *ImageController) Unlock() error {
 	return ic.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the image.
 func (ic *ImageController) UnlockContext(ctx context.Context) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.unlock", ic.ID)
 	return err
@@ -287,6 +311,8 @@ func (ic *ImageController) Delete() error {
 	return ic.DeleteContext(context.Background())
 }
 
+// DeleteContext will remove the image from OpenNebula, which will remove it from the
+// backend.
 func (ic *ImageController) DeleteContext(ctx context.Context) error {
 	_, err := ic.c.Client.CallContext(ctx, "one.image.delete", ic.ID)
 	return err

--- a/src/oca/go/src/goca/marketplace.go
+++ b/src/oca/go/src/goca/marketplace.go
@@ -44,9 +44,13 @@ func (c *Controller) MarketPlace(id int) *MarketPlaceController {
 
 // ByName return MarketPlace ID from name
 func (c *MarketPlacesController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *MarketPlacesController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	marketPool, err := c.Info()
+	marketPool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/marketplace.go
+++ b/src/oca/go/src/goca/marketplace.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -72,13 +73,17 @@ func (c *MarketPlacesController) ByName(name string) (int, error) {
 // Info returns a marketplace pool. A connection to OpenNebula is
 // performed.
 func (mc *MarketPlacesController) Info(args ...int) (*marketplace.Pool, error) {
+	return mc.InfoContext(context.Background(), args...)
+}
+
+func (mc *MarketPlacesController) InfoContext(ctx context.Context, args ...int) (*marketplace.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := mc.c.Client.Call("one.marketpool.info", fArgs...)
+	response, err := mc.c.Client.CallContext(ctx, "one.marketpool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +99,11 @@ func (mc *MarketPlacesController) Info(args ...int) (*marketplace.Pool, error) {
 
 // Info retrieves information for the marketplace.
 func (mc *MarketPlaceController) Info(decrypt bool) (*marketplace.MarketPlace, error) {
-	response, err := mc.c.Client.Call("one.market.info", mc.ID, decrypt)
+	return mc.InfoContext(context.Background(), decrypt)
+}
+
+func (mc *MarketPlaceController) InfoContext(ctx context.Context, decrypt bool) (*marketplace.MarketPlace, error) {
+	response, err := mc.c.Client.CallContext(ctx, "one.market.info", mc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +118,11 @@ func (mc *MarketPlaceController) Info(decrypt bool) (*marketplace.MarketPlace, e
 // Create allocates a new marketplace. It returns the new marketplace ID.
 // * tpl: template of the marketplace
 func (mc *MarketPlacesController) Create(tpl string) (int, error) {
-	response, err := mc.c.Client.Call("one.market.allocate", tpl)
+	return mc.CreateContext(context.Background(), tpl)
+}
+
+func (mc *MarketPlacesController) CreateContext(ctx context.Context, tpl string) (int, error) {
+	response, err := mc.c.Client.CallContext(ctx, "one.market.allocate", tpl)
 	if err != nil {
 		return -1, err
 	}
@@ -119,7 +132,11 @@ func (mc *MarketPlacesController) Create(tpl string) (int, error) {
 
 // Delete deletes the given marketplace from the pool.
 func (mc *MarketPlaceController) Delete() error {
-	_, err := mc.c.Client.Call("one.market.delete", mc.ID)
+	return mc.DeleteContext(context.Background())
+}
+
+func (mc *MarketPlaceController) DeleteContext(ctx context.Context) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.market.delete", mc.ID)
 	return err
 }
 
@@ -128,15 +145,23 @@ func (mc *MarketPlaceController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (mc *MarketPlaceController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := mc.c.Client.Call("one.market.update", mc.ID, tpl, uType)
+	return mc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (mc *MarketPlaceController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.market.update", mc.ID, tpl, uType)
 	return err
 }
 
 // Chmod changes the permission bits of a marketplace
 func (mc *MarketPlaceController) Chmod(perm shared.Permissions) error {
+	return mc.ChmodContext(context.Background(), perm)
+}
+
+func (mc *MarketPlaceController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{mc.ID}, perm.ToArgs()...)
 
-	_, err := mc.c.Client.Call("one.market.chmod", args...)
+	_, err := mc.c.Client.CallContext(ctx, "one.market.chmod", args...)
 	return err
 }
 
@@ -144,13 +169,21 @@ func (mc *MarketPlaceController) Chmod(perm shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (mc *MarketPlaceController) Chown(userID, groupID int) error {
-	_, err := mc.c.Client.Call("one.market.chown", mc.ID, userID, groupID)
+	return mc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (mc *MarketPlaceController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.market.chown", mc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a marketplace.
 // * newName: The new name.
 func (mc *MarketPlaceController) Rename(newName string) error {
-	_, err := mc.c.Client.Call("one.market.rename", mc.ID, newName)
+	return mc.RenameContext(context.Background(), newName)
+}
+
+func (mc *MarketPlaceController) RenameContext(ctx context.Context, newName string) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.market.rename", mc.ID, newName)
 	return err
 }

--- a/src/oca/go/src/goca/marketplace.go
+++ b/src/oca/go/src/goca/marketplace.go
@@ -47,6 +47,7 @@ func (c *MarketPlacesController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext return MarketPlace ID from name
 func (c *MarketPlacesController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -80,6 +81,8 @@ func (mc *MarketPlacesController) Info(args ...int) (*marketplace.Pool, error) {
 	return mc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a marketplace pool. A connection to OpenNebula is
+// performed.
 func (mc *MarketPlacesController) InfoContext(ctx context.Context, args ...int) (*marketplace.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -106,6 +109,7 @@ func (mc *MarketPlaceController) Info(decrypt bool) (*marketplace.MarketPlace, e
 	return mc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the marketplace.
 func (mc *MarketPlaceController) InfoContext(ctx context.Context, decrypt bool) (*marketplace.MarketPlace, error) {
 	response, err := mc.c.Client.CallContext(ctx, "one.market.info", mc.ID, decrypt)
 	if err != nil {
@@ -125,6 +129,9 @@ func (mc *MarketPlacesController) Create(tpl string) (int, error) {
 	return mc.CreateContext(context.Background(), tpl)
 }
 
+// Create allocates a new marketplace. It returns the new marketplace ID.
+// * ctx: context for cancelation
+// * tpl: template of the marketplace
 func (mc *MarketPlacesController) CreateContext(ctx context.Context, tpl string) (int, error) {
 	response, err := mc.c.Client.CallContext(ctx, "one.market.allocate", tpl)
 	if err != nil {
@@ -139,6 +146,7 @@ func (mc *MarketPlaceController) Delete() error {
 	return mc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given marketplace from the pool.
 func (mc *MarketPlaceController) DeleteContext(ctx context.Context) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.market.delete", mc.ID)
 	return err
@@ -152,6 +160,11 @@ func (mc *MarketPlaceController) Update(tpl string, uType parameters.UpdateType)
 	return mc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// Update adds marketplace content.
+//   - ctx: context for cancelation
+//   - tpl: The new marketplace contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (mc *MarketPlaceController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.market.update", mc.ID, tpl, uType)
 	return err
@@ -162,6 +175,7 @@ func (mc *MarketPlaceController) Chmod(perm shared.Permissions) error {
 	return mc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a marketplace
 func (mc *MarketPlaceController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{mc.ID}, perm.ToArgs()...)
 
@@ -176,6 +190,10 @@ func (mc *MarketPlaceController) Chown(userID, groupID int) error {
 	return mc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a marketplace.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (mc *MarketPlaceController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.market.chown", mc.ID, userID, groupID)
 	return err
@@ -187,6 +205,9 @@ func (mc *MarketPlaceController) Rename(newName string) error {
 	return mc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a marketplace.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (mc *MarketPlaceController) RenameContext(ctx context.Context, newName string) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.market.rename", mc.ID, newName)
 	return err

--- a/src/oca/go/src/goca/marketplaceapp.go
+++ b/src/oca/go/src/goca/marketplaceapp.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -71,13 +72,17 @@ func (c *MarketPlaceAppsController) ByName(name string, args ...int) (int, error
 // Info returns a marketplace app pool. A connection to OpenNebula is
 // performed.
 func (mc *MarketPlaceAppsController) Info(args ...int) (*marketplaceapp.Pool, error) {
+	return mc.InfoContext(context.Background(), args...)
+}
+
+func (mc *MarketPlaceAppsController) InfoContext(ctx context.Context, args ...int) (*marketplaceapp.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := mc.c.Client.Call("one.marketapppool.info", fArgs...)
+	response, err := mc.c.Client.CallContext(ctx, "one.marketapppool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +98,11 @@ func (mc *MarketPlaceAppsController) Info(args ...int) (*marketplaceapp.Pool, er
 
 // Info retrieves information for the marketplace app.
 func (mc *MarketPlaceAppController) Info(decrypt bool) (*marketplaceapp.MarketPlaceApp, error) {
-	response, err := mc.c.Client.Call("one.marketapp.info", mc.ID, decrypt)
+	return mc.InfoContext(context.Background(), decrypt)
+}
+
+func (mc *MarketPlaceAppController) InfoContext(ctx context.Context, decrypt bool) (*marketplaceapp.MarketPlaceApp, error) {
+	response, err := mc.c.Client.CallContext(ctx, "one.marketapp.info", mc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +119,11 @@ func (mc *MarketPlaceAppController) Info(decrypt bool) (*marketplaceapp.MarketPl
 // * tpl: template of the marketplace app
 // * market: market place ID
 func (mc *MarketPlaceAppsController) Create(tpl string, market int) (int, error) {
-	response, err := mc.c.Client.Call("one.marketapp.allocate", tpl, market)
+	return mc.CreateContext(context.Background(), tpl, market)
+}
+
+func (mc *MarketPlaceAppsController) CreateContext(ctx context.Context, tpl string, market int) (int, error) {
+	response, err := mc.c.Client.CallContext(ctx, "one.marketapp.allocate", tpl, market)
 	if err != nil {
 		return -1, err
 	}
@@ -120,14 +133,22 @@ func (mc *MarketPlaceAppsController) Create(tpl string, market int) (int, error)
 
 // Delete deletes the given marketplace app from the pool.
 func (mc *MarketPlaceAppController) Delete() error {
-	_, err := mc.c.Client.Call("one.marketapp.delete", mc.ID)
+	return mc.DeleteContext(context.Background())
+}
+
+func (mc *MarketPlaceAppController) DeleteContext(ctx context.Context) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.delete", mc.ID)
 	return err
 }
 
 // Enable enables or disables a marketplace app.
 // * enable: True for enabling, False for disabling
 func (mc *MarketPlaceAppController) Enable(enable bool) error {
-	_, err := mc.c.Client.Call("one.marketapp.enable", mc.ID, enable)
+	return mc.EnableContext(context.Background(), enable)
+}
+
+func (mc *MarketPlaceAppController) EnableContext(ctx context.Context, enable bool) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.enable", mc.ID, enable)
 	return err
 }
 
@@ -136,14 +157,22 @@ func (mc *MarketPlaceAppController) Enable(enable bool) error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (mc *MarketPlaceAppController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := mc.c.Client.Call("one.marketapp.update", mc.ID, tpl, uType)
+	return mc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (mc *MarketPlaceAppController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.update", mc.ID, tpl, uType)
 	return err
 }
 
 // Chmod changes the permission bits of a marketplace app
 func (mc *MarketPlaceAppController) Chmod(perm shared.Permissions) error {
+	return mc.ChmodContext(context.Background(), perm)
+}
+
+func (mc *MarketPlaceAppController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{mc.ID}, perm.ToArgs()...)
-	_, err := mc.c.Client.Call("one.marketapp.chmod", args...)
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.chmod", args...)
 	return err
 }
 
@@ -151,25 +180,41 @@ func (mc *MarketPlaceAppController) Chmod(perm shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (mc *MarketPlaceAppController) Chown(userID, groupID int) error {
-	_, err := mc.c.Client.Call("one.marketapp.chown", mc.ID, userID, groupID)
+	return mc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (mc *MarketPlaceAppController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.chown", mc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a marketplace app.
 // * newName: The new name.
 func (mc *MarketPlaceAppController) Rename(newName string) error {
-	_, err := mc.c.Client.Call("one.marketapp.rename", mc.ID, newName)
+	return mc.RenameContext(context.Background(), newName)
+}
+
+func (mc *MarketPlaceAppController) RenameContext(ctx context.Context, newName string) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.rename", mc.ID, newName)
 	return err
 }
 
 // Lock locks the marketplace app depending on blocking level. See levels in locks.go.
 func (mc *MarketPlaceAppController) Lock(level shared.LockLevel) error {
-	_, err := mc.c.Client.Call("one.marketapp.lock", mc.ID, level)
+	return mc.LockContext(context.Background(), level)
+}
+
+func (mc *MarketPlaceAppController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.lock", mc.ID, level)
 	return err
 }
 
 // Unlock unlocks the marketplace app.
 func (mc *MarketPlaceAppController) Unlock() error {
-	_, err := mc.c.Client.Call("one.marketapp.unlock", mc.ID)
+	return mc.UnlockContext(context.Background())
+}
+
+func (mc *MarketPlaceAppController) UnlockContext(ctx context.Context) error {
+	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.unlock", mc.ID)
 	return err
 }

--- a/src/oca/go/src/goca/marketplaceapp.go
+++ b/src/oca/go/src/goca/marketplaceapp.go
@@ -44,9 +44,13 @@ func (c *Controller) MarketPlaceApp(id int) *MarketPlaceAppController {
 
 // ByName returns a MarketPlace ID from name
 func (c *MarketPlaceAppsController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *MarketPlaceAppsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	marketAppPool, err := c.Info(args...)
+	marketAppPool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/marketplaceapp.go
+++ b/src/oca/go/src/goca/marketplaceapp.go
@@ -47,6 +47,7 @@ func (c *MarketPlaceAppsController) ByName(name string, args ...int) (int, error
 	return c.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns a MarketPlace ID from name
 func (c *MarketPlaceAppsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -79,6 +80,8 @@ func (mc *MarketPlaceAppsController) Info(args ...int) (*marketplaceapp.Pool, er
 	return mc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a marketplace app pool. A connection to OpenNebula is
+// performed.
 func (mc *MarketPlaceAppsController) InfoContext(ctx context.Context, args ...int) (*marketplaceapp.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -105,6 +108,7 @@ func (mc *MarketPlaceAppController) Info(decrypt bool) (*marketplaceapp.MarketPl
 	return mc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the marketplace app.
 func (mc *MarketPlaceAppController) InfoContext(ctx context.Context, decrypt bool) (*marketplaceapp.MarketPlaceApp, error) {
 	response, err := mc.c.Client.CallContext(ctx, "one.marketapp.info", mc.ID, decrypt)
 	if err != nil {
@@ -126,6 +130,10 @@ func (mc *MarketPlaceAppsController) Create(tpl string, market int) (int, error)
 	return mc.CreateContext(context.Background(), tpl, market)
 }
 
+// Create allocates a new marketplace app. It returns the new marketplace app ID.
+// * ctx: context for cancelation
+// * tpl: template of the marketplace app
+// * market: market place ID
 func (mc *MarketPlaceAppsController) CreateContext(ctx context.Context, tpl string, market int) (int, error) {
 	response, err := mc.c.Client.CallContext(ctx, "one.marketapp.allocate", tpl, market)
 	if err != nil {
@@ -140,6 +148,7 @@ func (mc *MarketPlaceAppController) Delete() error {
 	return mc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given marketplace app from the pool.
 func (mc *MarketPlaceAppController) DeleteContext(ctx context.Context) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.delete", mc.ID)
 	return err
@@ -151,6 +160,9 @@ func (mc *MarketPlaceAppController) Enable(enable bool) error {
 	return mc.EnableContext(context.Background(), enable)
 }
 
+// EnableContext enables or disables a marketplace app.
+// * ctx: context for cancelation
+// * enable: True for enabling, False for disabling
 func (mc *MarketPlaceAppController) EnableContext(ctx context.Context, enable bool) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.enable", mc.ID, enable)
 	return err
@@ -164,6 +176,11 @@ func (mc *MarketPlaceAppController) Update(tpl string, uType parameters.UpdateTy
 	return mc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds marketplace app content.
+//   - ctx: context for cancelation
+//   - tpl: The new marketplace contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (mc *MarketPlaceAppController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.update", mc.ID, tpl, uType)
 	return err
@@ -174,6 +191,7 @@ func (mc *MarketPlaceAppController) Chmod(perm shared.Permissions) error {
 	return mc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a marketplace app
 func (mc *MarketPlaceAppController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{mc.ID}, perm.ToArgs()...)
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.chmod", args...)
@@ -187,6 +205,10 @@ func (mc *MarketPlaceAppController) Chown(userID, groupID int) error {
 	return mc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a marketplace app.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (mc *MarketPlaceAppController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.chown", mc.ID, userID, groupID)
 	return err
@@ -198,6 +220,9 @@ func (mc *MarketPlaceAppController) Rename(newName string) error {
 	return mc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a marketplace app.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (mc *MarketPlaceAppController) RenameContext(ctx context.Context, newName string) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.rename", mc.ID, newName)
 	return err
@@ -208,6 +233,7 @@ func (mc *MarketPlaceAppController) Lock(level shared.LockLevel) error {
 	return mc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the marketplace app depending on blocking level. See levels in locks.go.
 func (mc *MarketPlaceAppController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.lock", mc.ID, level)
 	return err
@@ -218,6 +244,7 @@ func (mc *MarketPlaceAppController) Unlock() error {
 	return mc.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the marketplace app.
 func (mc *MarketPlaceAppController) UnlockContext(ctx context.Context) error {
 	_, err := mc.c.Client.CallContext(ctx, "one.marketapp.unlock", mc.ID)
 	return err

--- a/src/oca/go/src/goca/securitygroup.go
+++ b/src/oca/go/src/goca/securitygroup.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -71,13 +72,17 @@ func (c *SecurityGroupsController) ByName(name string, args ...int) (int, error)
 // Info returns a security group pool. A connection to OpenNebula is
 // performed.
 func (sc *SecurityGroupsController) Info(args ...int) (*securitygroup.Pool, error) {
+	return sc.InfoContext(context.Background(), args...)
+}
+
+func (sc *SecurityGroupsController) InfoContext(ctx context.Context, args ...int) (*securitygroup.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := sc.c.Client.Call("one.secgrouppool.info", fArgs...)
+	response, err := sc.c.Client.CallContext(ctx, "one.secgrouppool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +98,11 @@ func (sc *SecurityGroupsController) Info(args ...int) (*securitygroup.Pool, erro
 
 // Info retrieves information for the security group.
 func (sc *SecurityGroupController) Info(decrypt bool) (*securitygroup.SecurityGroup, error) {
-	response, err := sc.c.Client.Call("one.secgroup.info", sc.ID, decrypt)
+	return sc.InfoContext(context.Background(), decrypt)
+}
+
+func (sc *SecurityGroupController) InfoContext(ctx context.Context, decrypt bool) (*securitygroup.SecurityGroup, error) {
+	response, err := sc.c.Client.CallContext(ctx, "one.secgroup.info", sc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +118,11 @@ func (sc *SecurityGroupController) Info(decrypt bool) (*securitygroup.SecurityGr
 // Create allocates a new security group. It returns the new security group ID.
 // * tpl: template of the security group
 func (sc *SecurityGroupsController) Create(tpl string) (int, error) {
-	response, err := sc.c.Client.Call("one.secgroup.allocate", tpl)
+	return sc.CreateContext(context.Background(), tpl)
+}
+
+func (sc *SecurityGroupsController) CreateContext(ctx context.Context, tpl string) (int, error) {
+	response, err := sc.c.Client.CallContext(ctx, "one.secgroup.allocate", tpl)
 	if err != nil {
 		return -1, err
 	}
@@ -119,7 +132,11 @@ func (sc *SecurityGroupsController) Create(tpl string) (int, error) {
 
 // Clone clones an existing security group. It returns the clone ID
 func (sc *SecurityGroupController) Clone(cloneName string) (int, error) {
-	response, err := sc.c.Client.Call("one.secgroup.clone", sc.ID, cloneName)
+	return sc.CloneContext(context.Background(), cloneName)
+}
+
+func (sc *SecurityGroupController) CloneContext(ctx context.Context, cloneName string) (int, error) {
+	response, err := sc.c.Client.CallContext(ctx, "one.secgroup.clone", sc.ID, cloneName)
 	if err != nil {
 		return -1, err
 	}
@@ -129,7 +146,11 @@ func (sc *SecurityGroupController) Clone(cloneName string) (int, error) {
 
 // Delete deletes the given security group from the pool.
 func (sc *SecurityGroupController) Delete() error {
-	_, err := sc.c.Client.Call("one.secgroup.delete", sc.ID)
+	return sc.DeleteContext(context.Background())
+}
+
+func (sc *SecurityGroupController) DeleteContext(ctx context.Context) error {
+	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.delete", sc.ID)
 	return err
 }
 
@@ -138,21 +159,33 @@ func (sc *SecurityGroupController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (sc *SecurityGroupController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := sc.c.Client.Call("one.secgroup.update", sc.ID, tpl, uType)
+	return sc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (sc *SecurityGroupController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.update", sc.ID, tpl, uType)
 	return err
 }
 
 // Commit apply security group changes to associated VMs.
 // * recovery: If set the commit operation will only operate on outdated and error VMs. If not set operate on all VMs
 func (sc *SecurityGroupController) Commit(recovery bool) error {
-	_, err := sc.c.Client.Call("one.secgroup.commit", sc.ID, recovery)
+	return sc.CommitContext(context.Background(), recovery)
+}
+
+func (sc *SecurityGroupController) CommitContext(ctx context.Context, recovery bool) error {
+	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.commit", sc.ID, recovery)
 	return err
 }
 
 // Chmod changes the permission bits of a security group
 func (sc *SecurityGroupController) Chmod(perm shared.Permissions) error {
+	return sc.ChmodContext(context.Background(), perm)
+}
+
+func (sc *SecurityGroupController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{sc.ID}, perm.ToArgs()...)
-	_, err := sc.c.Client.Call("one.secgroup.chmod", args...)
+	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.chmod", args...)
 	return err
 }
 
@@ -160,13 +193,21 @@ func (sc *SecurityGroupController) Chmod(perm shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (sc *SecurityGroupController) Chown(userID, groupID int) error {
-	_, err := sc.c.Client.Call("one.secgroup.chown", sc.ID, userID, groupID)
+	return sc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (sc *SecurityGroupController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.chown", sc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a security group.
 // * newName: The new name.
 func (sc *SecurityGroupController) Rename(newName string) error {
-	_, err := sc.c.Client.Call("one.secgroup.rename", sc.ID, newName)
+	return sc.RenameContext(context.Background(), newName)
+}
+
+func (sc *SecurityGroupController) RenameContext(ctx context.Context, newName string) error {
+	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.rename", sc.ID, newName)
 	return err
 }

--- a/src/oca/go/src/goca/securitygroup.go
+++ b/src/oca/go/src/goca/securitygroup.go
@@ -44,9 +44,13 @@ func (c *Controller) SecurityGroup(id int) *SecurityGroupController {
 
 // ByName returns a SecurityGroup by Name
 func (c *SecurityGroupsController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *SecurityGroupsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	secgroupPool, err := c.Info(args...)
+	secgroupPool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/securitygroup.go
+++ b/src/oca/go/src/goca/securitygroup.go
@@ -47,6 +47,7 @@ func (c *SecurityGroupsController) ByName(name string, args ...int) (int, error)
 	return c.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns a SecurityGroup by Name
 func (c *SecurityGroupsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -79,6 +80,8 @@ func (sc *SecurityGroupsController) Info(args ...int) (*securitygroup.Pool, erro
 	return sc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a security group pool. A connection to OpenNebula is
+// performed.
 func (sc *SecurityGroupsController) InfoContext(ctx context.Context, args ...int) (*securitygroup.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -105,6 +108,7 @@ func (sc *SecurityGroupController) Info(decrypt bool) (*securitygroup.SecurityGr
 	return sc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the security group.
 func (sc *SecurityGroupController) InfoContext(ctx context.Context, decrypt bool) (*securitygroup.SecurityGroup, error) {
 	response, err := sc.c.Client.CallContext(ctx, "one.secgroup.info", sc.ID, decrypt)
 	if err != nil {
@@ -125,6 +129,9 @@ func (sc *SecurityGroupsController) Create(tpl string) (int, error) {
 	return sc.CreateContext(context.Background(), tpl)
 }
 
+// CreateContext allocates a new security group. It returns the new security group ID.
+// * ctx: context for cancelation
+// * tpl: template of the security group
 func (sc *SecurityGroupsController) CreateContext(ctx context.Context, tpl string) (int, error) {
 	response, err := sc.c.Client.CallContext(ctx, "one.secgroup.allocate", tpl)
 	if err != nil {
@@ -139,6 +146,7 @@ func (sc *SecurityGroupController) Clone(cloneName string) (int, error) {
 	return sc.CloneContext(context.Background(), cloneName)
 }
 
+// CloneContext clones an existing security group. It returns the clone ID
 func (sc *SecurityGroupController) CloneContext(ctx context.Context, cloneName string) (int, error) {
 	response, err := sc.c.Client.CallContext(ctx, "one.secgroup.clone", sc.ID, cloneName)
 	if err != nil {
@@ -153,6 +161,7 @@ func (sc *SecurityGroupController) Delete() error {
 	return sc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given security group from the pool.
 func (sc *SecurityGroupController) DeleteContext(ctx context.Context) error {
 	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.delete", sc.ID)
 	return err
@@ -166,6 +175,11 @@ func (sc *SecurityGroupController) Update(tpl string, uType parameters.UpdateTyp
 	return sc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds security group content.
+//   - ctx: context for cancelation
+//   - tpl: The new security group contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (sc *SecurityGroupController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.update", sc.ID, tpl, uType)
 	return err
@@ -177,6 +191,9 @@ func (sc *SecurityGroupController) Commit(recovery bool) error {
 	return sc.CommitContext(context.Background(), recovery)
 }
 
+// CommitContext apply security group changes to associated VMs.
+// * ctx: context for cancelation
+// * recovery: If set the commit operation will only operate on outdated and error VMs. If not set operate on all VMs
 func (sc *SecurityGroupController) CommitContext(ctx context.Context, recovery bool) error {
 	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.commit", sc.ID, recovery)
 	return err
@@ -187,6 +204,7 @@ func (sc *SecurityGroupController) Chmod(perm shared.Permissions) error {
 	return sc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a security group
 func (sc *SecurityGroupController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{sc.ID}, perm.ToArgs()...)
 	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.chmod", args...)
@@ -200,6 +218,10 @@ func (sc *SecurityGroupController) Chown(userID, groupID int) error {
 	return sc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a security group.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (sc *SecurityGroupController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.chown", sc.ID, userID, groupID)
 	return err
@@ -211,6 +233,9 @@ func (sc *SecurityGroupController) Rename(newName string) error {
 	return sc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a security group.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (sc *SecurityGroupController) RenameContext(ctx context.Context, newName string) error {
 	_, err := sc.c.Client.CallContext(ctx, "one.secgroup.rename", sc.ID, newName)
 	return err

--- a/src/oca/go/src/goca/template.go
+++ b/src/oca/go/src/goca/template.go
@@ -44,9 +44,13 @@ func (c *Controller) Template(id int) *TemplateController {
 
 // ByName returns a Template by Name
 func (c *TemplatesController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *TemplatesController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	templatePool, err := c.Info(args...)
+	templatePool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/template.go
+++ b/src/oca/go/src/goca/template.go
@@ -47,6 +47,7 @@ func (c *TemplatesController) ByName(name string, args ...int) (int, error) {
 	return c.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns a Template by Name
 func (c *TemplatesController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -79,6 +80,8 @@ func (tc *TemplatesController) Info(args ...int) (*template.Pool, error) {
 	return tc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a template pool. A connection to OpenNebula is
+// performed.
 func (tc *TemplatesController) InfoContext(ctx context.Context, args ...int) (*template.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -105,6 +108,7 @@ func (tc *TemplateController) Info(extended, decrypt bool) (*template.Template, 
 	return tc.InfoContext(context.Background(), extended, decrypt)
 }
 
+// InfoContext connects to OpenNebula and fetches the information of the Template
 func (tc *TemplateController) InfoContext(ctx context.Context, extended, decrypt bool) (*template.Template, error) {
 	response, err := tc.c.Client.CallContext(ctx, "one.template.info", tc.ID, extended, decrypt)
 	if err != nil {
@@ -124,6 +128,7 @@ func (tc *TemplatesController) Create(template string) (int, error) {
 	return tc.CreateContext(context.Background(), template)
 }
 
+// CreateContext allocates a new template. It returns the new template ID.
 func (tc *TemplatesController) CreateContext(ctx context.Context, template string) (int, error) {
 	response, err := tc.c.Client.CallContext(ctx, "one.template.allocate", template)
 	if err != nil {
@@ -141,6 +146,11 @@ func (tc *TemplateController) Update(tpl string, uType parameters.UpdateType) er
 	return tc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds template content.
+//   - ctx: context for cancelation
+//   - tpl: The new template contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (tc *TemplateController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.update", tc.ID, tpl, uType)
 	return err
@@ -152,6 +162,8 @@ func (tc *TemplateController) Chown(uid, gid int) error {
 	return tc.ChownContext(context.Background(), uid, gid)
 }
 
+// ChownContext changes the owner/group of a template. If uid or gid is -1 it will not
+// change
 func (tc *TemplateController) ChownContext(ctx context.Context, uid, gid int) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.chown", tc.ID, uid, gid)
 	return err
@@ -163,6 +175,8 @@ func (tc *TemplateController) Chmod(perm shared.Permissions) error {
 	return tc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permissions of a template. If any perm is -1 it will not
+// change
 func (tc *TemplateController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{tc.ID}, perm.ToArgs()...)
 	_, err := tc.c.Client.CallContext(ctx, "one.template.chmod", args...)
@@ -174,6 +188,7 @@ func (tc *TemplateController) Rename(newName string) error {
 	return tc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext changes the name of template
 func (tc *TemplateController) RenameContext(ctx context.Context, newName string) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.rename", tc.ID, newName)
 	return err
@@ -184,6 +199,7 @@ func (tc *TemplateController) Delete() error {
 	return tc.DeleteContext(context.Background())
 }
 
+// DeleteContext will remove the template from OpenNebula.
 func (tc *TemplateController) DeleteContext(ctx context.Context) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.delete", tc.ID)
 	return err
@@ -194,6 +210,7 @@ func (tc *TemplateController) Instantiate(name string, pending bool, extra strin
 	return tc.InstantiateContext(context.Background(), name, pending, extra, clone)
 }
 
+// InstantiateContext will instantiate the template
 func (tc *TemplateController) InstantiateContext(ctx context.Context, name string, pending bool, extra string, clone bool) (int, error) {
 	response, err := tc.c.Client.CallContext(ctx, "one.template.instantiate", tc.ID, name, pending, extra, clone)
 
@@ -210,6 +227,8 @@ func (tc *TemplateController) Clone(name string, recursive bool) error {
 	return tc.CloneContext(context.Background(), name, recursive)
 }
 
+// CloneContext an existing template. If recursive is true it will clone the template
+// plus any image defined in DISK. The new IMAGE_ID is set into each DISK.
 func (tc *TemplateController) CloneContext(ctx context.Context, name string, recursive bool) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.clone", tc.ID, name, recursive)
 	return err
@@ -220,6 +239,7 @@ func (tc *TemplateController) Lock(level shared.LockLevel) error {
 	return tc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the template following block level. See levels in locks.go.
 func (tc *TemplateController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.lock", tc.ID, level)
 	return err
@@ -230,6 +250,7 @@ func (tc *TemplateController) Unlock() error {
 	return tc.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the template.
 func (tc *TemplateController) UnlockContext(ctx context.Context) error {
 	_, err := tc.c.Client.CallContext(ctx, "one.template.unlock", tc.ID)
 	return err

--- a/src/oca/go/src/goca/user.go
+++ b/src/oca/go/src/goca/user.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -81,7 +82,11 @@ func (c *UsersController) ByName(name string) (int, error) {
 // Info returns a user pool. A connection to OpenNebula is
 // performed.
 func (uc *UsersController) Info() (*user.Pool, error) {
-	response, err := uc.c.Client.Call("one.userpool.info")
+	return uc.InfoContext(context.Background())
+}
+
+func (uc *UsersController) InfoContext(ctx context.Context) (*user.Pool, error) {
+	response, err := uc.c.Client.CallContext(ctx, "one.userpool.info")
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +102,11 @@ func (uc *UsersController) Info() (*user.Pool, error) {
 
 // Info retrieves information for the user from ID
 func (uc *UserController) Info(decrypt bool) (*user.User, error) {
-	response, err := uc.c.Client.Call("one.user.info", uc.ID, decrypt)
+	return uc.InfoContext(context.Background(), decrypt)
+}
+
+func (uc *UserController) InfoContext(ctx context.Context, decrypt bool) (*user.User, error) {
+	response, err := uc.c.Client.CallContext(ctx, "one.user.info", uc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +125,11 @@ func (uc *UserController) Info(decrypt bool) (*user.User, error) {
 // * authDriver: auth driver
 // * groupIDs: array of groupIDs to add to the user
 func (uc *UsersController) Create(name, password, authDriver string, groupIDs []int) (int, error) {
-	response, err := uc.c.Client.Call("one.user.allocate", name, password, authDriver, groupIDs)
+	return uc.CreateContext(context.Background(), name, password, authDriver, groupIDs)
+}
+
+func (uc *UsersController) CreateContext(ctx context.Context, name, password, authDriver string, groupIDs []int) (int, error) {
+	response, err := uc.c.Client.CallContext(ctx, "one.user.allocate", name, password, authDriver, groupIDs)
 	if err != nil {
 		return -1, err
 	}
@@ -126,14 +139,22 @@ func (uc *UsersController) Create(name, password, authDriver string, groupIDs []
 
 // Delete deletes the given user from the pool.
 func (uc *UserController) Delete() error {
-	_, err := uc.c.Client.Call("one.user.delete", uc.ID)
+	return uc.DeleteContext(context.Background())
+}
+
+func (uc *UserController) DeleteContext(ctx context.Context) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.delete", uc.ID)
 	return err
 }
 
 // Passwd changes the password for the given user.
 // * password: The new password
 func (uc *UserController) Passwd(password string) error {
-	_, err := uc.c.Client.Call("one.user.passwd", uc.ID, password)
+	return uc.PasswdContext(context.Background(), password)
+}
+
+func (uc *UserController) PasswdContext(ctx context.Context, password string) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.passwd", uc.ID, password)
 	return err
 }
 
@@ -143,12 +164,16 @@ func (uc *UserController) Passwd(password string) error {
 // * effectiveGID: Effective GID to use with this token. To use the current GID and user groups set it to -1
 // NOTE: This method make two XML-RPC calls, to make only one call, use UserByName(name).Login(...) method
 func (uc *UserController) Login(token string, timeSeconds int, effectiveGID int) error {
+	return uc.LoginContext(context.Background(), token, timeSeconds, effectiveGID)
+}
+
+func (uc *UserController) LoginContext(ctx context.Context, token string, timeSeconds int, effectiveGID int) error {
 	user, err := uc.Info(false)
 
 	if err != nil {
 		return err
 	}
-	_, err = uc.c.Client.Call("one.user.login", user.Name, token, timeSeconds, effectiveGID)
+	_, err = uc.c.Client.CallContext(ctx, "one.user.login", user.Name, token, timeSeconds, effectiveGID)
 	return err
 }
 
@@ -157,7 +182,11 @@ func (uc *UserController) Login(token string, timeSeconds int, effectiveGID int)
 // * timeSeconds: Valid period in seconds; 0 reset the token and -1 for a non-expiring token.
 // * effectiveGID: Effective GID to use with this token. To use the current GID and user groups set it to -1
 func (uc *UserByNameController) Login(token string, timeSeconds int, effectiveGID int) error {
-	_, err := uc.c.Client.Call("one.user.login", uc.Name, token, timeSeconds, effectiveGID)
+	return uc.LoginContext(context.Background(), token, timeSeconds, effectiveGID)
+}
+
+func (uc *UserByNameController) LoginContext(ctx context.Context, token string, timeSeconds int, effectiveGID int) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.login", uc.Name, token, timeSeconds, effectiveGID)
 	return err
 }
 
@@ -166,7 +195,11 @@ func (uc *UserByNameController) Login(token string, timeSeconds int, effectiveGI
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (uc *UserController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := uc.c.Client.Call("one.user.update", uc.ID, tpl, uType)
+	return uc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (uc *UserController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.update", uc.ID, tpl, uType)
 	return err
 }
 
@@ -174,34 +207,54 @@ func (uc *UserController) Update(tpl string, uType parameters.UpdateType) error 
 // * authDriver: The new authentication driver.
 // * password: The new password. If it is an empty string
 func (uc *UserController) Chauth(authDriver, password string) error {
-	_, err := uc.c.Client.Call("one.user.chauth", uc.ID, authDriver, password)
+	return uc.ChauthContext(context.Background(), authDriver, password)
+}
+
+func (uc *UserController) ChauthContext(ctx context.Context, authDriver, password string) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.chauth", uc.ID, authDriver, password)
 	return err
 }
 
 // Quota sets the user quota limits.
 // * tpl: The new quota template contents. Syntax can be the usual attribute=value or XML.
 func (uc *UserController) Quota(tpl string) error {
-	_, err := uc.c.Client.Call("one.user.quota", uc.ID, tpl)
+	return uc.QuotaContext(context.Background(), tpl)
+}
+
+func (uc *UserController) QuotaContext(ctx context.Context, tpl string) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.quota", uc.ID, tpl)
 	return err
 }
 
 // Chgrp changes the group of the given user.
 // * groupID: The Group ID of the new group.
 func (uc *UserController) Chgrp(groupID int) error {
-	_, err := uc.c.Client.Call("one.user.chgrp", uc.ID, int(groupID))
+	return uc.ChgrpContext(context.Background(), groupID)
+}
+
+func (uc *UserController) ChgrpContext(ctx context.Context, groupID int) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.chgrp", uc.ID, int(groupID))
 	return err
 }
 
 // AddGroup adds the User to a secondary group.
 // * groupID: The Group ID of the new group.
 func (uc *UserController) AddGroup(groupID int) error {
-	_, err := uc.c.Client.Call("one.user.addgroup", uc.ID, int(groupID))
+	return uc.AddGroupContext(context.Background(), groupID)
+}
+
+func (uc *UserController) AddGroupContext(ctx context.Context, groupID int) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.addgroup", uc.ID, int(groupID))
 	return err
 }
 
 // DelGroup removes the User from a secondary group
 // * groupID: The Group ID.
 func (uc *UserController) DelGroup(groupID int) error {
-	_, err := uc.c.Client.Call("one.user.delgroup", uc.ID, int(groupID))
+	return uc.DelGroupContext(context.Background(), groupID)
+}
+
+func (uc *UserController) DelGroupContext(ctx context.Context, groupID int) error {
+	_, err := uc.c.Client.CallContext(ctx, "one.user.delgroup", uc.ID, int(groupID))
 	return err
 }

--- a/src/oca/go/src/goca/user.go
+++ b/src/oca/go/src/goca/user.go
@@ -54,9 +54,13 @@ func (c *Controller) UserByName(name string) *UserByNameController {
 
 // ByName returns a User by Name
 func (c *UsersController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *UsersController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	userPool, err := c.Info()
+	userPool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/user.go
+++ b/src/oca/go/src/goca/user.go
@@ -57,6 +57,7 @@ func (c *UsersController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a User by Name
 func (c *UsersController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -89,6 +90,8 @@ func (uc *UsersController) Info() (*user.Pool, error) {
 	return uc.InfoContext(context.Background())
 }
 
+// InfoContext returns a user pool. A connection to OpenNebula is
+// performed.
 func (uc *UsersController) InfoContext(ctx context.Context) (*user.Pool, error) {
 	response, err := uc.c.Client.CallContext(ctx, "one.userpool.info")
 	if err != nil {
@@ -109,6 +112,7 @@ func (uc *UserController) Info(decrypt bool) (*user.User, error) {
 	return uc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the user from ID
 func (uc *UserController) InfoContext(ctx context.Context, decrypt bool) (*user.User, error) {
 	response, err := uc.c.Client.CallContext(ctx, "one.user.info", uc.ID, decrypt)
 	if err != nil {
@@ -132,6 +136,12 @@ func (uc *UsersController) Create(name, password, authDriver string, groupIDs []
 	return uc.CreateContext(context.Background(), name, password, authDriver, groupIDs)
 }
 
+// CreateContext allocates a new user. It returns the new user ID.
+// * ctx: context for cancelation
+// * name: name of the user
+// * password: password of the user
+// * authDriver: auth driver
+// * groupIDs: array of groupIDs to add to the user
 func (uc *UsersController) CreateContext(ctx context.Context, name, password, authDriver string, groupIDs []int) (int, error) {
 	response, err := uc.c.Client.CallContext(ctx, "one.user.allocate", name, password, authDriver, groupIDs)
 	if err != nil {
@@ -146,6 +156,7 @@ func (uc *UserController) Delete() error {
 	return uc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given user from the pool.
 func (uc *UserController) DeleteContext(ctx context.Context) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.delete", uc.ID)
 	return err
@@ -157,6 +168,8 @@ func (uc *UserController) Passwd(password string) error {
 	return uc.PasswdContext(context.Background(), password)
 }
 
+// PasswdContext changes the password for the given user.
+// * password: The new password
 func (uc *UserController) PasswdContext(ctx context.Context, password string) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.passwd", uc.ID, password)
 	return err
@@ -171,6 +184,12 @@ func (uc *UserController) Login(token string, timeSeconds int, effectiveGID int)
 	return uc.LoginContext(context.Background(), token, timeSeconds, effectiveGID)
 }
 
+// LoginContext generates or sets a login token.
+// * ctx: context for cancelation
+// * token: The token, if empty oned will generate one
+// * timeSeconds: Valid period in seconds; 0 reset the token and -1 for a non-expiring token.
+// * effectiveGID: Effective GID to use with this token. To use the current GID and user groups set it to -1
+// NOTE: This method make two XML-RPC calls, to make only one call, use UserByName(name).Login(...) method
 func (uc *UserController) LoginContext(ctx context.Context, token string, timeSeconds int, effectiveGID int) error {
 	user, err := uc.Info(false)
 
@@ -189,6 +208,11 @@ func (uc *UserByNameController) Login(token string, timeSeconds int, effectiveGI
 	return uc.LoginContext(context.Background(), token, timeSeconds, effectiveGID)
 }
 
+// LoginContext generates or sets a login token.
+// * ctx: context for cancelation
+// * token: The token, if empty oned will generate one
+// * timeSeconds: Valid period in seconds; 0 reset the token and -1 for a non-expiring token.
+// * effectiveGID: Effective GID to use with this token. To use the current GID and user groups set it to -1
 func (uc *UserByNameController) LoginContext(ctx context.Context, token string, timeSeconds int, effectiveGID int) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.login", uc.Name, token, timeSeconds, effectiveGID)
 	return err
@@ -202,6 +226,11 @@ func (uc *UserController) Update(tpl string, uType parameters.UpdateType) error 
 	return uc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds user content.
+//   - ctx: context for cancelation
+//   - tpl: The new user contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (uc *UserController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.update", uc.ID, tpl, uType)
 	return err
@@ -214,6 +243,10 @@ func (uc *UserController) Chauth(authDriver, password string) error {
 	return uc.ChauthContext(context.Background(), authDriver, password)
 }
 
+// ChauthContext changes the authentication driver and the password for the given user.
+// * ctx: context for cancelation
+// * authDriver: The new authentication driver.
+// * password: The new password. If it is an empty string
 func (uc *UserController) ChauthContext(ctx context.Context, authDriver, password string) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.chauth", uc.ID, authDriver, password)
 	return err
@@ -225,6 +258,9 @@ func (uc *UserController) Quota(tpl string) error {
 	return uc.QuotaContext(context.Background(), tpl)
 }
 
+// QuotaContext sets the user quota limits.
+// * ctx: context for cancelation
+// * tpl: The new quota template contents. Syntax can be the usual attribute=value or XML.
 func (uc *UserController) QuotaContext(ctx context.Context, tpl string) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.quota", uc.ID, tpl)
 	return err
@@ -236,6 +272,9 @@ func (uc *UserController) Chgrp(groupID int) error {
 	return uc.ChgrpContext(context.Background(), groupID)
 }
 
+// ChgrpContext changes the group of the given user.
+// * ctx: context for cancelation
+// * groupID: The Group ID of the new group.
 func (uc *UserController) ChgrpContext(ctx context.Context, groupID int) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.chgrp", uc.ID, int(groupID))
 	return err
@@ -247,6 +286,9 @@ func (uc *UserController) AddGroup(groupID int) error {
 	return uc.AddGroupContext(context.Background(), groupID)
 }
 
+// AddGroupContext adds the User to a secondary group.
+// * ctx: context for cancelation
+// * groupID: The Group ID of the new group.
 func (uc *UserController) AddGroupContext(ctx context.Context, groupID int) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.addgroup", uc.ID, int(groupID))
 	return err
@@ -258,6 +300,9 @@ func (uc *UserController) DelGroup(groupID int) error {
 	return uc.DelGroupContext(context.Background(), groupID)
 }
 
+// DelGroupContext removes the User from a secondary group
+// * ctx: context for cancelation
+// * groupID: The Group ID.
 func (uc *UserController) DelGroupContext(ctx context.Context, groupID int) error {
 	_, err := uc.c.Client.CallContext(ctx, "one.user.delgroup", uc.ID, int(groupID))
 	return err

--- a/src/oca/go/src/goca/vdc.go
+++ b/src/oca/go/src/goca/vdc.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,7 +71,11 @@ func (c *VDCsController) ByName(name string) (int, error) {
 // Info returns a vdc pool. A connection to OpenNebula is
 // performed.
 func (vc *VDCsController) Info() (*vdc.Pool, error) {
-	response, err := vc.c.Client.Call("one.vdcpool.info")
+	return vc.InfoContext(context.Background())
+}
+
+func (vc *VDCsController) InfoContext(ctx context.Context) (*vdc.Pool, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vdcpool.info")
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +91,11 @@ func (vc *VDCsController) Info() (*vdc.Pool, error) {
 
 // Info retrieves information for the VDC.
 func (vc *VDCController) Info(decrypt bool) (*vdc.VDC, error) {
-	response, err := vc.c.Client.Call("one.vdc.info", vc.ID, decrypt)
+	return vc.InfoContext(context.Background(), decrypt)
+}
+
+func (vc *VDCController) InfoContext(ctx context.Context, decrypt bool) (*vdc.VDC, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vdc.info", vc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +114,11 @@ func (vc *VDCController) Info(decrypt bool) (*vdc.VDC, error) {
 // * clusterID: The cluster ID. If it is -1, this virtual network won’t be added
 //     to any cluster
 func (vc *VDCsController) Create(tpl string, clusterID int) (int, error) {
-	response, err := vc.c.Client.Call("one.vdc.allocate", tpl, clusterID)
+	return vc.CreateContext(context.Background(), tpl, clusterID)
+}
+
+func (vc *VDCsController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vdc.allocate", tpl, clusterID)
 	if err != nil {
 		return -1, err
 	}
@@ -115,7 +128,11 @@ func (vc *VDCsController) Create(tpl string, clusterID int) (int, error) {
 
 // Delete deletes the given VDC from the pool.
 func (vc *VDCController) Delete() error {
-	_, err := vc.c.Client.Call("one.vdc.delete", vc.ID)
+	return vc.DeleteContext(context.Background())
+}
+
+func (vc *VDCController) DeleteContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delete", vc.ID)
 	return err
 }
 
@@ -124,28 +141,44 @@ func (vc *VDCController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (vc *VDCController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := vc.c.Client.Call("one.vdc.update", vc.ID, tpl, uType)
+	return vc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (vc *VDCController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.update", vc.ID, tpl, uType)
 	return err
 }
 
 // Rename renames a VDC.
 // * newName: The new name.
 func (vc *VDCController) Rename(newName string) error {
-	_, err := vc.c.Client.Call("one.vdc.rename", vc.ID, newName)
+	return vc.RenameContext(context.Background(), newName)
+}
+
+func (vc *VDCController) RenameContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.rename", vc.ID, newName)
 	return err
 }
 
 // AddGroup adds a group to the VDC
 // * groupID: The group ID.
 func (vc *VDCController) AddGroup(groupID int) error {
-	_, err := vc.c.Client.Call("one.vdc.addgroup", vc.ID, int(groupID))
+	return vc.AddGroupContext(context.Background(), groupID)
+}
+
+func (vc *VDCController) AddGroupContext(ctx context.Context, groupID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addgroup", vc.ID, int(groupID))
 	return err
 }
 
 // DelGroup deletes a group from the VDC
 // * groupID: The group ID.
 func (vc *VDCController) DelGroup(groupID int) error {
-	_, err := vc.c.Client.Call("one.vdc.delgroup", vc.ID, int(groupID))
+	return vc.DelGroupContext(context.Background(), groupID)
+}
+
+func (vc *VDCController) DelGroupContext(ctx context.Context, groupID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delgroup", vc.ID, int(groupID))
 	return err
 }
 
@@ -153,7 +186,11 @@ func (vc *VDCController) DelGroup(groupID int) error {
 // * zoneID: The Zone ID.
 // * clusterID: The Cluster ID.
 func (vc *VDCController) AddCluster(zoneID, clusterID int) error {
-	_, err := vc.c.Client.Call("one.vdc.addcluster", vc.ID, int(zoneID), int(clusterID))
+	return vc.AddClusterContext(context.Background(), zoneID, clusterID)
+}
+
+func (vc *VDCController) AddClusterContext(ctx context.Context, zoneID, clusterID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addcluster", vc.ID, int(zoneID), int(clusterID))
 	return err
 }
 
@@ -161,7 +198,11 @@ func (vc *VDCController) AddCluster(zoneID, clusterID int) error {
 // * zoneID: The Zone ID.
 // * clusterID: The Cluster ID.
 func (vc *VDCController) DelCluster(zoneID, clusterID int) error {
-	_, err := vc.c.Client.Call("one.vdc.delcluster", vc.ID, int(zoneID), int(clusterID))
+	return vc.DelClusterContext(context.Background(), zoneID, clusterID)
+}
+
+func (vc *VDCController) DelClusterContext(ctx context.Context, zoneID, clusterID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delcluster", vc.ID, int(zoneID), int(clusterID))
 	return err
 }
 
@@ -169,7 +210,11 @@ func (vc *VDCController) DelCluster(zoneID, clusterID int) error {
 // * zoneID: The Zone ID.
 // * hostID: The Host ID.
 func (vc *VDCController) AddHost(zoneID, hostID int) error {
-	_, err := vc.c.Client.Call("one.vdc.addhost", vc.ID, int(zoneID), int(hostID))
+	return vc.AddHostContext(context.Background(), zoneID, hostID)
+}
+
+func (vc *VDCController) AddHostContext(ctx context.Context, zoneID, hostID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addhost", vc.ID, int(zoneID), int(hostID))
 	return err
 }
 
@@ -177,7 +222,11 @@ func (vc *VDCController) AddHost(zoneID, hostID int) error {
 // * zoneID: The Zone ID.
 // * hostID: The Host ID.
 func (vc *VDCController) DelHost(zoneID, hostID int) error {
-	_, err := vc.c.Client.Call("one.vdc.delhost", vc.ID, int(zoneID), int(hostID))
+	return vc.DelHostContext(context.Background(), zoneID, hostID)
+}
+
+func (vc *VDCController) DelHostContext(ctx context.Context, zoneID, hostID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delhost", vc.ID, int(zoneID), int(hostID))
 	return err
 }
 
@@ -185,7 +234,11 @@ func (vc *VDCController) DelHost(zoneID, hostID int) error {
 // * zoneID: The Zone ID.
 // * dsID: The Datastore ID.
 func (vc *VDCController) AddDatastore(zoneID, dsID int) error {
-	_, err := vc.c.Client.Call("one.vdc.adddatastore", vc.ID, int(zoneID), int(dsID))
+	return vc.AddDatastoreContext(context.Background(), zoneID, dsID)
+}
+
+func (vc *VDCController) AddDatastoreContext(ctx context.Context, zoneID, dsID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.adddatastore", vc.ID, int(zoneID), int(dsID))
 	return err
 }
 
@@ -193,7 +246,11 @@ func (vc *VDCController) AddDatastore(zoneID, dsID int) error {
 // * zoneID: The Zone ID.
 // * dsID: The Datastore ID.
 func (vc *VDCController) DelDatastore(zoneID, dsID int) error {
-	_, err := vc.c.Client.Call("one.vdc.deldatastore", vc.ID, int(zoneID), int(dsID))
+	return vc.DelDatastoreContext(context.Background(), zoneID, dsID)
+}
+
+func (vc *VDCController) DelDatastoreContext(ctx context.Context, zoneID, dsID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.deldatastore", vc.ID, int(zoneID), int(dsID))
 	return err
 }
 
@@ -201,7 +258,11 @@ func (vc *VDCController) DelDatastore(zoneID, dsID int) error {
 // * zoneID: The Zone ID.
 // * vnetID: The Vnet ID.
 func (vc *VDCController) AddVnet(zoneID, vnetID int) error {
-	_, err := vc.c.Client.Call("one.vdc.addvnet", vc.ID, int(zoneID), int(vnetID))
+	return vc.AddVnetContext(context.Background(), zoneID, vnetID)
+}
+
+func (vc *VDCController) AddVnetContext(ctx context.Context, zoneID, vnetID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addvnet", vc.ID, int(zoneID), int(vnetID))
 	return err
 }
 
@@ -209,6 +270,10 @@ func (vc *VDCController) AddVnet(zoneID, vnetID int) error {
 // * zoneID: The Zone ID.
 // * vnetID: The Vnet ID.
 func (vc *VDCController) DelVnet(zoneID, vnetID int) error {
-	_, err := vc.c.Client.Call("one.vdc.delvnet", vc.ID, int(zoneID), int(vnetID))
+	return vc.DelVnetContext(context.Background(), zoneID, vnetID)
+}
+
+func (vc *VDCController) DelVnetContext(ctx context.Context, zoneID, vnetID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delvnet", vc.ID, int(zoneID), int(vnetID))
 	return err
 }

--- a/src/oca/go/src/goca/vdc.go
+++ b/src/oca/go/src/goca/vdc.go
@@ -43,9 +43,13 @@ func (c *Controller) VDC(id int) *VDCController {
 
 // ByName returns a Vdc ID from name
 func (c *VDCsController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *VDCsController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	vdcPool, err := c.Info()
+	vdcPool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/vdc.go
+++ b/src/oca/go/src/goca/vdc.go
@@ -46,6 +46,7 @@ func (c *VDCsController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a Vdc ID from name
 func (c *VDCsController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -78,6 +79,8 @@ func (vc *VDCsController) Info() (*vdc.Pool, error) {
 	return vc.InfoContext(context.Background())
 }
 
+// InfoContext returns a vdc pool. A connection to OpenNebula is
+// performed.
 func (vc *VDCsController) InfoContext(ctx context.Context) (*vdc.Pool, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vdcpool.info")
 	if err != nil {
@@ -98,6 +101,7 @@ func (vc *VDCController) Info(decrypt bool) (*vdc.VDC, error) {
 	return vc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the VDC.
 func (vc *VDCController) InfoContext(ctx context.Context, decrypt bool) (*vdc.VDC, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vdc.info", vc.ID, decrypt)
 	if err != nil {
@@ -121,6 +125,12 @@ func (vc *VDCsController) Create(tpl string, clusterID int) (int, error) {
 	return vc.CreateContext(context.Background(), tpl, clusterID)
 }
 
+// CreateContext allocates a new vdc. It returns the new vdc ID.
+//   - ctx: context for cancelation
+//   - tpl:	A string containing the template of the VDC. Syntax can be the usual
+//     attribute=value or XML.
+//   - clusterID: The cluster ID. If it is -1, this virtual network won’t be added
+//     to any cluster
 func (vc *VDCsController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vdc.allocate", tpl, clusterID)
 	if err != nil {
@@ -135,6 +145,7 @@ func (vc *VDCController) Delete() error {
 	return vc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given VDC from the pool.
 func (vc *VDCController) DeleteContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delete", vc.ID)
 	return err
@@ -148,6 +159,11 @@ func (vc *VDCController) Update(tpl string, uType parameters.UpdateType) error {
 	return vc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds vdc content.
+//   - ctx: context for cancelation
+//   - tpl: The new vdc contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (vc *VDCController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.update", vc.ID, tpl, uType)
 	return err
@@ -159,6 +175,9 @@ func (vc *VDCController) Rename(newName string) error {
 	return vc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a VDC.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (vc *VDCController) RenameContext(ctx context.Context, newName string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.rename", vc.ID, newName)
 	return err
@@ -170,6 +189,9 @@ func (vc *VDCController) AddGroup(groupID int) error {
 	return vc.AddGroupContext(context.Background(), groupID)
 }
 
+// AddGroupContext adds a group to the VDC
+// * ctx: context for cancelation
+// * groupID: The group ID.
 func (vc *VDCController) AddGroupContext(ctx context.Context, groupID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addgroup", vc.ID, int(groupID))
 	return err
@@ -181,6 +203,9 @@ func (vc *VDCController) DelGroup(groupID int) error {
 	return vc.DelGroupContext(context.Background(), groupID)
 }
 
+// DelGroupContext deletes a group from the VDC
+// * ctx: context for cancelation
+// * groupID: The group ID.
 func (vc *VDCController) DelGroupContext(ctx context.Context, groupID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delgroup", vc.ID, int(groupID))
 	return err
@@ -193,6 +218,10 @@ func (vc *VDCController) AddCluster(zoneID, clusterID int) error {
 	return vc.AddClusterContext(context.Background(), zoneID, clusterID)
 }
 
+// AddClusterContext adds a cluster to the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * clusterID: The Cluster ID.
 func (vc *VDCController) AddClusterContext(ctx context.Context, zoneID, clusterID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addcluster", vc.ID, int(zoneID), int(clusterID))
 	return err
@@ -205,6 +234,10 @@ func (vc *VDCController) DelCluster(zoneID, clusterID int) error {
 	return vc.DelClusterContext(context.Background(), zoneID, clusterID)
 }
 
+// DelClusterContext deletes a cluster from the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * clusterID: The Cluster ID.
 func (vc *VDCController) DelClusterContext(ctx context.Context, zoneID, clusterID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delcluster", vc.ID, int(zoneID), int(clusterID))
 	return err
@@ -217,6 +250,10 @@ func (vc *VDCController) AddHost(zoneID, hostID int) error {
 	return vc.AddHostContext(context.Background(), zoneID, hostID)
 }
 
+// AddHostContext adds a host to the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * hostID: The Host ID.
 func (vc *VDCController) AddHostContext(ctx context.Context, zoneID, hostID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addhost", vc.ID, int(zoneID), int(hostID))
 	return err
@@ -229,6 +266,10 @@ func (vc *VDCController) DelHost(zoneID, hostID int) error {
 	return vc.DelHostContext(context.Background(), zoneID, hostID)
 }
 
+// DelHostContext deletes a host from the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * hostID: The Host ID.
 func (vc *VDCController) DelHostContext(ctx context.Context, zoneID, hostID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delhost", vc.ID, int(zoneID), int(hostID))
 	return err
@@ -241,6 +282,10 @@ func (vc *VDCController) AddDatastore(zoneID, dsID int) error {
 	return vc.AddDatastoreContext(context.Background(), zoneID, dsID)
 }
 
+// AddDatastoreContext adds a datastore to the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * dsID: The Datastore ID.
 func (vc *VDCController) AddDatastoreContext(ctx context.Context, zoneID, dsID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.adddatastore", vc.ID, int(zoneID), int(dsID))
 	return err
@@ -253,6 +298,10 @@ func (vc *VDCController) DelDatastore(zoneID, dsID int) error {
 	return vc.DelDatastoreContext(context.Background(), zoneID, dsID)
 }
 
+// DelDatastoreContext deletes a datastore from the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * dsID: The Datastore ID.
 func (vc *VDCController) DelDatastoreContext(ctx context.Context, zoneID, dsID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.deldatastore", vc.ID, int(zoneID), int(dsID))
 	return err
@@ -265,6 +314,10 @@ func (vc *VDCController) AddVnet(zoneID, vnetID int) error {
 	return vc.AddVnetContext(context.Background(), zoneID, vnetID)
 }
 
+// AddVnetContext adds a vnet to the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * vnetID: The Vnet ID.
 func (vc *VDCController) AddVnetContext(ctx context.Context, zoneID, vnetID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.addvnet", vc.ID, int(zoneID), int(vnetID))
 	return err
@@ -277,6 +330,10 @@ func (vc *VDCController) DelVnet(zoneID, vnetID int) error {
 	return vc.DelVnetContext(context.Background(), zoneID, vnetID)
 }
 
+// DelVnetContext deletes a vnet from the VDC
+// * ctx: context for cancelation
+// * zoneID: The Zone ID.
+// * vnetID: The Vnet ID.
 func (vc *VDCController) DelVnetContext(ctx context.Context, zoneID, vnetID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vdc.delvnet", vc.ID, int(zoneID), int(vnetID))
 	return err

--- a/src/oca/go/src/goca/virtualnetwork.go
+++ b/src/oca/go/src/goca/virtualnetwork.go
@@ -44,9 +44,13 @@ func (c *Controller) VirtualNetwork(id int) *VirtualNetworkController {
 
 // ByName returns a VirtualNetwork ID from name
 func (c *VirtualNetworksController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *VirtualNetworksController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	virtualNetworkPool, err := c.Info(args...)
+	virtualNetworkPool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/virtualnetwork.go
+++ b/src/oca/go/src/goca/virtualnetwork.go
@@ -307,7 +307,11 @@ func (vc *VirtualNetworkController) UnlockContext(ctx context.Context) error {
 // Recover recovers a stuck Virtual Network
 // * op: (0) failure, (1) success, (2) retry, (3) delete
 func (vc *VirtualNetworkController) Recover(op int) error {
-	_, err := vc.c.Client.Call("one.vn.recover", vc.ID, op)
+	return vc.RecoverContext(context.Background(), op)
+}
+
+func (vc *VirtualNetworkController) RecoverContext(ctx context.Context, op int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.recover", vc.ID, op)
 	return err
 }
 

--- a/src/oca/go/src/goca/virtualnetwork.go
+++ b/src/oca/go/src/goca/virtualnetwork.go
@@ -47,6 +47,7 @@ func (c *VirtualNetworksController) ByName(name string, args ...int) (int, error
 	return c.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns a VirtualNetwork ID from name
 func (c *VirtualNetworksController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -78,6 +79,7 @@ func (vc *VirtualNetworksController) Info(args ...int) (*vn.Pool, error) {
 	return vc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a virtualnetwork pool.
 func (vc *VirtualNetworksController) InfoContext(ctx context.Context, args ...int) (*vn.Pool, error) {
 	var who, start, end int
 
@@ -117,6 +119,7 @@ func (vc *VirtualNetworkController) Info(decrypt bool) (*vn.VirtualNetwork, erro
 	return vc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the virtual network.
 func (vc *VirtualNetworkController) InfoContext(ctx context.Context, decrypt bool) (*vn.VirtualNetwork, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vn.info", vc.ID, decrypt)
 	if err != nil {
@@ -137,6 +140,10 @@ func (vc *VirtualNetworksController) Create(tpl string, clusterID int) (int, err
 	return vc.CreateContext(context.Background(), tpl, clusterID)
 }
 
+// CreateContext allocates a new virtualnetwork. It returns the new virtualnetwork ID.
+// * ctx: context for cancelation
+// * tpl: template of the virtualnetwork
+// * clusterID: The cluster ID. If it is -1, the default one will be used.
 func (vc *VirtualNetworksController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vn.allocate", tpl, clusterID)
 	if err != nil {
@@ -151,6 +158,7 @@ func (vc *VirtualNetworkController) Delete() error {
 	return vc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given virtual network from the pool.
 func (vc *VirtualNetworkController) DeleteContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.delete", vc.ID)
 	return err
@@ -162,6 +170,9 @@ func (vc *VirtualNetworkController) AddAR(tpl string) error {
 	return vc.AddARContext(context.Background(), tpl)
 }
 
+// AddARContext adds address ranges to a virtual network.
+// * ctx: context for cancelation
+// * tpl: template of the address ranges to add. Syntax can be the usual attribute=value or XML
 func (vc *VirtualNetworkController) AddARContext(ctx context.Context, tpl string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.add_ar", vc.ID, tpl)
 	return err
@@ -173,6 +184,9 @@ func (vc *VirtualNetworkController) RmAR(arID int) error {
 	return vc.RmARContext(context.Background(), arID)
 }
 
+// RmARContext removes an address range from a virtual network.
+// * ctx: context for cancelation
+// * arID: ID of the address range to remove.
 func (vc *VirtualNetworkController) RmARContext(ctx context.Context, arID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.rm_ar", vc.ID, arID)
 	return err
@@ -184,6 +198,9 @@ func (vc *VirtualNetworkController) UpdateAR(tpl string) error {
 	return vc.UpdateARContext(context.Background(), tpl)
 }
 
+// UpdateARContext updates the attributes of an address range.
+// * ctx: context for cancelation
+// * tpl: template of the address ranges to update. Syntax can be the usual attribute=value or XML
 func (vc *VirtualNetworkController) UpdateARContext(ctx context.Context, tpl string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.update_ar", vc.ID, tpl)
 	return err
@@ -195,6 +212,9 @@ func (vc *VirtualNetworkController) Reserve(tpl string) (int, error) {
 	return vc.ReserveContext(context.Background(), tpl)
 }
 
+// ReserveContext reserve network addresses. It returns the Reserved Virtual Network ID
+// * ctx: context for cancelation
+// * tpl: Template
 func (vc *VirtualNetworkController) ReserveContext(ctx context.Context, tpl string) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vn.reserve", vc.ID, tpl)
 	if err != nil {
@@ -210,6 +230,9 @@ func (vc *VirtualNetworkController) FreeAR(arID int) error {
 	return vc.FreeARContext(context.Background(), arID)
 }
 
+// FreeARContext frees a reserved address range from a virtual network.
+// * ctx: context for cancelation
+// * arID: ID of the address range to free.
 func (vc *VirtualNetworkController) FreeARContext(ctx context.Context, arID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.free_ar", vc.ID, arID)
 	return err
@@ -221,6 +244,9 @@ func (vc *VirtualNetworkController) Hold(tpl string) error {
 	return vc.HoldContext(context.Background(), tpl)
 }
 
+// HoldContext holds a virtual network Lease as used.
+// * ctx: context for cancelation
+// * tpl: template of the lease to hold
 func (vc *VirtualNetworkController) HoldContext(ctx context.Context, tpl string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.hold", vc.ID, tpl)
 	return err
@@ -232,6 +258,9 @@ func (vc *VirtualNetworkController) Release(tpl string) error {
 	return vc.ReleaseContext(context.Background(), tpl)
 }
 
+// ReleaseContext releases a virtual network Lease on hold.
+// * ctx: context for cancelation
+// * tpl: template of the lease to release
 func (vc *VirtualNetworkController) ReleaseContext(ctx context.Context, tpl string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.release", vc.ID, tpl)
 	return err
@@ -245,6 +274,11 @@ func (vc *VirtualNetworkController) Update(tpl string, uType parameters.UpdateTy
 	return vc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds virtual network content.
+//   - ctx: context for cancelation
+//   - tpl: The new virtual network contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (vc *VirtualNetworkController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.update", vc.ID, tpl, uType)
 	return err
@@ -255,6 +289,7 @@ func (vc *VirtualNetworkController) Chmod(perm shared.Permissions) error {
 	return vc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a virtual network.
 func (vc *VirtualNetworkController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.chmod", args...)
@@ -268,6 +303,10 @@ func (vc *VirtualNetworkController) Chown(userID, groupID int) error {
 	return vc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a virtual network.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (vc *VirtualNetworkController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.chown", vc.ID, userID, groupID)
 	return err
@@ -279,6 +318,9 @@ func (vc *VirtualNetworkController) Rename(newName string) error {
 	return vc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a virtual network.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (vc *VirtualNetworkController) RenameContext(ctx context.Context, newName string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.rename", vc.ID, newName)
 	return err
@@ -289,6 +331,7 @@ func (vc *VirtualNetworkController) Lock(level shared.LockLevel) error {
 	return vc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the vn following lock level. See levels in locks.go.
 func (vc *VirtualNetworkController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.lock", vc.ID, level)
 	return err
@@ -299,6 +342,7 @@ func (vc *VirtualNetworkController) Unlock() error {
 	return vc.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the vn.
 func (vc *VirtualNetworkController) UnlockContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.unlock", vc.ID)
 	return err
@@ -310,6 +354,9 @@ func (vc *VirtualNetworkController) Recover(op int) error {
 	return vc.RecoverContext(context.Background(), op)
 }
 
+// RecoverContext recovers a stuck Virtual Network
+// * ctx: context for cancelation
+// * op: (0) failure, (1) success, (2) retry, (3) delete
 func (vc *VirtualNetworkController) RecoverContext(ctx context.Context, op int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vn.recover", vc.ID, op)
 	return err

--- a/src/oca/go/src/goca/virtualnetwork.go
+++ b/src/oca/go/src/goca/virtualnetwork.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,6 +71,10 @@ func (c *VirtualNetworksController) ByName(name string, args ...int) (int, error
 
 // Info returns a virtualnetwork pool.
 func (vc *VirtualNetworksController) Info(args ...int) (*vn.Pool, error) {
+	return vc.InfoContext(context.Background(), args...)
+}
+
+func (vc *VirtualNetworksController) InfoContext(ctx context.Context, args ...int) (*vn.Pool, error) {
 	var who, start, end int
 
 	switch len(args) {
@@ -89,7 +94,7 @@ func (vc *VirtualNetworksController) Info(args ...int) (*vn.Pool, error) {
 		return nil, errors.New("Wrong number of arguments")
 	}
 
-	response, err := vc.c.Client.Call("one.vnpool.info", who, start, end)
+	response, err := vc.c.Client.CallContext(ctx, "one.vnpool.info", who, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +110,11 @@ func (vc *VirtualNetworksController) Info(args ...int) (*vn.Pool, error) {
 
 // Info retrieves information for the virtual network.
 func (vc *VirtualNetworkController) Info(decrypt bool) (*vn.VirtualNetwork, error) {
-	response, err := vc.c.Client.Call("one.vn.info", vc.ID, decrypt)
+	return vc.InfoContext(context.Background(), decrypt)
+}
+
+func (vc *VirtualNetworkController) InfoContext(ctx context.Context, decrypt bool) (*vn.VirtualNetwork, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vn.info", vc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +130,11 @@ func (vc *VirtualNetworkController) Info(decrypt bool) (*vn.VirtualNetwork, erro
 // * tpl: template of the virtualnetwork
 // * clusterID: The cluster ID. If it is -1, the default one will be used.
 func (vc *VirtualNetworksController) Create(tpl string, clusterID int) (int, error) {
-	response, err := vc.c.Client.Call("one.vn.allocate", tpl, clusterID)
+	return vc.CreateContext(context.Background(), tpl, clusterID)
+}
+
+func (vc *VirtualNetworksController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vn.allocate", tpl, clusterID)
 	if err != nil {
 		return -1, err
 	}
@@ -131,35 +144,55 @@ func (vc *VirtualNetworksController) Create(tpl string, clusterID int) (int, err
 
 // Delete deletes the given virtual network from the pool.
 func (vc *VirtualNetworkController) Delete() error {
-	_, err := vc.c.Client.Call("one.vn.delete", vc.ID)
+	return vc.DeleteContext(context.Background())
+}
+
+func (vc *VirtualNetworkController) DeleteContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.delete", vc.ID)
 	return err
 }
 
 // AddAR adds address ranges to a virtual network.
 // * tpl: template of the address ranges to add. Syntax can be the usual attribute=value or XML
 func (vc *VirtualNetworkController) AddAR(tpl string) error {
-	_, err := vc.c.Client.Call("one.vn.add_ar", vc.ID, tpl)
+	return vc.AddARContext(context.Background(), tpl)
+}
+
+func (vc *VirtualNetworkController) AddARContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.add_ar", vc.ID, tpl)
 	return err
 }
 
 // RmAR removes an address range from a virtual network.
 // * arID: ID of the address range to remove.
 func (vc *VirtualNetworkController) RmAR(arID int) error {
-	_, err := vc.c.Client.Call("one.vn.rm_ar", vc.ID, arID)
+	return vc.RmARContext(context.Background(), arID)
+}
+
+func (vc *VirtualNetworkController) RmARContext(ctx context.Context, arID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.rm_ar", vc.ID, arID)
 	return err
 }
 
 // UpdateAR updates the attributes of an address range.
 // * tpl: template of the address ranges to update. Syntax can be the usual attribute=value or XML
 func (vc *VirtualNetworkController) UpdateAR(tpl string) error {
-	_, err := vc.c.Client.Call("one.vn.update_ar", vc.ID, tpl)
+	return vc.UpdateARContext(context.Background(), tpl)
+}
+
+func (vc *VirtualNetworkController) UpdateARContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.update_ar", vc.ID, tpl)
 	return err
 }
 
 // Reserve reserve network addresses. It returns the Reserved Virtual Network ID
 // * tpl: Template
 func (vc *VirtualNetworkController) Reserve(tpl string) (int, error) {
-	response, err := vc.c.Client.Call("one.vn.reserve", vc.ID, tpl)
+	return vc.ReserveContext(context.Background(), tpl)
+}
+
+func (vc *VirtualNetworkController) ReserveContext(ctx context.Context, tpl string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vn.reserve", vc.ID, tpl)
 	if err != nil {
 		return -1, err
 	}
@@ -170,21 +203,33 @@ func (vc *VirtualNetworkController) Reserve(tpl string) (int, error) {
 // FreeAR frees a reserved address range from a virtual network.
 // * arID: ID of the address range to free.
 func (vc *VirtualNetworkController) FreeAR(arID int) error {
-	_, err := vc.c.Client.Call("one.vn.free_ar", vc.ID, arID)
+	return vc.FreeARContext(context.Background(), arID)
+}
+
+func (vc *VirtualNetworkController) FreeARContext(ctx context.Context, arID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.free_ar", vc.ID, arID)
 	return err
 }
 
 // Hold holds a virtual network Lease as used.
 // * tpl: template of the lease to hold
 func (vc *VirtualNetworkController) Hold(tpl string) error {
-	_, err := vc.c.Client.Call("one.vn.hold", vc.ID, tpl)
+	return vc.HoldContext(context.Background(), tpl)
+}
+
+func (vc *VirtualNetworkController) HoldContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.hold", vc.ID, tpl)
 	return err
 }
 
 // Release releases a virtual network Lease on hold.
 // * tpl: template of the lease to release
 func (vc *VirtualNetworkController) Release(tpl string) error {
-	_, err := vc.c.Client.Call("one.vn.release", vc.ID, tpl)
+	return vc.ReleaseContext(context.Background(), tpl)
+}
+
+func (vc *VirtualNetworkController) ReleaseContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.release", vc.ID, tpl)
 	return err
 }
 
@@ -193,14 +238,22 @@ func (vc *VirtualNetworkController) Release(tpl string) error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (vc *VirtualNetworkController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := vc.c.Client.Call("one.vn.update", vc.ID, tpl, uType)
+	return vc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (vc *VirtualNetworkController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.update", vc.ID, tpl, uType)
 	return err
 }
 
 // Chmod changes the permission bits of a virtual network.
 func (vc *VirtualNetworkController) Chmod(perm shared.Permissions) error {
+	return vc.ChmodContext(context.Background(), perm)
+}
+
+func (vc *VirtualNetworkController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
-	_, err := vc.c.Client.Call("one.vn.chmod", args...)
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.chmod", args...)
 	return err
 }
 
@@ -208,26 +261,42 @@ func (vc *VirtualNetworkController) Chmod(perm shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (vc *VirtualNetworkController) Chown(userID, groupID int) error {
-	_, err := vc.c.Client.Call("one.vn.chown", vc.ID, userID, groupID)
+	return vc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (vc *VirtualNetworkController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.chown", vc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a virtual network.
 // * newName: The new name.
 func (vc *VirtualNetworkController) Rename(newName string) error {
-	_, err := vc.c.Client.Call("one.vn.rename", vc.ID, newName)
+	return vc.RenameContext(context.Background(), newName)
+}
+
+func (vc *VirtualNetworkController) RenameContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.rename", vc.ID, newName)
 	return err
 }
 
 // Lock locks the vn following lock level. See levels in locks.go.
 func (vc *VirtualNetworkController) Lock(level shared.LockLevel) error {
-	_, err := vc.c.Client.Call("one.vn.lock", vc.ID, level)
+	return vc.LockContext(context.Background(), level)
+}
+
+func (vc *VirtualNetworkController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.lock", vc.ID, level)
 	return err
 }
 
 // Unlock unlocks the vn.
 func (vc *VirtualNetworkController) Unlock() error {
-	_, err := vc.c.Client.Call("one.vn.unlock", vc.ID)
+	return vc.UnlockContext(context.Background())
+}
+
+func (vc *VirtualNetworkController) UnlockContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vn.unlock", vc.ID)
 	return err
 }
 

--- a/src/oca/go/src/goca/virtualrouter.go
+++ b/src/oca/go/src/goca/virtualrouter.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,6 +71,10 @@ func (c *Controller) VirtualRouterByName(name string, args ...int) (int, error) 
 // Info returns a virtual router pool. A connection to OpenNebula is
 // performed.
 func (vc *VirtualRoutersController) Info(args ...int) (*vr.Pool, error) {
+	return vc.InfoContext(context.Background(), args...)
+}
+
+func (vc *VirtualRoutersController) InfoContext(ctx context.Context, args ...int) (*vr.Pool, error) {
 	var who, start, end int
 
 	switch len(args) {
@@ -85,7 +90,7 @@ func (vc *VirtualRoutersController) Info(args ...int) (*vr.Pool, error) {
 		return nil, errors.New("Wrong number of arguments")
 	}
 
-	response, err := vc.c.Client.Call("one.vrouterpool.info", who, start, end)
+	response, err := vc.c.Client.CallContext(ctx, "one.vrouterpool.info", who, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +107,11 @@ func (vc *VirtualRoutersController) Info(args ...int) (*vr.Pool, error) {
 
 // Info connects to OpenNebula and fetches the information of the VirtualRouter
 func (vc *VirtualRouterController) Info(decrypt bool) (*vr.VirtualRouter, error) {
-	response, err := vc.c.Client.Call("one.vrouter.info", vc.ID, decrypt)
+	return vc.InfoContext(context.Background(), decrypt)
+}
+
+func (vc *VirtualRouterController) InfoContext(ctx context.Context, decrypt bool) (*vr.VirtualRouter, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vrouter.info", vc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +127,11 @@ func (vc *VirtualRouterController) Info(decrypt bool) (*vr.VirtualRouter, error)
 // Create allocates a new virtual router. It returns the new Virtual Router ID
 // * tpl: template of the marketplace
 func (vc *VirtualRoutersController) Create(tpl string) (int, error) {
-	response, err := vc.c.Client.Call("one.vrouter.allocate", tpl)
+	return vc.CreateContext(context.Background(), tpl)
+}
+
+func (vc *VirtualRoutersController) CreateContext(ctx context.Context, tpl string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vrouter.allocate", tpl)
 	if err != nil {
 		return -1, err
 	}
@@ -131,35 +144,55 @@ func (vc *VirtualRoutersController) Create(tpl string) (int, error) {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (vc *VirtualRouterController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := vc.c.Client.Call("one.vrouter.update", vc.ID, tpl, uType)
+	return vc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (vc *VirtualRouterController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.update", vc.ID, tpl, uType)
 	return err
 }
 
 // Chown changes the owner/group of a virtual router. If uid or gid is -1 it will not
 // change
 func (vc *VirtualRouterController) Chown(uid, gid int) error {
-	_, err := vc.c.Client.Call("one.vrouter.chown", vc.ID, uid, gid)
+	return vc.ChownContext(context.Background(), uid, gid)
+}
+
+func (vc *VirtualRouterController) ChownContext(ctx context.Context, uid, gid int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.chown", vc.ID, uid, gid)
 	return err
 }
 
 // Chmod changes the permissions of a virtual router. If any perm is -1 it will not
 // change
 func (vc *VirtualRouterController) Chmod(perm shared.Permissions) error {
+	return vc.ChmodContext(context.Background(), perm)
+}
+
+func (vc *VirtualRouterController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
 
-	_, err := vc.c.Client.Call("one.vrouter.chmod", args...)
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.chmod", args...)
 	return err
 }
 
 // Rename changes the name of virtual router
 func (vc *VirtualRouterController) Rename(newName string) error {
-	_, err := vc.c.Client.Call("one.vrouter.rename", vc.ID, newName)
+	return vc.RenameContext(context.Background(), newName)
+}
+
+func (vc *VirtualRouterController) RenameContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.rename", vc.ID, newName)
 	return err
 }
 
 // Delete will remove the virtual router from OpenNebula.
 func (vc *VirtualRouterController) Delete() error {
-	_, err := vc.c.Client.Call("one.vrouter.delete", vc.ID)
+	return vc.DeleteContext(context.Background())
+}
+
+func (vc *VirtualRouterController) DeleteContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.delete", vc.ID)
 	return err
 }
 
@@ -170,7 +203,11 @@ func (vc *VirtualRouterController) Delete() error {
 // * hold: False to create the VM on pending (default), True to create it on hold.
 // * extra: A string containing an extra template to be merged with the one being instantiated. It can be empty. Syntax can be the usual attribute=value or XML.
 func (vc *VirtualRouterController) Instantiate(number, tplid int, name string, hold bool, extra string) (int, error) {
-	response, err := vc.c.Client.Call("one.vrouter.instantiate", vc.ID, number, tplid, name, hold, extra)
+	return vc.InstantiateContext(context.Background(), number, tplid, name, hold, extra)
+}
+
+func (vc *VirtualRouterController) InstantiateContext(ctx context.Context, number, tplid int, name string, hold bool, extra string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vrouter.instantiate", vc.ID, number, tplid, name, hold, extra)
 
 	if err != nil {
 		return -1, err
@@ -182,25 +219,41 @@ func (vc *VirtualRouterController) Instantiate(number, tplid int, name string, h
 // AttachNic attaches a new network interface to the virtual router and the virtual machines.
 // * tpl: NIC template string
 func (vc *VirtualRouterController) AttachNic(tpl string) error {
-	_, err := vc.c.Client.Call("one.vrouter.attachnic", vc.ID, tpl)
+	return vc.AttachNicContext(context.Background(), tpl)
+}
+
+func (vc *VirtualRouterController) AttachNicContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.attachnic", vc.ID, tpl)
 	return err
 }
 
 // DetachNic detaches a network interface from the virtual router and the virtual machines
 // * nicid: NIC ID to detach
 func (vc *VirtualRouterController) DetachNic(nicid int) error {
-	_, err := vc.c.Client.Call("one.vrouter.detachnic", vc.ID, nicid)
+	return vc.DetachNicContext(context.Background(), nicid)
+}
+
+func (vc *VirtualRouterController) DetachNicContext(ctx context.Context, nicid int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.detachnic", vc.ID, nicid)
 	return err
 }
 
 // Lock locks the virtual router depending on blocking level. See levels in locks.go.
 func (vc *VirtualRouterController) Lock(level shared.LockLevel) error {
-	_, err := vc.c.Client.Call("one.vrouter.lock", vc.ID, level)
+	return vc.LockContext(context.Background(), level)
+}
+
+func (vc *VirtualRouterController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.lock", vc.ID, level)
 	return err
 }
 
 // Unlock unlocks the virtual router.
 func (vc *VirtualRouterController) Unlock() error {
-	_, err := vc.c.Client.Call("one.vrouter.unlock", vc.ID)
+	return vc.UnlockContext(context.Background())
+}
+
+func (vc *VirtualRouterController) UnlockContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.unlock", vc.ID)
 	return err
 }

--- a/src/oca/go/src/goca/virtualrouter.go
+++ b/src/oca/go/src/goca/virtualrouter.go
@@ -44,9 +44,13 @@ func (c *Controller) VirtualRouter(id int) *VirtualRouterController {
 
 // VirtualRouterByName returns a VirtualRouter By name
 func (c *Controller) VirtualRouterByName(name string, args ...int) (int, error) {
-	var id int
+	return c.VirtualRouterByNameContext(context.Background(), name, args...)
+}
 
-	vrouterPool, err := (&VirtualRoutersController{c}).Info(args...)
+func (c *Controller) VirtualRouterByNameContext(ctx context.Context, name string, args ...int) (int, error) {
+
+	vrouterPool, err := (&VirtualRoutersController{c}).InfoContext(ctx, args...)
+	var id int
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/virtualrouter.go
+++ b/src/oca/go/src/goca/virtualrouter.go
@@ -47,6 +47,7 @@ func (c *Controller) VirtualRouterByName(name string, args ...int) (int, error) 
 	return c.VirtualRouterByNameContext(context.Background(), name, args...)
 }
 
+// VirtualRouterByNameContext returns a VirtualRouter By name
 func (c *Controller) VirtualRouterByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 
 	vrouterPool, err := (&VirtualRoutersController{c}).InfoContext(ctx, args...)
@@ -78,6 +79,8 @@ func (vc *VirtualRoutersController) Info(args ...int) (*vr.Pool, error) {
 	return vc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a virtual router pool. A connection to OpenNebula is
+// performed.
 func (vc *VirtualRoutersController) InfoContext(ctx context.Context, args ...int) (*vr.Pool, error) {
 	var who, start, end int
 
@@ -114,6 +117,7 @@ func (vc *VirtualRouterController) Info(decrypt bool) (*vr.VirtualRouter, error)
 	return vc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext connects to OpenNebula and fetches the information of the VirtualRouter
 func (vc *VirtualRouterController) InfoContext(ctx context.Context, decrypt bool) (*vr.VirtualRouter, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vrouter.info", vc.ID, decrypt)
 	if err != nil {
@@ -134,6 +138,9 @@ func (vc *VirtualRoutersController) Create(tpl string) (int, error) {
 	return vc.CreateContext(context.Background(), tpl)
 }
 
+// CreateContext allocates a new virtual router. It returns the new Virtual Router ID
+// * ctx: context for cancelation
+// * tpl: template of the marketplace
 func (vc *VirtualRoutersController) CreateContext(ctx context.Context, tpl string) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vrouter.allocate", tpl)
 	if err != nil {
@@ -144,13 +151,18 @@ func (vc *VirtualRoutersController) CreateContext(ctx context.Context, tpl strin
 }
 
 // Update adds virtual router content.
-// * tpl: The new virtual router contents. Syntax can be the usual attribute=value or XML.
-// * uType: Update type: Replace: Replace the whole template.
-//   Merge: Merge new template with the existing one.
+//   - tpl: The new virtual router contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (vc *VirtualRouterController) Update(tpl string, uType parameters.UpdateType) error {
 	return vc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds virtual router content.
+//   - ctx: context for cancelation
+//   - tpl: The new virtual router contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (vc *VirtualRouterController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.update", vc.ID, tpl, uType)
 	return err
@@ -162,6 +174,8 @@ func (vc *VirtualRouterController) Chown(uid, gid int) error {
 	return vc.ChownContext(context.Background(), uid, gid)
 }
 
+// ChownContext changes the owner/group of a virtual router. If uid or gid is -1 it will not
+// change
 func (vc *VirtualRouterController) ChownContext(ctx context.Context, uid, gid int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.chown", vc.ID, uid, gid)
 	return err
@@ -173,6 +187,8 @@ func (vc *VirtualRouterController) Chmod(perm shared.Permissions) error {
 	return vc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permissions of a virtual router. If any perm is -1 it will not
+// change
 func (vc *VirtualRouterController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
 
@@ -185,6 +201,7 @@ func (vc *VirtualRouterController) Rename(newName string) error {
 	return vc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext changes the name of virtual router
 func (vc *VirtualRouterController) RenameContext(ctx context.Context, newName string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.rename", vc.ID, newName)
 	return err
@@ -195,6 +212,7 @@ func (vc *VirtualRouterController) Delete() error {
 	return vc.DeleteContext(context.Background())
 }
 
+// DeleteContext will remove the virtual router from OpenNebula.
 func (vc *VirtualRouterController) DeleteContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.delete", vc.ID)
 	return err
@@ -210,6 +228,13 @@ func (vc *VirtualRouterController) Instantiate(number, tplid int, name string, h
 	return vc.InstantiateContext(context.Background(), number, tplid, name, hold, extra)
 }
 
+// InstantiateContext will instantiate the virtual router. It returns the ID of the new VM
+// * ctx: context for cancelation
+// * number: Number of VMs to instantiate.
+// * tplid: VM Template id to instantiate.
+// * name: Name for the VM instances. If it is an empty string OpenNebula will set a default name. Wildcard %i can be used.
+// * hold: False to create the VM on pending (default), True to create it on hold.
+// * extra: A string containing an extra template to be merged with the one being instantiated. It can be empty. Syntax can be the usual attribute=value or XML.
 func (vc *VirtualRouterController) InstantiateContext(ctx context.Context, number, tplid int, name string, hold bool, extra string) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vrouter.instantiate", vc.ID, number, tplid, name, hold, extra)
 
@@ -226,6 +251,9 @@ func (vc *VirtualRouterController) AttachNic(tpl string) error {
 	return vc.AttachNicContext(context.Background(), tpl)
 }
 
+// AttachNicContext attaches a new network interface to the virtual router and the virtual machines.
+// * ctx: context for cancelation
+// * tpl: NIC template string
 func (vc *VirtualRouterController) AttachNicContext(ctx context.Context, tpl string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.attachnic", vc.ID, tpl)
 	return err
@@ -237,6 +265,9 @@ func (vc *VirtualRouterController) DetachNic(nicid int) error {
 	return vc.DetachNicContext(context.Background(), nicid)
 }
 
+// DetachNicContext detaches a network interface from the virtual router and the virtual machines
+// * ctx: context for cancelation
+// * nicid: NIC ID to detach
 func (vc *VirtualRouterController) DetachNicContext(ctx context.Context, nicid int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.detachnic", vc.ID, nicid)
 	return err
@@ -247,6 +278,7 @@ func (vc *VirtualRouterController) Lock(level shared.LockLevel) error {
 	return vc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the virtual router depending on blocking level. See levels in locks.go.
 func (vc *VirtualRouterController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.lock", vc.ID, level)
 	return err
@@ -257,6 +289,7 @@ func (vc *VirtualRouterController) Unlock() error {
 	return vc.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the virtual router.
 func (vc *VirtualRouterController) UnlockContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vrouter.unlock", vc.ID)
 	return err

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -58,9 +58,13 @@ func (vc *VMController) DiskContext(ctx context.Context, id int) *VMDiskControll
 
 // ByName returns VM ID from name
 func (c *VMsController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *VMsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	vmPool, err := c.Info(args...)
+	vmPool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -609,7 +609,7 @@ func (vc *VMController) TerminateHard() error {
 }
 
 func (vc *VMController) TerminateHardContext(ctx context.Context) error {
-	return vc.Action("terminate-hard")
+	return vc.ActionContext(ctx, "terminate-hard")
 }
 
 // Terminate action on the VM
@@ -618,7 +618,7 @@ func (vc *VMController) Terminate() error {
 }
 
 func (vc *VMController) TerminateContext(ctx context.Context) error {
-	return vc.Action("terminate")
+	return vc.ActionContext(ctx, "terminate")
 }
 
 // UndeployHard action on the VM
@@ -627,7 +627,7 @@ func (vc *VMController) UndeployHard() error {
 }
 
 func (vc *VMController) UndeployHardContext(ctx context.Context) error {
-	return vc.Action("undeploy-hard")
+	return vc.ActionContext(ctx, "undeploy-hard")
 }
 
 // Undeploy action on the VM
@@ -636,7 +636,7 @@ func (vc *VMController) Undeploy() error {
 }
 
 func (vc *VMController) UndeployContext(ctx context.Context) error {
-	return vc.Action("undeploy")
+	return vc.ActionContext(ctx, "undeploy")
 }
 
 // PoweroffHard action on the VM
@@ -645,7 +645,7 @@ func (vc *VMController) PoweroffHard() error {
 }
 
 func (vc *VMController) PoweroffHardContext(ctx context.Context) error {
-	return vc.Action("poweroff-hard")
+	return vc.ActionContext(ctx, "poweroff-hard")
 }
 
 // Poweroff action on the VM
@@ -654,7 +654,7 @@ func (vc *VMController) Poweroff() error {
 }
 
 func (vc *VMController) PoweroffContext(ctx context.Context) error {
-	return vc.Action("poweroff")
+	return vc.ActionContext(ctx, "poweroff")
 }
 
 // RebootHard action on the VM
@@ -663,7 +663,7 @@ func (vc *VMController) RebootHard() error {
 }
 
 func (vc *VMController) RebootHardContext(ctx context.Context) error {
-	return vc.Action("reboot-hard")
+	return vc.ActionContext(ctx, "reboot-hard")
 }
 
 // Reboot action on the VM
@@ -672,7 +672,7 @@ func (vc *VMController) Reboot() error {
 }
 
 func (vc *VMController) RebootContext(ctx context.Context) error {
-	return vc.Action("reboot")
+	return vc.ActionContext(ctx, "reboot")
 }
 
 // Hold action on the VM
@@ -681,7 +681,7 @@ func (vc *VMController) Hold() error {
 }
 
 func (vc *VMController) HoldContext(ctx context.Context) error {
-	return vc.Action("hold")
+	return vc.ActionContext(ctx, "hold")
 }
 
 // Release action on the VM
@@ -690,7 +690,7 @@ func (vc *VMController) Release() error {
 }
 
 func (vc *VMController) ReleaseContext(ctx context.Context) error {
-	return vc.Action("release")
+	return vc.ActionContext(ctx, "release")
 }
 
 // Stop action on the VM
@@ -699,7 +699,7 @@ func (vc *VMController) Stop() error {
 }
 
 func (vc *VMController) StopContext(ctx context.Context) error {
-	return vc.Action("stop")
+	return vc.ActionContext(ctx, "stop")
 }
 
 // Suspend action on the VM
@@ -708,7 +708,7 @@ func (vc *VMController) Suspend() error {
 }
 
 func (vc *VMController) SuspendContext(ctx context.Context) error {
-	return vc.Action("suspend")
+	return vc.ActionContext(ctx, "suspend")
 }
 
 // Resume action on the VM
@@ -717,7 +717,7 @@ func (vc *VMController) Resume() error {
 }
 
 func (vc *VMController) ResumeContext(ctx context.Context) error {
-	return vc.Action("resume")
+	return vc.ActionContext(ctx, "resume")
 }
 
 // Resched action on the VM
@@ -726,7 +726,7 @@ func (vc *VMController) Resched() error {
 }
 
 func (vc *VMController) ReschedContext(ctx context.Context) error {
-	return vc.Action("resched")
+	return vc.ActionContext(ctx, "resched")
 }
 
 // Unresched action on the VM
@@ -735,7 +735,7 @@ func (vc *VMController) Unresched() error {
 }
 
 func (vc *VMController) UnreschedContext(ctx context.Context) error {
-	return vc.Action("unresched")
+	return vc.ActionContext(ctx, "unresched")
 }
 
 // End actions
@@ -852,13 +852,21 @@ func (vc *VMController) DeleteSchedActionContext(ctx context.Context, actionId i
 
 // AttachSG attaches new Security Group to Virtual Machine NIC
 func (vc *VMController) AttachSG(nicID int, sgID int) error {
-	_, err := vc.c.Client.Call("one.vm.attachsg", vc.ID, nicID, sgID)
+	return vc.AttachSGContext(context.Background(), nicID, sgID)
+}
+
+func (vc *VMController) AttachSGContext(ctx context.Context, nicID int, sgID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.attachsg", vc.ID, nicID, sgID)
 	return err
 }
 
 // DetachSG detaches a Security Group from Virtual Machine NIC
 func (vc *VMController) DetachSG(nicID int, sgID int) error {
-	_, err := vc.c.Client.Call("one.vm.detachsg", vc.ID, nicID, sgID)
+	return vc.DetachSGContext(context.Background(), nicID, sgID)
+}
+
+func (vc *VMController) DetachSGContext(ctx context.Context, nicID int, sgID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.detachsg", vc.ID, nicID, sgID)
 	return err
 }
 

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -48,6 +49,10 @@ func (c *Controller) VM(id int) *VMController {
 
 // Disk returns a new vm disk controller.
 func (vc *VMController) Disk(id int) *VMDiskController {
+	return vc.DiskContext(context.Background(), id)
+}
+
+func (vc *VMController) DiskContext(ctx context.Context, id int) *VMDiskController {
 	return &VMDiskController{vc.c, vc.ID, id}
 }
 
@@ -80,13 +85,17 @@ func (c *VMsController) ByName(name string, args ...int) (int, error) {
 
 // Info returns a new VM pool. It accepts the scope of the query.
 func (vc *VMsController) Info(args ...int) (*vm.Pool, error) {
+	return vc.InfoContext(context.Background(), args...)
+}
+
+func (vc *VMsController) InfoContext(ctx context.Context, args ...int) (*vm.Pool, error) {
 
 	fArgs, err := handleVMArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := vc.c.Client.Call("one.vmpool.info", fArgs...)
+	response, err := vc.c.Client.CallContext(ctx, "one.vmpool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,13 +111,17 @@ func (vc *VMsController) Info(args ...int) (*vm.Pool, error) {
 
 // InfoExtended connects to OpenNebula and fetches the whole VM_POOL information
 func (vc *VMsController) InfoExtended(args ...int) (*vm.Pool, error) {
+	return vc.InfoExtendedContext(context.Background(), args...)
+}
+
+func (vc *VMsController) InfoExtendedContext(ctx context.Context, args ...int) (*vm.Pool, error) {
 
 	fArgs, err := handleVMArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := vc.c.Client.Call("one.vmpool.infoextended", fArgs...)
+	response, err := vc.c.Client.CallContext(ctx, "one.vmpool.infoextended", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -122,12 +135,16 @@ func (vc *VMsController) InfoExtended(args ...int) (*vm.Pool, error) {
 
 // InfoFilter returns a new VM pool. It accepts the scope of the query.
 func (vc *VMsController) InfoFilter(f *VMFilter) (*vm.Pool, error) {
+	return vc.InfoFilterContext(context.Background(), f)
+}
+
+func (vc *VMsController) InfoFilterContext(ctx context.Context, f *VMFilter) (*vm.Pool, error) {
 
 	if f == nil {
 		return nil, fmt.Errorf("InfoFilter: nil parameter passed.")
 	}
 
-	response, err := vc.c.Client.Call("one.vmpool.info", f.toArgs()...)
+	response, err := vc.c.Client.CallContext(ctx, "one.vmpool.info", f.toArgs()...)
 	if err != nil {
 		return nil, err
 	}
@@ -143,12 +160,16 @@ func (vc *VMsController) InfoFilter(f *VMFilter) (*vm.Pool, error) {
 
 // InfoExtendedFilter connects to OpenNebula and fetches the whole VM_POOL information
 func (vc *VMsController) InfoExtendedFilter(f *VMFilter) (*vm.Pool, error) {
+	return vc.InfoExtendedFilterContext(context.Background(), f)
+}
+
+func (vc *VMsController) InfoExtendedFilterContext(ctx context.Context, f *VMFilter) (*vm.Pool, error) {
 
 	if f == nil {
 		return nil, fmt.Errorf("InfoFilter: nil parameter passed.")
 	}
 
-	response, err := vc.c.Client.Call("one.vmpool.infoextended", f.toArgs()...)
+	response, err := vc.c.Client.CallContext(ctx, "one.vmpool.infoextended", f.toArgs()...)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +183,11 @@ func (vc *VMsController) InfoExtendedFilter(f *VMFilter) (*vm.Pool, error) {
 
 // InfoSet connects to OpenNebula and fetches a VM_POOL containing the VMs in vmIds
 func (vc *VMsController) InfoSet(vmIds string, extended bool) (*vm.Pool, error) {
-	response, err := vc.c.Client.Call("one.vmpool.infoset", vmIds, extended)
+	return vc.InfoSetContext(context.Background(), vmIds, extended)
+}
+
+func (vc *VMsController) InfoSetContext(ctx context.Context, vmIds string, extended bool) (*vm.Pool, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vmpool.infoset", vmIds, extended)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +201,11 @@ func (vc *VMsController) InfoSet(vmIds string, extended bool) (*vm.Pool, error) 
 
 // Info connects to OpenNebula and fetches the information of the VM
 func (vc *VMController) Info(decrypt bool) (*vm.VM, error) {
-	response, err := vc.c.Client.Call("one.vm.info", vc.ID, decrypt)
+	return vc.InfoContext(context.Background(), decrypt)
+}
+
+func (vc *VMController) InfoContext(ctx context.Context, decrypt bool) (*vm.VM, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vm.info", vc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +227,11 @@ func (vc *VMController) Info(decrypt bool) (*vm.VM, error) {
 // num: Retrieve monitor records in the last num seconds.
 // 0 just the last record, -1 all records
 func (vc *VMsController) Monitoring(filter, num int) (*vm.PoolMonitoring, error) {
-	monitorData, err := vc.c.Client.Call("one.vmpool.monitoring", filter, num)
+	return vc.MonitoringContext(context.Background(), filter, num)
+}
+
+func (vc *VMsController) MonitoringContext(ctx context.Context, filter, num int) (*vm.PoolMonitoring, error) {
+	monitorData, err := vc.c.Client.CallContext(ctx, "one.vmpool.monitoring", filter, num)
 	if err != nil {
 		return nil, err
 	}
@@ -214,54 +247,88 @@ func (vc *VMsController) Monitoring(filter, num int) (*vm.PoolMonitoring, error)
 
 // Accounting returns the virtual machine history records
 // filter flag:
-//   -4: Resources belonging to the user's primary group
-//   -3: Resources belonging to the user
-//   -2: All resources
-//   -1: Resources belonging to the user and any of his groups
-//   >= 0: UID User's Resources
+//
+//	-4: Resources belonging to the user's primary group
+//	-3: Resources belonging to the user
+//	-2: All resources
+//	-1: Resources belonging to the user and any of his groups
+//	>= 0: UID User's Resources
+//
 // if startTime and/or endTime are -1 it means no limit
 func (vc *VMsController) Accounting(filter, startTime, endTime int) error {
-	_, err := vc.c.Client.Call("one.vmpool.accounting", filter)
+	return vc.AccountingContext(context.Background(), filter, startTime, endTime)
+}
+
+func (vc *VMsController) AccountingContext(ctx context.Context, filter, startTime, endTime int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmpool.accounting", filter)
 	return err
 }
 
 // Showback returns the virtual machine showback records
 // filter flag
-//   <= -3: Connected user's resources
-//   -2: All resources
-//   -1: Connected user's and his group's resources
-//   >= 0: UID User's Resources
+//
+//	<= -3: Connected user's resources
+//	-2: All resources
+//	-1: Connected user's and his group's resources
+//	>= 0: UID User's Resources
+//
 // firstMonth: January is 1. Can be -1, in which case the time interval won't have
-//   a left boundary.
+//
+//	a left boundary.
+//
 // firstYear: Can be -1, in which case the time interval won't have a left
-//   boundary.
+//
+//	boundary.
+//
 // lastMonth: January is 1. Can be -1, in which case the time interval won't have
-//   a right boundary.
+//
+//	a right boundary.
+//
 // lastYear: Can be -1, in which case the time interval won't have a right
-//   boundary.
+//
+//	boundary.
 func (vc *VMsController) Showback(filter, firstMonth, firstYear, lastMonth, lastYear int) error {
-	_, err := vc.c.Client.Call("one.vmpool.showback", filter, firstMonth, firstYear, lastMonth, lastYear)
+	return vc.ShowbackContext(context.Background(), filter, firstMonth, firstYear, lastMonth, lastYear)
+}
+
+func (vc *VMsController) ShowbackContext(ctx context.Context, filter, firstMonth, firstYear, lastMonth, lastYear int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmpool.showback", filter, firstMonth, firstYear, lastMonth, lastYear)
 	return err
 }
 
 // CalculateShowback processes all the history records, and stores the monthly cost for each VM
 // firstMonth: January is 1. Can be -1, in which case the time interval won't have
-//   a left boundary.
+//
+//	a left boundary.
+//
 // firstYear: Can be -1, in which case the time interval won't have a left
-//   boundary.
+//
+//	boundary.
+//
 // lastMonth: January is 1. Can be -1, in which case the time interval won't have
-//   a right boundary.
+//
+//	a right boundary.
+//
 // lastYear: Can be -1, in which case the time interval won't have a right
-//   boundary.
+//
+//	boundary.
 func (vc *VMsController) CalculateShowback(firstMonth, firstYear, lastMonth, lastYear int) error {
-	_, err := vc.c.Client.Call("one.vmpool.calculateshowback", firstMonth, firstYear, lastMonth, lastYear)
+	return vc.CalculateShowbackContext(context.Background(), firstMonth, firstYear, lastMonth, lastYear)
+}
+
+func (vc *VMsController) CalculateShowbackContext(ctx context.Context, firstMonth, firstYear, lastMonth, lastYear int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmpool.calculateshowback", firstMonth, firstYear, lastMonth, lastYear)
 	return err
 }
 
 // Create allocates a new VM based on the template string provided. It
 // returns the image ID
 func (vc *VMsController) Create(template string, pending bool) (int, error) {
-	response, err := vc.c.Client.Call("one.vm.allocate", template, pending)
+	return vc.CreateContext(context.Background(), template, pending)
+}
+
+func (vc *VMsController) CreateContext(ctx context.Context, template string, pending bool) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vm.allocate", template, pending)
 	if err != nil {
 		return -1, err
 	}
@@ -271,29 +338,45 @@ func (vc *VMsController) Create(template string, pending bool) (int, error) {
 
 // Action is the generic method to run any action on the VM
 func (vc *VMController) Action(action string) error {
-	_, err := vc.c.Client.Call("one.vm.action", action, vc.ID)
+	return vc.ActionContext(context.Background(), action)
+}
+
+func (vc *VMController) ActionContext(ctx context.Context, action string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.action", action, vc.ID)
 	return err
 }
 
 // Update adds vm content.
-// * tpl: The new vm contents. Syntax can be the usual attribute=value or XML.
-// * uType: Update type: Replace: Replace the whole template.
-//   Merge: Merge new template with the existing one.
+//   - tpl: The new vm contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (vc *VMController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := vc.c.Client.Call("one.vm.update", vc.ID, tpl, uType)
+	return vc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (vc *VMController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.update", vc.ID, tpl, uType)
 	return err
 }
 
 // UpdateConf updates (appends) a set of supported configuration attributes in
 // the VM template
 func (vc *VMController) UpdateConf(tpl string) error {
-	_, err := vc.c.Client.Call("one.vm.updateconf", vc.ID, tpl)
+	return vc.UpdateConfContext(context.Background(), tpl)
+}
+
+func (vc *VMController) UpdateConfContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.updateconf", vc.ID, tpl)
 	return err
 }
 
 // Monitoring Returns the virtual machine monitoring records
 func (vc *VMController) Monitoring() (*vm.Monitoring, error) {
-	monitorData, err := vc.c.Client.Call("one.vm.monitoring", vc.ID)
+	return vc.MonitoringContext(context.Background())
+}
+
+func (vc *VMController) MonitoringContext(ctx context.Context) (*vm.Monitoring, error) {
+	monitorData, err := vc.c.Client.CallContext(ctx, "one.vm.monitoring", vc.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -310,21 +393,33 @@ func (vc *VMController) Monitoring() (*vm.Monitoring, error) {
 // Chown changes the owner/group of a VM. If uid or gid is -1 it will not
 // change
 func (vc *VMController) Chown(uid, gid int) error {
-	_, err := vc.c.Client.Call("one.vm.chown", vc.ID, uid, gid)
+	return vc.ChownContext(context.Background(), uid, gid)
+}
+
+func (vc *VMController) ChownContext(ctx context.Context, uid, gid int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.chown", vc.ID, uid, gid)
 	return err
 }
 
 // Chmod changes the permissions of a VM. If any perm is -1 it will not
 // change
 func (vc *VMController) Chmod(perm shared.Permissions) error {
+	return vc.ChmodContext(context.Background(), perm)
+}
+
+func (vc *VMController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
-	_, err := vc.c.Client.Call("one.vm.chmod", args...)
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.chmod", args...)
 	return err
 }
 
 // Rename changes the name of a VM
 func (vc *VMController) Rename(newName string) error {
-	_, err := vc.c.Client.Call("one.vm.rename", vc.ID, newName)
+	return vc.RenameContext(context.Background(), newName)
+}
+
+func (vc *VMController) RenameContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.rename", vc.ID, newName)
 	return err
 }
 
@@ -332,13 +427,21 @@ func (vc *VMController) Rename(newName string) error {
 // overcommitment. Enforce is automatically enabled for non-oneadmin users.
 // Set dsID to -1 to let OpenNebula choose the datastore.
 func (vc *VMController) Deploy(hostID int, enforce bool, dsID int) error {
-	_, err := vc.c.Client.Call("one.vm.deploy", vc.ID, int(hostID), enforce, dsID)
+	return vc.DeployContext(context.Background(), hostID, enforce, dsID)
+}
+
+func (vc *VMController) DeployContext(ctx context.Context, hostID int, enforce bool, dsID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.deploy", vc.ID, int(hostID), enforce, dsID)
 	return err
 }
 
 // Resize changes the capacity of the virtual machine
 func (vc *VMController) Resize(template string, enforce bool) error {
-	_, err := vc.c.Client.Call("one.vm.resize", vc.ID, template, enforce)
+	return vc.ResizeContext(context.Background(), template, enforce)
+}
+
+func (vc *VMController) ResizeContext(ctx context.Context, template string, enforce bool) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.resize", vc.ID, template, enforce)
 	return err
 }
 
@@ -346,7 +449,11 @@ func (vc *VMController) Resize(template string, enforce bool) error {
 // If imageType is empty the default one will be used.
 // If snapID is -1 the current image state will be exported
 func (vc *VMDiskController) Saveas(imageName, imageType string, snapID int) (int, error) {
-	response, err := vc.c.Client.Call("one.vm.disksaveas", vc.entityID, vc.ID, imageName, imageType, snapID)
+	return vc.SaveasContext(context.Background(), imageName, imageType, snapID)
+}
+
+func (vc *VMDiskController) SaveasContext(ctx context.Context, imageName, imageType string, snapID int) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vm.disksaveas", vc.entityID, vc.ID, imageName, imageType, snapID)
 	if err != nil {
 		return -1, err
 	}
@@ -356,7 +463,11 @@ func (vc *VMDiskController) Saveas(imageName, imageType string, snapID int) (int
 
 // SnapshotCreate will create a snapshot of the disk image
 func (vc *VMDiskController) SnapshotCreate(description string) (int, error) {
-	response, err := vc.c.Client.Call("one.vm.disksnapshotcreate", vc.entityID, vc.ID, description)
+	return vc.SnapshotCreateContext(context.Background(), description)
+}
+
+func (vc *VMDiskController) SnapshotCreateContext(ctx context.Context, description string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vm.disksnapshotcreate", vc.entityID, vc.ID, description)
 	if err != nil {
 		return -1, err
 	}
@@ -366,19 +477,31 @@ func (vc *VMDiskController) SnapshotCreate(description string) (int, error) {
 
 // SnapshotDelete will delete a snapshot
 func (vc *VMDiskController) SnapshotDelete(snapID int) error {
-	_, err := vc.c.Client.Call("one.vm.disksnapshotdelete", vc.entityID, vc.ID, snapID)
+	return vc.SnapshotDeleteContext(context.Background(), snapID)
+}
+
+func (vc *VMDiskController) SnapshotDeleteContext(ctx context.Context, snapID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.disksnapshotdelete", vc.entityID, vc.ID, snapID)
 	return err
 }
 
 // SnapshotRevert will revert disk state to a previously taken snapshot
 func (vc *VMDiskController) SnapshotRevert(snapID int) error {
-	_, err := vc.c.Client.Call("one.vm.disksnapshotrevert", vc.entityID, vc.ID, snapID)
+	return vc.SnapshotRevertContext(context.Background(), snapID)
+}
+
+func (vc *VMDiskController) SnapshotRevertContext(ctx context.Context, snapID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.disksnapshotrevert", vc.entityID, vc.ID, snapID)
 	return err
 }
 
 // SnapshotRename renames a snapshot
 func (vc *VMDiskController) SnapshotRename(snapID int, newName string) error {
-	_, err := vc.c.Client.Call("one.vm.disksnapshotrename", vc.entityID, vc.ID, snapID, newName)
+	return vc.SnapshotRenameContext(context.Background(), snapID, newName)
+}
+
+func (vc *VMDiskController) SnapshotRenameContext(ctx context.Context, snapID int, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.disksnapshotrename", vc.entityID, vc.ID, snapID, newName)
 	return err
 }
 
@@ -386,55 +509,91 @@ func (vc *VMDiskController) SnapshotRename(snapID int, newName string) error {
 // a single DISK vector attribute. Syntax can be the usual attribute=value or
 // XML
 func (vc *VMController) DiskAttach(diskTemplate string) error {
-	_, err := vc.c.Client.Call("one.vm.attach", vc.ID, diskTemplate)
+	return vc.DiskAttachContext(context.Background(), diskTemplate)
+}
+
+func (vc *VMController) DiskAttachContext(ctx context.Context, diskTemplate string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.attach", vc.ID, diskTemplate)
 	return err
 }
 
 // Detach a disk from a virtual machine
 func (vc *VMDiskController) Detach() error {
-	_, err := vc.c.Client.Call("one.vm.detach", vc.entityID, vc.ID)
+	return vc.DetachContext(context.Background())
+}
+
+func (vc *VMDiskController) DetachContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.detach", vc.entityID, vc.ID)
 	return err
 }
 
 // Resize a disk of a virtual machine
 func (vc *VMDiskController) Resize(size string) error {
-	_, err := vc.c.Client.Call("one.vm.diskresize", vc.entityID, vc.ID, size)
+	return vc.ResizeContext(context.Background(), size)
+}
+
+func (vc *VMDiskController) ResizeContext(ctx context.Context, size string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.diskresize", vc.entityID, vc.ID, size)
 	return err
 }
 
 // SnapshotCreate creates a new virtual machine snapshot. name can be empty
 func (vc *VMController) SnapshotCreate(name string) error {
-	_, err := vc.c.Client.Call("one.vm.snapshotcreate", vc.ID, name)
+	return vc.SnapshotCreateContext(context.Background(), name)
+}
+
+func (vc *VMController) SnapshotCreateContext(ctx context.Context, name string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.snapshotcreate", vc.ID, name)
 	return err
 }
 
 // SnapshotDelete deletes a virtual machine snapshot
 func (vc *VMController) SnapshotDelete(snapID int) error {
-	_, err := vc.c.Client.Call("one.vm.snapshotdelete", vc.ID, snapID)
+	return vc.SnapshotDeleteContext(context.Background(), snapID)
+}
+
+func (vc *VMController) SnapshotDeleteContext(ctx context.Context, snapID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.snapshotdelete", vc.ID, snapID)
 	return err
 }
 
 // SnapshotRevert reverts a virtual machine to a snapshot
 func (vc *VMController) SnapshotRevert(snapID int) error {
-	_, err := vc.c.Client.Call("one.vm.snapshotrevert", vc.ID, snapID)
+	return vc.SnapshotRevertContext(context.Background(), snapID)
+}
+
+func (vc *VMController) SnapshotRevertContext(ctx context.Context, snapID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.snapshotrevert", vc.ID, snapID)
 	return err
 }
 
 // Migrate a VM to a target host and/or to another ds
 func (vc *VMController) Migrate(hostID int, live, enforce bool, dsID int, migrationType int) error {
-	_, err := vc.c.Client.Call("one.vm.migrate", vc.ID, hostID, live, enforce, dsID, migrationType)
+	return vc.MigrateContext(context.Background(), hostID, live, enforce, dsID, migrationType)
+}
+
+func (vc *VMController) MigrateContext(ctx context.Context, hostID int, live, enforce bool, dsID int, migrationType int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.migrate", vc.ID, hostID, live, enforce, dsID, migrationType)
 	return err
 }
 
 // AttachNIC attaches new network interface to the virtual machine
 func (vc *VMController) AttachNIC(tpl string) error {
-	_, err := vc.c.Client.Call("one.vm.attachnic", vc.ID, tpl)
+	return vc.AttachNICContext(context.Background(), tpl)
+}
+
+func (vc *VMController) AttachNICContext(ctx context.Context, tpl string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.attachnic", vc.ID, tpl)
 	return err
 }
 
 // DetachNIC detaches a network interface from the virtual machine
 func (vc *VMController) DetachNIC(nicID int) error {
-	_, err := vc.c.Client.Call("one.vm.detachnic", vc.ID, nicID)
+	return vc.DetachNICContext(context.Background(), nicID)
+}
+
+func (vc *VMController) DetachNICContext(ctx context.Context, nicID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.detachnic", vc.ID, nicID)
 	return err
 }
 
@@ -442,76 +601,136 @@ func (vc *VMController) DetachNIC(nicID int) error {
 
 // TerminateHard action on the VM
 func (vc *VMController) TerminateHard() error {
+	return vc.TerminateHardContext(context.Background())
+}
+
+func (vc *VMController) TerminateHardContext(ctx context.Context) error {
 	return vc.Action("terminate-hard")
 }
 
 // Terminate action on the VM
 func (vc *VMController) Terminate() error {
+	return vc.TerminateContext(context.Background())
+}
+
+func (vc *VMController) TerminateContext(ctx context.Context) error {
 	return vc.Action("terminate")
 }
 
 // UndeployHard action on the VM
 func (vc *VMController) UndeployHard() error {
+	return vc.UndeployHardContext(context.Background())
+}
+
+func (vc *VMController) UndeployHardContext(ctx context.Context) error {
 	return vc.Action("undeploy-hard")
 }
 
 // Undeploy action on the VM
 func (vc *VMController) Undeploy() error {
+	return vc.UndeployContext(context.Background())
+}
+
+func (vc *VMController) UndeployContext(ctx context.Context) error {
 	return vc.Action("undeploy")
 }
 
 // PoweroffHard action on the VM
 func (vc *VMController) PoweroffHard() error {
+	return vc.PoweroffHardContext(context.Background())
+}
+
+func (vc *VMController) PoweroffHardContext(ctx context.Context) error {
 	return vc.Action("poweroff-hard")
 }
 
 // Poweroff action on the VM
 func (vc *VMController) Poweroff() error {
+	return vc.PoweroffContext(context.Background())
+}
+
+func (vc *VMController) PoweroffContext(ctx context.Context) error {
 	return vc.Action("poweroff")
 }
 
 // RebootHard action on the VM
 func (vc *VMController) RebootHard() error {
+	return vc.RebootHardContext(context.Background())
+}
+
+func (vc *VMController) RebootHardContext(ctx context.Context) error {
 	return vc.Action("reboot-hard")
 }
 
 // Reboot action on the VM
 func (vc *VMController) Reboot() error {
+	return vc.RebootContext(context.Background())
+}
+
+func (vc *VMController) RebootContext(ctx context.Context) error {
 	return vc.Action("reboot")
 }
 
 // Hold action on the VM
 func (vc *VMController) Hold() error {
+	return vc.HoldContext(context.Background())
+}
+
+func (vc *VMController) HoldContext(ctx context.Context) error {
 	return vc.Action("hold")
 }
 
 // Release action on the VM
 func (vc *VMController) Release() error {
+	return vc.ReleaseContext(context.Background())
+}
+
+func (vc *VMController) ReleaseContext(ctx context.Context) error {
 	return vc.Action("release")
 }
 
 // Stop action on the VM
 func (vc *VMController) Stop() error {
+	return vc.StopContext(context.Background())
+}
+
+func (vc *VMController) StopContext(ctx context.Context) error {
 	return vc.Action("stop")
 }
 
 // Suspend action on the VM
 func (vc *VMController) Suspend() error {
+	return vc.SuspendContext(context.Background())
+}
+
+func (vc *VMController) SuspendContext(ctx context.Context) error {
 	return vc.Action("suspend")
 }
 
 // Resume action on the VM
 func (vc *VMController) Resume() error {
+	return vc.ResumeContext(context.Background())
+}
+
+func (vc *VMController) ResumeContext(ctx context.Context) error {
 	return vc.Action("resume")
 }
 
 // Resched action on the VM
 func (vc *VMController) Resched() error {
+	return vc.ReschedContext(context.Background())
+}
+
+func (vc *VMController) ReschedContext(ctx context.Context) error {
 	return vc.Action("resched")
 }
 
 // Unresched action on the VM
 func (vc *VMController) Unresched() error {
+	return vc.UnreschedContext(context.Background())
+}
+
+func (vc *VMController) UnreschedContext(ctx context.Context) error {
 	return vc.Action("unresched")
 }
 
@@ -519,67 +738,111 @@ func (vc *VMController) Unresched() error {
 
 // Recover recovers a stuck VM that is waiting for a driver operation
 func (vc *VMController) Recover(op int) error {
-	_, err := vc.c.Client.Call("one.vm.recover", vc.ID, op)
+	return vc.RecoverContext(context.Background(), op)
+}
+
+func (vc *VMController) RecoverContext(ctx context.Context, op int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.recover", vc.ID, op)
 	return err
 }
 
 // RecoverSuccess forces a success
 func (vc *VMController) RecoverSuccess() error {
+	return vc.RecoverSuccessContext(context.Background())
+}
+
+func (vc *VMController) RecoverSuccessContext(ctx context.Context) error {
 	return vc.Recover(1)
 }
 
 // RecoverFailure forces a success
 func (vc *VMController) RecoverFailure() error {
+	return vc.RecoverFailureContext(context.Background())
+}
+
+func (vc *VMController) RecoverFailureContext(ctx context.Context) error {
 	return vc.Recover(0)
 }
 
 // RecoverRetry forces a success
 func (vc *VMController) RecoverRetry() error {
+	return vc.RecoverRetryContext(context.Background())
+}
+
+func (vc *VMController) RecoverRetryContext(ctx context.Context) error {
 	return vc.Recover(2)
 }
 
 // RecoverDelete forces a delete
 func (vc *VMController) RecoverDelete() error {
+	return vc.RecoverDeleteContext(context.Background())
+}
+
+func (vc *VMController) RecoverDeleteContext(ctx context.Context) error {
 	return vc.Recover(3)
 }
 
 // RecoverDeleteRecreate forces a delete
 func (vc *VMController) RecoverDeleteRecreate() error {
+	return vc.RecoverDeleteRecreateContext(context.Background())
+}
+
+func (vc *VMController) RecoverDeleteRecreateContext(ctx context.Context) error {
 	return vc.Recover(4)
 }
 
 // Lock locks the vm following lock level. See levels in locks.go.
 func (vc *VMController) Lock(level shared.LockLevel) error {
-	_, err := vc.c.Client.Call("one.vm.lock", vc.ID, level)
+	return vc.LockContext(context.Background(), level)
+}
+
+func (vc *VMController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.lock", vc.ID, level)
 	return err
 }
 
 // Unlock unlocks the vm.
 func (vc *VMController) Unlock() error {
-	_, err := vc.c.Client.Call("one.vm.unlock", vc.ID)
+	return vc.UnlockContext(context.Background())
+}
+
+func (vc *VMController) UnlockContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.unlock", vc.ID)
 	return err
 }
 
 // AddSchedAction adds a new scheduled action to the VM
 func (vc *VMController) AddSchedAction(action *vm.SchedAction) error {
-	_, err := vc.c.Client.Call("one.vm.schedadd", vc.ID, action.String())
+	return vc.AddSchedActionContext(context.Background(), action)
+}
+
+func (vc *VMController) AddSchedActionContext(ctx context.Context, action *vm.SchedAction) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.schedadd", vc.ID, action.String())
 	return err
 }
 
 // UpdateSchedAction updates the scheduled action specified by the action ID attribute
 func (vc *VMController) UpdateSchedAction(action *vm.SchedAction) error {
+	return vc.UpdateSchedActionContext(context.Background(), action)
+}
+
+func (vc *VMController) UpdateSchedActionContext(ctx context.Context, action *vm.SchedAction) error {
 	actionId, err := action.GetInt(string(keys.ActionID))
 	if err != nil {
 		return err
 	}
 
-	_, err = vc.c.Client.Call("one.vm.schedupdate", vc.ID, actionId, action.String())
+	_, err = vc.c.Client.CallContext(ctx, "one.vm.schedupdate", vc.ID, actionId, action.String())
 	return err
 }
 
 // DeleteSchedAction deletes the actionId action
 func (vc *VMController) DeleteSchedAction(actionId int) error {
-	_, err := vc.c.Client.Call("one.vm.scheddelete", vc.ID, actionId)
+	return vc.DeleteSchedActionContext(context.Background(), actionId)
+}
+
+func (vc *VMController) DeleteSchedActionContext(ctx context.Context, actionId int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.scheddelete", vc.ID, actionId)
 	return err
 }
 

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -49,10 +49,6 @@ func (c *Controller) VM(id int) *VMController {
 
 // Disk returns a new vm disk controller.
 func (vc *VMController) Disk(id int) *VMDiskController {
-	return vc.DiskContext(context.Background(), id)
-}
-
-func (vc *VMController) DiskContext(ctx context.Context, id int) *VMDiskController {
 	return &VMDiskController{vc.c, vc.ID, id}
 }
 

--- a/src/oca/go/src/goca/vm.go
+++ b/src/oca/go/src/goca/vm.go
@@ -1003,12 +1003,22 @@ func (vc *VMController) DetachSGContext(ctx context.Context, nicID int, sgID int
 
 // Backup Virtual Machine
 func (vc *VMController) Backup(dsID int, reset bool) error {
-	_, err := vc.c.Client.Call("one.vm.backup", vc.ID, dsID, reset)
+	return vc.BackupContext(context.Background(), dsID, reset)
+}
+
+// Backup Virtual Machine
+func (vc *VMController) BackupContext(ctx context.Context, dsID int, reset bool) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.backup", vc.ID, dsID, reset)
 	return err
 }
 
 // Cancel ongoing backup operation
 func (vc *VMController) BackupCancel() error {
-	_, err := vc.c.Client.Call("one.vm.backupcancel", vc.ID)
+	return vc.BackupCancelContext(context.Background())
+}
+
+// Cancel ongoing backup operation
+func (vc *VMController) BackupCancelContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vm.backupcancel", vc.ID)
 	return err
 }

--- a/src/oca/go/src/goca/vmgroup.go
+++ b/src/oca/go/src/goca/vmgroup.go
@@ -43,9 +43,13 @@ func (c *Controller) VMGroup(id int) *VMGroupController {
 
 // ByName returns a VMGroup ID from name
 func (c *VMGroupsController) ByName(name string, args ...int) (int, error) {
+	return c.ByNameContext(context.Background(), name, args...)
+}
+
+func (c *VMGroupsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
-	vmGroupPool, err := c.Info(args...)
+	vmGroupPool, err := c.InfoContext(ctx, args...)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/vmgroup.go
+++ b/src/oca/go/src/goca/vmgroup.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,13 +71,17 @@ func (c *VMGroupsController) ByName(name string, args ...int) (int, error) {
 // Info returns a vm group pool. A connection to OpenNebula is
 // performed.
 func (vc *VMGroupsController) Info(args ...int) (*vmgroup.Pool, error) {
+	return vc.InfoContext(context.Background(), args...)
+}
+
+func (vc *VMGroupsController) InfoContext(ctx context.Context, args ...int) (*vmgroup.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := vc.c.Client.Call("one.vmgrouppool.info", fArgs...)
+	response, err := vc.c.Client.CallContext(ctx, "one.vmgrouppool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +97,11 @@ func (vc *VMGroupsController) Info(args ...int) (*vmgroup.Pool, error) {
 
 // Info retrieves information for the vm group.
 func (vc *VMGroupController) Info(decrypt bool) (*vmgroup.VMGroup, error) {
-	response, err := vc.c.Client.Call("one.vmgroup.info", vc.ID, decrypt)
+	return vc.InfoContext(context.Background(), decrypt)
+}
+
+func (vc *VMGroupController) InfoContext(ctx context.Context, decrypt bool) (*vmgroup.VMGroup, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vmgroup.info", vc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +116,11 @@ func (vc *VMGroupController) Info(decrypt bool) (*vmgroup.VMGroup, error) {
 
 // Create allocates a new vmGroup. It returns the new vmGroup ID.
 func (vc *VMGroupsController) Create(tpl string) (int, error) {
-	response, err := vc.c.Client.Call("one.vmgroup.allocate", tpl)
+	return vc.CreateContext(context.Background(), tpl)
+}
+
+func (vc *VMGroupsController) CreateContext(ctx context.Context, tpl string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vmgroup.allocate", tpl)
 	if err != nil {
 		return -1, err
 	}
@@ -118,13 +131,21 @@ func (vc *VMGroupsController) Create(tpl string) (int, error) {
 // Clone clones an existing vmGroup.
 // * newName: Name for the new vmGroup.
 func (vc *VMGroupController) Clone(newName string) error {
-	_, err := vc.c.Client.Call("one.vmgroup.clone", vc.ID, newName)
+	return vc.CloneContext(context.Background(), newName)
+}
+
+func (vc *VMGroupController) CloneContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.clone", vc.ID, newName)
 	return err
 }
 
 // Delete deletes the given vmGroup from the pool.
 func (vc *VMGroupController) Delete() error {
-	_, err := vc.c.Client.Call("one.vmgroup.delete", vc.ID)
+	return vc.DeleteContext(context.Background())
+}
+
+func (vc *VMGroupController) DeleteContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.delete", vc.ID)
 	return err
 }
 
@@ -132,14 +153,22 @@ func (vc *VMGroupController) Delete() error {
 // * tpl: The new vmGroup template contents. Syntax can be the usual attribute=value or XML.
 // * appendTemplate: Update type: 0: Replace the whole template. 1: Merge new template with the existing one.
 func (vc *VMGroupController) Update(tpl string, uType int) error {
-	_, err := vc.c.Client.Call("one.vmgroup.update", vc.ID, tpl, uType)
+	return vc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (vc *VMGroupController) UpdateContext(ctx context.Context, tpl string, uType int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.update", vc.ID, tpl, uType)
 	return err
 }
 
 // Chmod changes the permission bits of a vmGroup.
 func (vc *VMGroupController) Chmod(perm shared.Permissions) error {
+	return vc.ChmodContext(context.Background(), perm)
+}
+
+func (vc *VMGroupController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
-	_, err := vc.c.Client.Call("one.vmgroup.chmod", args...)
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.chmod", args...)
 	return err
 }
 
@@ -147,25 +176,41 @@ func (vc *VMGroupController) Chmod(perm shared.Permissions) error {
 // * userID: The User ID of the new owner. If set to -1, it will not change.
 // * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (vc *VMGroupController) Chown(userID, groupID int) error {
-	_, err := vc.c.Client.Call("one.vmgroup.chown", vc.ID, userID, groupID)
+	return vc.ChownContext(context.Background(), userID, groupID)
+}
+
+func (vc *VMGroupController) ChownContext(ctx context.Context, userID, groupID int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.chown", vc.ID, userID, groupID)
 	return err
 }
 
 // Rename renames a vmGroup.
 // * newName: The new name.
 func (vc *VMGroupController) Rename(newName string) error {
-	_, err := vc.c.Client.Call("one.vmgroup.rename", vc.ID, newName)
+	return vc.RenameContext(context.Background(), newName)
+}
+
+func (vc *VMGroupController) RenameContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.rename", vc.ID, newName)
 	return err
 }
 
 // Lock locks the vmGroup following lock level. See levels in locks.go.
 func (vc *VMGroupController) Lock(level shared.LockLevel) error {
-	_, err := vc.c.Client.Call("one.vmgroup.lock", vc.ID, level)
+	return vc.LockContext(context.Background(), level)
+}
+
+func (vc *VMGroupController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.lock", vc.ID, level)
 	return err
 }
 
 // Unlock unlocks the vmGroup.
 func (vc *VMGroupController) Unlock() error {
-	_, err := vc.c.Client.Call("one.vmgroup.unlock", vc.ID)
+	return vc.UnlockContext(context.Background())
+}
+
+func (vc *VMGroupController) UnlockContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.unlock", vc.ID)
 	return err
 }

--- a/src/oca/go/src/goca/vmgroup.go
+++ b/src/oca/go/src/goca/vmgroup.go
@@ -46,6 +46,7 @@ func (c *VMGroupsController) ByName(name string, args ...int) (int, error) {
 	return c.ByNameContext(context.Background(), name, args...)
 }
 
+// ByNameContext returns a VMGroup ID from name
 func (c *VMGroupsController) ByNameContext(ctx context.Context, name string, args ...int) (int, error) {
 	var id int
 
@@ -78,6 +79,8 @@ func (vc *VMGroupsController) Info(args ...int) (*vmgroup.Pool, error) {
 	return vc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a vm group pool. A connection to OpenNebula is
+// performed.
 func (vc *VMGroupsController) InfoContext(ctx context.Context, args ...int) (*vmgroup.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -104,6 +107,7 @@ func (vc *VMGroupController) Info(decrypt bool) (*vmgroup.VMGroup, error) {
 	return vc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the vm group.
 func (vc *VMGroupController) InfoContext(ctx context.Context, decrypt bool) (*vmgroup.VMGroup, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vmgroup.info", vc.ID, decrypt)
 	if err != nil {
@@ -123,6 +127,7 @@ func (vc *VMGroupsController) Create(tpl string) (int, error) {
 	return vc.CreateContext(context.Background(), tpl)
 }
 
+// CreateContext allocates a new vmGroup. It returns the new vmGroup ID.
 func (vc *VMGroupsController) CreateContext(ctx context.Context, tpl string) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vmgroup.allocate", tpl)
 	if err != nil {
@@ -138,6 +143,9 @@ func (vc *VMGroupController) Clone(newName string) error {
 	return vc.CloneContext(context.Background(), newName)
 }
 
+// CloneContext clones an existing vmGroup.
+// * ctx: context for cancelation
+// * newName: Name for the new vmGroup.
 func (vc *VMGroupController) CloneContext(ctx context.Context, newName string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.clone", vc.ID, newName)
 	return err
@@ -148,6 +156,7 @@ func (vc *VMGroupController) Delete() error {
 	return vc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given vmGroup from the pool.
 func (vc *VMGroupController) DeleteContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.delete", vc.ID)
 	return err
@@ -160,6 +169,10 @@ func (vc *VMGroupController) Update(tpl string, uType int) error {
 	return vc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext replaces the vmGroup template content.
+// * ctx: context for cancelation
+// * tpl: The new vmGroup template contents. Syntax can be the usual attribute=value or XML.
+// * appendTemplate: Update type: 0: Replace the whole template. 1: Merge new template with the existing one.
 func (vc *VMGroupController) UpdateContext(ctx context.Context, tpl string, uType int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.update", vc.ID, tpl, uType)
 	return err
@@ -170,6 +183,7 @@ func (vc *VMGroupController) Chmod(perm shared.Permissions) error {
 	return vc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permission bits of a vmGroup.
 func (vc *VMGroupController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.chmod", args...)
@@ -183,6 +197,10 @@ func (vc *VMGroupController) Chown(userID, groupID int) error {
 	return vc.ChownContext(context.Background(), userID, groupID)
 }
 
+// ChownContext changes the ownership of a vmGroup.
+// * ctx: context for cancelation
+// * userID: The User ID of the new owner. If set to -1, it will not change.
+// * groupID: The Group ID of the new group. If set to -1, it will not change.
 func (vc *VMGroupController) ChownContext(ctx context.Context, userID, groupID int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.chown", vc.ID, userID, groupID)
 	return err
@@ -194,6 +212,9 @@ func (vc *VMGroupController) Rename(newName string) error {
 	return vc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a vmGroup.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (vc *VMGroupController) RenameContext(ctx context.Context, newName string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.rename", vc.ID, newName)
 	return err
@@ -204,6 +225,7 @@ func (vc *VMGroupController) Lock(level shared.LockLevel) error {
 	return vc.LockContext(context.Background(), level)
 }
 
+// LockContext locks the vmGroup following lock level. See levels in locks.go.
 func (vc *VMGroupController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.lock", vc.ID, level)
 	return err
@@ -214,6 +236,7 @@ func (vc *VMGroupController) Unlock() error {
 	return vc.UnlockContext(context.Background())
 }
 
+// UnlockContext unlocks the vmGroup.
 func (vc *VMGroupController) UnlockContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vmgroup.unlock", vc.ID)
 	return err

--- a/src/oca/go/src/goca/vntemplate.go
+++ b/src/oca/go/src/goca/vntemplate.go
@@ -19,6 +19,7 @@ package goca
 // Since version 5.8 of OpenNebula
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -73,13 +74,17 @@ func (c *VNTemplatesController) ByName(name string) (int, error) {
 // Info returns a vntemplate pool. A connection to OpenNebula is
 // performed.
 func (vc *VNTemplatesController) Info(args ...int) (*vntemplate.Pool, error) {
+	return vc.InfoContext(context.Background(), args...)
+}
+
+func (vc *VNTemplatesController) InfoContext(ctx context.Context, args ...int) (*vntemplate.Pool, error) {
 
 	fArgs, err := handleArgs(args)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := vc.c.Client.Call("one.vntemplatepool.info", fArgs...)
+	response, err := vc.c.Client.CallContext(ctx, "one.vntemplatepool.info", fArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +101,11 @@ func (vc *VNTemplatesController) Info(args ...int) (*vntemplate.Pool, error) {
 
 // Info connects to OpenNebula and fetches the information of the VNTemplate
 func (vc *VNTemplateController) Info(decrypt bool) (*vntemplate.VNTemplate, error) {
-	response, err := vc.c.Client.Call("one.vntemplate.info", vc.ID, decrypt)
+	return vc.InfoContext(context.Background(), decrypt)
+}
+
+func (vc *VNTemplateController) InfoContext(ctx context.Context, decrypt bool) (*vntemplate.VNTemplate, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vntemplate.info", vc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +120,11 @@ func (vc *VNTemplateController) Info(decrypt bool) (*vntemplate.VNTemplate, erro
 
 // Create allocates a new vntemplate. It returns the new vntemplate ID.
 func (vc *VNTemplateController) Create(vntemplate string) (int, error) {
-	response, err := vc.c.Client.Call("one.vntemplate.allocate", vntemplate)
+	return vc.CreateContext(context.Background(), vntemplate)
+}
+
+func (vc *VNTemplateController) CreateContext(ctx context.Context, vntemplate string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vntemplate.allocate", vntemplate)
 	if err != nil {
 		return -1, err
 	}
@@ -124,40 +137,64 @@ func (vc *VNTemplateController) Create(vntemplate string) (int, error) {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (vc *VNTemplateController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := vc.c.Client.Call("one.vntemplate.update", vc.ID, tpl, uType)
+	return vc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (vc *VNTemplateController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.update", vc.ID, tpl, uType)
 	return err
 }
 
 // Chown changes the owner/group of a vntemplate. If uid or gid is -1 it will not
 // change
 func (vc *VNTemplateController) Chown(uid, gid int) error {
-	_, err := vc.c.Client.Call("one.vntemplate.chown", vc.ID, uid, gid)
+	return vc.ChownContext(context.Background(), uid, gid)
+}
+
+func (vc *VNTemplateController) ChownContext(ctx context.Context, uid, gid int) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.chown", vc.ID, uid, gid)
 	return err
 }
 
 // Chmod changes the permissions of a vntemplate. If any perm is -1 it will not
 // change
 func (vc *VNTemplateController) Chmod(perm shared.Permissions) error {
+	return vc.ChmodContext(context.Background(), perm)
+}
+
+func (vc *VNTemplateController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
-	_, err := vc.c.Client.Call("one.vntemplate.chmod", args...)
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.chmod", args...)
 	return err
 }
 
 // Rename changes the name of vntemplate
 func (vc *VNTemplateController) Rename(newName string) error {
-	_, err := vc.c.Client.Call("one.vntemplate.rename", vc.ID, newName)
+	return vc.RenameContext(context.Background(), newName)
+}
+
+func (vc *VNTemplateController) RenameContext(ctx context.Context, newName string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.rename", vc.ID, newName)
 	return err
 }
 
 // Delete will remove the vntemplate from OpenNebula.
 func (vc *VNTemplateController) Delete() error {
-	_, err := vc.c.Client.Call("one.vntemplate.delete", vc.ID)
+	return vc.DeleteContext(context.Background())
+}
+
+func (vc *VNTemplateController) DeleteContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.delete", vc.ID)
 	return err
 }
 
 // Instantiate will instantiate the template
 func (vc *VNTemplateController) Instantiate(name string, extra string) (int, error) {
-	response, err := vc.c.Client.Call("one.vntemplate.instantiate", vc.ID, name, extra)
+	return vc.InstantiateContext(context.Background(), name, extra)
+}
+
+func (vc *VNTemplateController) InstantiateContext(ctx context.Context, name string, extra string) (int, error) {
+	response, err := vc.c.Client.CallContext(ctx, "one.vntemplate.instantiate", vc.ID, name, extra)
 
 	if err != nil {
 		return -1, err
@@ -168,18 +205,30 @@ func (vc *VNTemplateController) Instantiate(name string, extra string) (int, err
 
 // Clone an existing vntemplate.
 func (vc *VNTemplateController) Clone(name string) error {
-	_, err := vc.c.Client.Call("one.vntemplate.clone", vc.ID, name)
+	return vc.CloneContext(context.Background(), name)
+}
+
+func (vc *VNTemplateController) CloneContext(ctx context.Context, name string) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.clone", vc.ID, name)
 	return err
 }
 
 //Lock an existing vntemplate. See levels in locks.go.
 func (vc *VNTemplateController) Lock(level shared.LockLevel) error {
-	_, err := vc.c.Client.Call("one.vntemplate.lock", vc.ID, level)
+	return vc.LockContext(context.Background(), level)
+}
+
+func (vc *VNTemplateController) LockContext(ctx context.Context, level shared.LockLevel) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.lock", vc.ID, level)
 	return err
 }
 
 //Unlock an existing vntemplate
 func (vc *VNTemplateController) Unlock() error {
-	_, err := vc.c.Client.Call("one.vntemplate.unlock", vc.ID)
+	return vc.UnlockContext(context.Background())
+}
+
+func (vc *VNTemplateController) UnlockContext(ctx context.Context) error {
+	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.unlock", vc.ID)
 	return err
 }

--- a/src/oca/go/src/goca/vntemplate.go
+++ b/src/oca/go/src/goca/vntemplate.go
@@ -46,9 +46,13 @@ func (c *Controller) VNTemplate(id int) *VNTemplateController {
 
 // ByName returns a VNTemplate id from name
 func (c *VNTemplatesController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *VNTemplatesController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	vnTemplatePool, err := c.Info()
+	vnTemplatePool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/vntemplate.go
+++ b/src/oca/go/src/goca/vntemplate.go
@@ -49,6 +49,7 @@ func (c *VNTemplatesController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a VNTemplate id from name
 func (c *VNTemplatesController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -81,6 +82,8 @@ func (vc *VNTemplatesController) Info(args ...int) (*vntemplate.Pool, error) {
 	return vc.InfoContext(context.Background(), args...)
 }
 
+// InfoContext returns a vntemplate pool. A connection to OpenNebula is
+// performed.
 func (vc *VNTemplatesController) InfoContext(ctx context.Context, args ...int) (*vntemplate.Pool, error) {
 
 	fArgs, err := handleArgs(args)
@@ -108,6 +111,7 @@ func (vc *VNTemplateController) Info(decrypt bool) (*vntemplate.VNTemplate, erro
 	return vc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext connects to OpenNebula and fetches the information of the VNTemplate
 func (vc *VNTemplateController) InfoContext(ctx context.Context, decrypt bool) (*vntemplate.VNTemplate, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vntemplate.info", vc.ID, decrypt)
 	if err != nil {
@@ -127,6 +131,7 @@ func (vc *VNTemplateController) Create(vntemplate string) (int, error) {
 	return vc.CreateContext(context.Background(), vntemplate)
 }
 
+// CreateContext allocates a new vntemplate. It returns the new vntemplate ID.
 func (vc *VNTemplateController) CreateContext(ctx context.Context, vntemplate string) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vntemplate.allocate", vntemplate)
 	if err != nil {
@@ -144,6 +149,11 @@ func (vc *VNTemplateController) Update(tpl string, uType parameters.UpdateType) 
 	return vc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds vntemplate content.
+//   - ctx: context for cancelation
+//   - tpl: The new vntemplate contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (vc *VNTemplateController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.update", vc.ID, tpl, uType)
 	return err
@@ -155,6 +165,8 @@ func (vc *VNTemplateController) Chown(uid, gid int) error {
 	return vc.ChownContext(context.Background(), uid, gid)
 }
 
+// ChownContext changes the owner/group of a vntemplate. If uid or gid is -1 it will not
+// change
 func (vc *VNTemplateController) ChownContext(ctx context.Context, uid, gid int) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.chown", vc.ID, uid, gid)
 	return err
@@ -166,6 +178,8 @@ func (vc *VNTemplateController) Chmod(perm shared.Permissions) error {
 	return vc.ChmodContext(context.Background(), perm)
 }
 
+// ChmodContext changes the permissions of a vntemplate. If any perm is -1 it will not
+// change
 func (vc *VNTemplateController) ChmodContext(ctx context.Context, perm shared.Permissions) error {
 	args := append([]interface{}{vc.ID}, perm.ToArgs()...)
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.chmod", args...)
@@ -177,6 +191,7 @@ func (vc *VNTemplateController) Rename(newName string) error {
 	return vc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext changes the name of vntemplate
 func (vc *VNTemplateController) RenameContext(ctx context.Context, newName string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.rename", vc.ID, newName)
 	return err
@@ -187,6 +202,7 @@ func (vc *VNTemplateController) Delete() error {
 	return vc.DeleteContext(context.Background())
 }
 
+// DeleteContext will remove the vntemplate from OpenNebula.
 func (vc *VNTemplateController) DeleteContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.delete", vc.ID)
 	return err
@@ -197,6 +213,7 @@ func (vc *VNTemplateController) Instantiate(name string, extra string) (int, err
 	return vc.InstantiateContext(context.Background(), name, extra)
 }
 
+// InstantiateContext will instantiate the template
 func (vc *VNTemplateController) InstantiateContext(ctx context.Context, name string, extra string) (int, error) {
 	response, err := vc.c.Client.CallContext(ctx, "one.vntemplate.instantiate", vc.ID, name, extra)
 
@@ -212,26 +229,29 @@ func (vc *VNTemplateController) Clone(name string) error {
 	return vc.CloneContext(context.Background(), name)
 }
 
+// CloneContext an existing vntemplate.
 func (vc *VNTemplateController) CloneContext(ctx context.Context, name string) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.clone", vc.ID, name)
 	return err
 }
 
-//Lock an existing vntemplate. See levels in locks.go.
+// Lock an existing vntemplate. See levels in locks.go.
 func (vc *VNTemplateController) Lock(level shared.LockLevel) error {
 	return vc.LockContext(context.Background(), level)
 }
 
+// LockContext an existing vntemplate. See levels in locks.go.
 func (vc *VNTemplateController) LockContext(ctx context.Context, level shared.LockLevel) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.lock", vc.ID, level)
 	return err
 }
 
-//Unlock an existing vntemplate
+// Unlock an existing vntemplate
 func (vc *VNTemplateController) Unlock() error {
 	return vc.UnlockContext(context.Background())
 }
 
+// UnlockContext an existing vntemplate
 func (vc *VNTemplateController) UnlockContext(ctx context.Context) error {
 	_, err := vc.c.Client.CallContext(ctx, "one.vntemplate.unlock", vc.ID)
 	return err

--- a/src/oca/go/src/goca/zone.go
+++ b/src/oca/go/src/goca/zone.go
@@ -17,6 +17,7 @@
 package goca
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 
@@ -70,7 +71,11 @@ func (c *ZonesController) ByName(name string) (int, error) {
 // Info returns a zone pool. A connection to OpenNebula is
 // performed.
 func (zc *ZonesController) Info() (*zone.Pool, error) {
-	response, err := zc.c.Client.Call("one.zonepool.info")
+	return zc.InfoContext(context.Background())
+}
+
+func (zc *ZonesController) InfoContext(ctx context.Context) (*zone.Pool, error) {
+	response, err := zc.c.Client.CallContext(ctx, "one.zonepool.info")
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +91,11 @@ func (zc *ZonesController) Info() (*zone.Pool, error) {
 
 // Info retrieves information for the zone.
 func (zc *ZoneController) Info(decrypt bool) (*zone.Zone, error) {
-	response, err := zc.c.Client.Call("one.zone.info", zc.ID, decrypt)
+	return zc.InfoContext(context.Background(), decrypt)
+}
+
+func (zc *ZoneController) InfoContext(ctx context.Context, decrypt bool) (*zone.Zone, error) {
+	response, err := zc.c.Client.CallContext(ctx, "one.zone.info", zc.ID, decrypt)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +112,11 @@ func (zc *ZoneController) Info(decrypt bool) (*zone.Zone, error) {
 //     attribute=value or XML.
 // * clusterID: The id of the cluster. If -1, the default one will be used
 func (zc *ZonesController) Create(tpl string, clusterID int) (int, error) {
-	response, err := zc.c.Client.Call("one.zone.allocate", tpl, clusterID)
+	return zc.CreateContext(context.Background(), tpl, clusterID)
+}
+
+func (zc *ZonesController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
+	response, err := zc.c.Client.CallContext(ctx, "one.zone.allocate", tpl, clusterID)
 	if err != nil {
 		return -1, err
 	}
@@ -113,7 +126,11 @@ func (zc *ZonesController) Create(tpl string, clusterID int) (int, error) {
 
 // Delete deletes the given zone from the pool.
 func (zc *ZoneController) Delete() error {
-	_, err := zc.c.Client.Call("one.zone.delete", zc.ID)
+	return zc.DeleteContext(context.Background())
+}
+
+func (zc *ZoneController) DeleteContext(ctx context.Context) error {
+	_, err := zc.c.Client.CallContext(ctx, "one.zone.delete", zc.ID)
 	return err
 }
 
@@ -122,20 +139,32 @@ func (zc *ZoneController) Delete() error {
 // * uType: Update type: Replace: Replace the whole template.
 //   Merge: Merge new template with the existing one.
 func (zc *ZoneController) Update(tpl string, uType parameters.UpdateType) error {
-	_, err := zc.c.Client.Call("one.zone.update", zc.ID, tpl, uType)
+	return zc.UpdateContext(context.Background(), tpl, uType)
+}
+
+func (zc *ZoneController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
+	_, err := zc.c.Client.CallContext(ctx, "one.zone.update", zc.ID, tpl, uType)
 	return err
 }
 
 // Rename renames a zone.
 // * newName: The new name.
 func (zc *ZoneController) Rename(newName string) error {
-	_, err := zc.c.Client.Call("one.zone.rename", zc.ID, newName)
+	return zc.RenameContext(context.Background(), newName)
+}
+
+func (zc *ZoneController) RenameContext(ctx context.Context, newName string) error {
+	_, err := zc.c.Client.CallContext(ctx, "one.zone.rename", zc.ID, newName)
 	return err
 }
 
 // ServerRaftStatus give the raft status of the server behind the current RPC endpoint. To get endpoints make an info call.
 func (zc *ZonesController) ServerRaftStatus() (*zone.ServerRaftStatus, error) {
-	response, err := zc.c.Client.Call("one.zone.raftstatus")
+	return zc.ServerRaftStatusContext(context.Background())
+}
+
+func (zc *ZonesController) ServerRaftStatusContext(ctx context.Context) (*zone.ServerRaftStatus, error) {
+	response, err := zc.c.Client.CallContext(ctx, "one.zone.raftstatus")
 	if err != nil {
 		return nil, err
 	}

--- a/src/oca/go/src/goca/zone.go
+++ b/src/oca/go/src/goca/zone.go
@@ -43,9 +43,13 @@ func (c *Controller) Zone(id int) *ZoneController {
 
 // ByName returns a zone id from name
 func (c *ZonesController) ByName(name string) (int, error) {
+	return c.ByNameContext(context.Background(), name)
+}
+
+func (c *ZonesController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
-	zonePool, err := c.Info()
+	zonePool, err := c.InfoContext(ctx)
 	if err != nil {
 		return -1, err
 	}

--- a/src/oca/go/src/goca/zone.go
+++ b/src/oca/go/src/goca/zone.go
@@ -46,6 +46,7 @@ func (c *ZonesController) ByName(name string) (int, error) {
 	return c.ByNameContext(context.Background(), name)
 }
 
+// ByNameContext returns a zone id from name
 func (c *ZonesController) ByNameContext(ctx context.Context, name string) (int, error) {
 	var id int
 
@@ -78,6 +79,8 @@ func (zc *ZonesController) Info() (*zone.Pool, error) {
 	return zc.InfoContext(context.Background())
 }
 
+// InfoContext returns a zone pool. A connection to OpenNebula is
+// performed.
 func (zc *ZonesController) InfoContext(ctx context.Context) (*zone.Pool, error) {
 	response, err := zc.c.Client.CallContext(ctx, "one.zonepool.info")
 	if err != nil {
@@ -98,6 +101,7 @@ func (zc *ZoneController) Info(decrypt bool) (*zone.Zone, error) {
 	return zc.InfoContext(context.Background(), decrypt)
 }
 
+// InfoContext retrieves information for the zone.
 func (zc *ZoneController) InfoContext(ctx context.Context, decrypt bool) (*zone.Zone, error) {
 	response, err := zc.c.Client.CallContext(ctx, "one.zone.info", zc.ID, decrypt)
 	if err != nil {
@@ -119,6 +123,11 @@ func (zc *ZonesController) Create(tpl string, clusterID int) (int, error) {
 	return zc.CreateContext(context.Background(), tpl, clusterID)
 }
 
+// CreateContext allocates a new zone. It returns the new zc.ID.
+//   - ctx: context for cancelation
+//   - tpl:	A string containing the template of the ZONE. Syntax can be the usual
+//     attribute=value or XML.
+//   - clusterID: The id of the cluster. If -1, the default one will be used
 func (zc *ZonesController) CreateContext(ctx context.Context, tpl string, clusterID int) (int, error) {
 	response, err := zc.c.Client.CallContext(ctx, "one.zone.allocate", tpl, clusterID)
 	if err != nil {
@@ -133,6 +142,7 @@ func (zc *ZoneController) Delete() error {
 	return zc.DeleteContext(context.Background())
 }
 
+// DeleteContext deletes the given zone from the pool.
 func (zc *ZoneController) DeleteContext(ctx context.Context) error {
 	_, err := zc.c.Client.CallContext(ctx, "one.zone.delete", zc.ID)
 	return err
@@ -146,6 +156,11 @@ func (zc *ZoneController) Update(tpl string, uType parameters.UpdateType) error 
 	return zc.UpdateContext(context.Background(), tpl, uType)
 }
 
+// UpdateContext adds zone content.
+//   - ctx: context for cancelation
+//   - tpl: The new zone contents. Syntax can be the usual attribute=value or XML.
+//   - uType: Update type: Replace: Replace the whole template.
+//     Merge: Merge new template with the existing one.
 func (zc *ZoneController) UpdateContext(ctx context.Context, tpl string, uType parameters.UpdateType) error {
 	_, err := zc.c.Client.CallContext(ctx, "one.zone.update", zc.ID, tpl, uType)
 	return err
@@ -157,6 +172,9 @@ func (zc *ZoneController) Rename(newName string) error {
 	return zc.RenameContext(context.Background(), newName)
 }
 
+// RenameContext renames a zone.
+// * ctx: context for cancelation
+// * newName: The new name.
 func (zc *ZoneController) RenameContext(ctx context.Context, newName string) error {
 	_, err := zc.c.Client.CallContext(ctx, "one.zone.rename", zc.ID, newName)
 	return err
@@ -167,6 +185,7 @@ func (zc *ZonesController) ServerRaftStatus() (*zone.ServerRaftStatus, error) {
 	return zc.ServerRaftStatusContext(context.Background())
 }
 
+// ServerRaftStatusContext give the raft status of the server behind the current RPC endpoint. To get endpoints make an info call.
 func (zc *ZonesController) ServerRaftStatusContext(ctx context.Context) (*zone.ServerRaftStatus, error) {
 	response, err := zc.c.Client.CallContext(ctx, "one.zone.raftstatus")
 	if err != nil {


### PR DESCRIPTION
This adds support for passing through a context to use for rpc requests in a backwards compatible fashion. This is similar to the way it was added to the standard go `database/sql` library, so it will be familiar to Go developers.