### PR TITLE
F #5906: improve error logging on onehost sync

### DIFF
--- a/src/mad/ruby/CommandManager.rb
+++ b/src/mad/ruby/CommandManager.rb
@@ -144,6 +144,10 @@ private
             terminator_e = nil
             mutex = Mutex.new
 
+            # print stdout and stderr for troubleshooting
+            STDERR.puts o.read
+            STDERR.puts e.read
+
             out_reader = Thread.new { o.read }
             err_reader = Thread.new { e.read }
             terminator = Thread.new {

--- a/src/mad/ruby/HostSyncManager.rb
+++ b/src/mad/ruby/HostSyncManager.rb
@@ -64,7 +64,7 @@ class HostSyncManager
         end
 
         assemble_cmd = lambda do |steps|
-            "exec 2>/dev/null; #{steps.join(' && ')}"
+            "exec 2>&1 /dev/null; #{steps.join(' && ')}"
         end
 
         case copy_method

--- a/src/mad/ruby/HostSyncManager.rb
+++ b/src/mad/ruby/HostSyncManager.rb
@@ -64,7 +64,7 @@ class HostSyncManager
         end
 
         assemble_cmd = lambda do |steps|
-            "exec 2>&1 /dev/null; #{steps.join(' && ')}"
+            "exec 2>&1 > /dev/null; #{steps.join(' && ')}"
         end
 
         case copy_method


### PR DESCRIPTION
Added printing of stdout & stderr for `onehost sync --force`.