### PR TITLE
F #1289 Add support for nested group in LDAP

### DIFF
--- a/src/authm_mad/remotes/ldap/ldap_auth.rb
+++ b/src/authm_mad/remotes/ldap/ldap_auth.rb
@@ -168,7 +168,7 @@ class OpenNebula::LdapAuth
         result=@ldap.search(
                     :base   => group,
                     :attributes => [@options[:group_field]],
-                    :filter => "(#{@options[:group_field]}=#{username})")
+                    :filter => "(#{@options[:group_field]}:=#{username})")
 
         if result && result.first
             true
@@ -202,7 +202,7 @@ class OpenNebula::LdapAuth
             ldap_groups = [@user['memberOf']].flatten
         else
             group_base = @options[:group_base] ? @options[:group_base] : @options[:base]
-            filter = Net::LDAP::Filter.equals(@options[:group_field], @user[@options[:user_group_field]].first)
+            filter = Net::LDAP::Filter.ex(@options[:group_field], @user[@options[:user_group_field]].first)
             ldap_groups = @ldap.search(
                 :base       => group_base,
                 :attributes => [ "dn" ],


### PR DESCRIPTION
This permit to use the the LDAP_MATCHING_RULE_IN_CHAIN for nested group membership 

Here is "ldap_auth.conf" config related :+1: 

    :group_field: 'member:1.2.840.113556.1.4.1941'
    :rfc2307bis: false

This fix #1289

Signed-off-by: Alexandre ROTA <alex@not24get.fr>