### PR TITLE
M #-: Sunstone - fixed showing IP6_GLOBAL addresses

### DIFF
--- a/src/sunstone/public/app/opennebula/vm.js
+++ b/src/sunstone/public/app/opennebula/vm.js
@@ -1110,7 +1110,7 @@ define(function(require) {
     var non_external_nics = [];
 
     nics.forEach(function(nic, index){
-     if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || (nic.IP6_ULA && nic.IP6_GLOBAL) || nic.MAC){
+     if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || nic.IP6_GLOBAL || nic.IP6_ULA || nic.MAC){
         var copy_nic = Object.assign({}, nic);
         if (nic.EXTERNAL_IP){
           external_nics.push(nic);
@@ -1138,8 +1138,35 @@ define(function(require) {
 
     return copy_nics.reduce(function(column, nic) {
       if (first){
-        if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || (nic.IP6_ULA && nic.IP6_GLOBAL) || nic.MAC) {
-          var ip = nic.EXTERNAL_IP || nic.IP || nic.IP6 || nic.MAC || nic.IP6_ULA + "&#10;&#13;" + identation + nic.IP6_GLOBAL;
+        if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || nic.IP6_GLOBAL || nic.IP6_ULA || nic.MAC) {
+          var ip;
+          if (nic.EXTERNAL_IP) {
+	          ip = nic.EXTERNAL_IP
+          }
+          else {
+	          var ips = [];
+
+	          if (nic.IP)
+		          ips.push(nic.IP)
+
+	          if (nic.IP6)
+	          	  ips.push(nic.IP6)
+	          else if (nic.IP6_ULA && nic.IP6_GLOBAL)
+	          	  ips.push(nic.IP6_ULA + "&#10;&#13;" + identation + nic.IP6_GLOBAL)
+	          else if (nic.IP6_GLOBAL)
+	          	  ips.push(nic.IP6_GLOBAL)
+
+	          if (ips.length == 0 && nic.MAC)
+	          	  ips.push(nic.MAC)
+
+              // show only first one
+	          ip = ips[0]
+	          if (ips.length > 1)
+	            // this ensure showing dropdown on the vms list datatable
+	          	ip += "&#10;&#13;"
+          }
+
+
           nic_and_ip = nic.NIC_ID + ": " + ip;
           if (nic.EXTERNAL_IP)
             nic_and_ip = "<span style='color: gray; font-weight: bold;'>" + nic_and_ip + "</span>";
@@ -1148,7 +1175,7 @@ define(function(require) {
         }
       }
       else{
-        if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || (nic.IP6_ULA && nic.IP6_GLOBAL) || nic.MAC) {
+        if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || nic.IP6_GLOBAL || nic.IP6_ULA || nic.MAC) {
           var ip;
           var nicSection = $("<a/>").css("color", "gray");
 
@@ -1157,7 +1184,22 @@ define(function(require) {
             nicSection.css("font-weight", "bold");
           }
           else{
-            ip = nic.IP || nic.IP6 || nic.MAC || nic.IP6_ULA + "&#10;&#13;" + identation + nic.IP6_GLOBAL;
+            var ips = [];
+
+	        if (nic.IP)
+		        ips.push(nic.IP)
+
+	        if (nic.IP6)
+	        	ips.push(nic.IP6)
+	        else if (nic.IP6_ULA && nic.IP6_GLOBAL)
+	        	ips.push(nic.IP6_ULA + "&#10;&#13;" + identation + nic.IP6_GLOBAL)
+	        else if (nic.IP6_GLOBAL)
+	        	ips.push(nic.IP6_GLOBAL)
+
+	        if (ips.length == 0 && nic.MAC)
+	        	ips.push(nic.MAC)
+
+	        ip = ips.join(", ")
           }
 
           nicSection.html(nic.NIC_ID + ": " + ip);
@@ -1175,14 +1217,20 @@ define(function(require) {
               });
 
               if (alias) {
-                var alias_ip;
+				var alias_ip;
+                var alias_ips = [];
 
                 if (alias.IP)
-                    alias_ip = identation + "> " + alias.IP;
-                else if (alias.IP6)
-                    alias_ip = identation + "> " + alias.IP6;
+                    alias_ips.push(alias.IP)
+
+                if (alias.IP6)
+                    alias_ips.push(alias.IP6)
                 else if (alias.IP6_ULA && alias.IP6_GLOBAL)
-                    alias_ip = alias.IP6_ULA + "&#10;&#13;" + identation + "> " + alias.IP6_GLOBAL;
+                    alias_ips.push(alias.IP6_ULA + "&#10;&#13;" + identation + "> " + alias.IP6_GLOBAL)
+                else if (alias.IP6_GLOBAL)
+                    alias_ips.push(alias.IP6_GLOBAL)
+
+				alias_ip = alias_ips.join(", ")
 
                 if (alias_ip){
                   column.append($("<li/>").append($("<a/>").css({
@@ -1208,7 +1256,7 @@ define(function(require) {
     var identation = "&nbsp;&nbsp;&nbsp;&nbsp;";
 
     return all_nics.reduce(function(column, nic) {
-      if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || nic.MAC || (nic.IP6_ULA && nic.IP6_GLOBAL)) {
+      if (nic.EXTERNAL_IP || nic.IP || nic.IP6 || nic.MAC || nic.IP6_GLOBAL || nic.IP6_ULA) {
         var ip;
 
         var nicSection = $("<p/>")
@@ -1220,7 +1268,22 @@ define(function(require) {
           nicSection.css("font-weight","bold");
         }
         else {
-          ip = nic.IP || nic.IP6 || nic.MAC || nic.IP6_ULA + "<br>" + identation + nic.IP6_GLOBAL;
+          var ips = [];
+
+          if (nic.IP)
+	          ips.push(nic.IP)
+
+          if (nic.IP6)
+          	  ips.push(nic.IP6)
+          else if (nic.IP6_ULA && nic.IP6_GLOBAL)
+          	  ips.push(nic.IP6_ULA + "<br>" + identation + nic.IP6_GLOBAL)
+          else if (nic.IP6_GLOBAL)
+          	  ips.push(nic.IP6_GLOBAL)
+
+          if (ips.length == 0 && nic.MAC)
+          	  ips.push(nic.MAC)
+
+          ip = ips.join(", ")
         }
 
         nicSection.html(nic.NIC_ID + ": " + ip);
@@ -1236,14 +1299,20 @@ define(function(require) {
             var alias = templateAlias.find(function(alias) { return alias.NIC_ID === aliasId; });
 
               if (alias) {
-                var alias_ip;
+	            var alias_ip;
+                var alias_ips = [];
 
                 if (alias.IP)
-                    alias_ip = identation + "> " + alias.IP;
-                else if (alias.IP6)
-                    alias_ip = identation + "> " + alias.IP6;
+                    alias_ips.push(alias.IP)
+
+                if (alias.IP6)
+                    alias_ips.push(alias.IP6)
                 else if (alias.IP6_ULA && alias.IP6_GLOBAL)
-                    alias_ip = alias.IP6_ULA + "<br>" + identation + "> " + alias.IP6_GLOBAL;
+                    alias_ips.push(alias.IP6_ULA + "<br>" + identation + "> " + alias.IP6_GLOBAL)
+                else if (alias.IP6_GLOBAL)
+                    alias_ips.push(alias.IP6_GLOBAL)
+
+				alias_ip = identation + "> " + alias_ips.join(", ")
 
                 if (alias_ip){
                   column.append($("<p/>").css({


### PR DESCRIPTION
From OpenNebula version 6, there are changes in Sunstone regarding how IP addresses are shown. Few bugs:

- Only one IP address is show per NIC
- It show IP6_GLOBAL only if IP6_ULA is also defined

I fixed both bugs in this PR, check screenshots.

<img width="917" alt="Screenshot 2022-09-01 at 0 59 53" src="https://user-images.githubusercontent.com/951648/187800303-ebb1352f-7ad5-4e06-a965-63cd201add5b.png">
<img width="421" alt="Screenshot 2022-09-01 at 0 59 47" src="https://user-images.githubusercontent.com/951648/187800311-3e4035fa-c3a0-4036-8bda-764409ae6134.png">
<img width="547" alt="Screenshot 2022-09-01 at 0 58 43" src="https://user-images.githubusercontent.com/951648/187800316-1e11af3c-e76c-4aae-b841-18865bf0ab21.png">
<img width="416" alt="Screenshot 2022-09-01 at 0 59 28" src="https://user-images.githubusercontent.com/951648/187800312-33be3c36-3481-406b-a0cb-6f3f60e2f726.png">
<img width="510" alt="Screenshot 2022-09-01 at 0 58 57" src="https://user-images.githubusercontent.com/951648/187800315-61e77362-a675-4705-83fc-8867540f7502.png">
<img width="400" alt="Screenshot 2022-09-01 at 0 59 14" src="https://user-images.githubusercontent.com/951648/187800314-a48b244c-7983-417e-990f-339c408e5bef.png">

