### PR TITLE
F #5681: disk source element depends on disk type

### DIFF
--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -1522,6 +1522,7 @@ int LibVirtDriver::deployment_description_kvm(
             Image::DiskType ctxt_disk_type = Image::FILE;
 
             string s_cdt;
+            string s_cst;
 
             if (auto ds = nd.get_dspool()->get_ro(vm->get_ds_id()))
             {
@@ -1530,21 +1531,20 @@ int LibVirtDriver::deployment_description_kvm(
 
             switch (ctxt_disk_type)
             {
-                case Image::FILE:
-                    s_cdt = "file";
-                    break;
                 case Image::BLOCK:
                     s_cdt = "block";
+                    s_cst = "dev";
                     break;
                 default:
                     s_cdt = "file";
+                    s_cst = "file";
                     break;
             }
 
             fname << vm->get_system_dir() << "/disk." << disk_id;
 
             file << "\t\t<disk type='" << s_cdt << "' device='cdrom'>\n"
-                 << "\t\t\t<source file="
+                 << "\t\t\t<source " << s_cst << "="
                      << one_util::escape_xml_attr(fname.str())  << "/>\n"
                  << "\t\t\t<target dev=" << one_util::escape_xml_attr(target);
 


### PR DESCRIPTION
following the domain XML definition https://libvirt.org/formatdomain.html
```
_source_
  Representation of the _disk source_ depends on the _disk type_ attribute value as follows:
  _file_
    The _file_ attribute specifies the fully-qualified path to the file holding the disk. Since 0.0.3
  _block_
    The _dev_ attribute specifies the fully-qualified path to the host device to serve as the disk. Since 0.0.3
```

Also, I took the liberty to remove the _Image::FILE_ case form the switch as it is the default one.