### PR TITLE
B #5869: Filter out unsupported CPU models

### DIFF
--- a/src/im_mad/remotes/kvm-probes.d/host/system/machines_models.rb
+++ b/src/im_mad/remotes/kvm-probes.d/host/system/machines_models.rb
@@ -98,6 +98,20 @@ begin
         end
     end
 
+    # Filter out the unsupported CPU models
+    cmd = 'virsh -c qemu:///system domcapabilities kvm'
+    domcapabilities, e, s = Open3.capture3(cmd)
+    if s.success?
+        domcap_xml = REXML::Document.new(domcapabilities)
+        domcap_xml = domcap_xml.root
+        cpu_mode_custom_elem = domcap_xml.elements["cpu/mode[@name='custom',@supported='yes']"]
+        if cpu_mode_custom_elem
+            cpu_mode_custom_elem.elements.each("model[@usable='no']") { |m|
+                models.delete(m.text)
+            }
+        end
+    end
+
     machines.uniq!
     models.uniq!
 


### PR DESCRIPTION
Decided to format it as a patch than an
entire rewrite of the probe script.
This could be rewritten to populate the
models array with the supported only.