### PR TITLE
Fix install by removing obsolete share directories

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,6 @@ SHARE_DIRS="$SHARE_LOCATION/examples \
             $SHARE_LOCATION/examples/network_hooks \
             $SHARE_LOCATION/websockify \
             $SHARE_LOCATION/websockify/websockify \
-            $SHARE_LOCATION/esx-fw-vnc \
             $SHARE_LOCATION/oneprovision \
             $SHARE_LOCATION/dockerhub \
             $SHARE_LOCATION/dockerhub/dockerfiles \
@@ -754,7 +753,6 @@ INSTALL_FILES=(
     LXD_NETWORK_HOOKS:$SHARE_LOCATION/examples/network_hooks
     WEBSOCKIFY_SHARE_RUN_FILES:$SHARE_LOCATION/websockify
     WEBSOCKIFY_SHARE_MODULE_FILES:$SHARE_LOCATION/websockify/websockify
-    ESX_FW_VNC_SHARE_FILES:$SHARE_LOCATION/esx-fw-vnc
     INSTALL_GEMS_SHARE_FILES:$SHARE_LOCATION
     ONETOKEN_SHARE_FILE:$SHARE_LOCATION
     FOLLOWER_CLEANUP_SHARE_FILE:$SHARE_LOCATION


### PR DESCRIPTION
Related to commit M #-: Get rid of obsolete .vib files d019bd49a6f463a7fff7ba4ae05fc8e6699066f1

Signed-off-by: Kristian Feldsam <feldsam@gmail.com>