### PR TITLE
B-5914: fix double lines

### DIFF
--- a/src/oca/go/src/goca/dynamic/dyntemplate.go
+++ b/src/oca/go/src/goca/dynamic/dyntemplate.go
@@ -81,8 +81,9 @@ func (p *Pair) String() string {
 	} else {
 		buf := bytes.NewBufferString(p.XMLName.Local)
 		buf.WriteString("=\"")
-		buf.WriteString(strings.ReplaceAll(p.Value, `"`, `\"`))
-		buf.WriteString(strings.ReplaceAll(p.Value, `\`, `\\`))
+		newValue := strings.ReplaceAll(p.Value, `"`, `\"`)
+		newValue = strings.ReplaceAll(newValue, `\`, `\\`)
+		buf.WriteString(newValue)
 		buf.WriteByte('"')
 
 		return buf.String()


### PR DESCRIPTION
PR #5932 introduced a bug that duplicate some template lines. It's due to the two WriteString calls, only one call was needed