### PR TITLE
use literal heredoc to prevent bash evaluation of stdin data

### DIFF
--- a/src/mad/ruby/OpenNebulaDriver.rb
+++ b/src/mad/ruby/OpenNebulaDriver.rb
@@ -108,7 +108,7 @@ class OpenNebulaDriver < ActionManager
                                          @timeout)
         elsif options[:ssh_stream]
             if options[:stdin]
-                cmdin = "cat << EOT | #{command}"
+                cmdin = "cat << 'EOT' | #{command}"
                 stdin = "#{options[:stdin]}\nEOT\n"
             else
                 cmdin = command


### PR DESCRIPTION
when the stdin of a command contains bash-evaluated characters, execution will fail with funny errors like:

```
bash: line 2: : command not found
```

this patch prevents the bash evaluation through a quoted here-doc word.

`man 1 bash` says:
> If word is unquoted, all lines of the here-document are subjected to parameter expansion,
> command substitution, and arithmetic expansion, the character sequence \\&lt;newline&gt; is ignored,
> and \ must be used to quote the characters \, $, and `.

we did not check if this allows unintended code execution through the input data, e.g. the configuration xml.


there's a lot more `<< EOT` here-docs in the code base which are unquoted - probably they can have the same unforseen side-effects.