### PR TITLE
F-6019: GOCA - add ipam field to AR structure

### DIFF
--- a/src/oca/go/src/goca/schemas/virtualnetwork/virtualnetwork.go
+++ b/src/oca/go/src/goca/schemas/virtualnetwork/virtualnetwork.go
@@ -77,6 +77,7 @@ type AR struct {
 	IP6GlobalEnd      string  `xml:"IP6_GLOBAL_END,omitempty"`
 	IP6               string  `xml:"IP6,omitempty"`
 	IP6End            string  `xml:"IP6_END,omitempty"`
+	IpamMad           string  `xml:"IPAM_MAD,omitempty"`
 	UsedLeases        string  `xml:"USED_LEASES,omitempty"`
 	Leases            []Lease `xml:"LEASES>LEASE,omitempty"`
 


### PR DESCRIPTION
Add ipam field to GOCA virtual network address range structure

Close #6019 