### PR TITLE
Add support for Extensible Match in LDAP Filter

### DIFF
--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -202,7 +202,7 @@ class OpenNebula::LdapAuth
             ldap_groups = [@user['memberOf']].flatten
         else
             group_base = @options[:group_base] ? @options[:group_base] : @options[:base]
-            filter = Net::LDAP::Filter.equals(@options[:group_field], @user[@options[:user_group_field]].first)
+            filter = Net::LDAP::Filter.ex(@options[:group_field], @user[@options[:user_group_field]].first)
             ldap_groups = @ldap.search(
                 :base       => group_base,
                 :attributes => [ "dn" ],


### PR DESCRIPTION
This permit to use the the LDAP_MATCHING_RULE_IN_CHAIN 
Fix #1289  if in the "ldap_auth.conf" you use :
    :group_field: 'member:1.2.840.113556.1.4.1941'