### PR TITLE
B #5914: GOCA - fix newline escaping in template values

### DIFF
--- a/src/oca/go/src/goca/dynamic/dyntemplate.go
+++ b/src/oca/go/src/goca/dynamic/dyntemplate.go
@@ -17,6 +17,7 @@
 package dynamic
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"strconv"
@@ -74,7 +75,19 @@ func (t *Template) String() string {
 
 // String prints a Pair in OpenNebula syntax
 func (p *Pair) String() string {
-	return fmt.Sprintf("%s=%s", p.XMLName.Local, strconv.Quote(p.Value))
+
+	if strconv.CanBackquote(p.Value) {
+		return fmt.Sprintf("%s=%s", p.XMLName.Local, strconv.Quote(p.Value))
+	} else {
+		buf := bytes.NewBufferString(p.XMLName.Local)
+		buf.WriteString("=\"")
+		buf.WriteString(strings.ReplaceAll(p.Value, `"`, `\"`))
+		buf.WriteString(strings.ReplaceAll(p.Value, `\`, `\\`))
+		buf.WriteByte('"')
+
+		return buf.String()
+
+	}
 }
 
 func (v *Vector) String() string {
@@ -350,6 +363,13 @@ func (t *Template) GetStrFromVec(vecKey, key string) (string, error) {
 // NewTemplate returns a new Template object
 func NewTemplate() *Template {
 	return &Template{}
+}
+
+// NewTemplate returns a new Template object
+func NewVector(name string) *Vector {
+	return &Vector{
+		XMLName: xml.Name{Local: name},
+	}
 }
 
 // AddVector creates a new vector in the template


### PR DESCRIPTION
In dynamic GOCA templates values are escaped via the `Quote` method. This also escape newline characters.
This PR try to keep using Quote to escape template pair values except for multiline values.
For the multiline case escaping will probably less accurate and strict than with quote.

Tested with some minimal sample of code:
```
func main() {
	tpl := vm.NewTemplate()
	tpl.Add("CPU", "1")
	tpl.Add("SCHED_REQUIREMENTS", `CLUSTER_ID!="123"`)
	tpl.Add("MEMORY", "1")
	tpl.Add("KEY", `line1 "
	line2`)
	tpl.Add("KEY2", "")
	tpl.Add("KEY3", `	ⓗ"']\[`)
	tpl.Add("NAME", "toto")

	fmt.Println(tpl.String())
}
```

Close #5914 