### PR TITLE
F #6099: Improve FT Hook Script host_error.rb

### DIFF
--- a/share/hooks/ft/host_error.rb
+++ b/share/hooks/ft/host_error.rb
@@ -122,7 +122,7 @@ end
 
 mode    = nil    # **must** be set to something other than nil using the options
 force   = false  # By default, don't recreate/delete suspended and poweroff VMs
-repeat  = 2      # By default, wait for 2 monitorization cycles
+repeat  = 2      # By default, wait for 2 monitorization cycles
 fencing = true
 
 opts = GetoptLong.new(
@@ -248,6 +248,13 @@ if OpenNebula.is_error?(rc)
     exit_error "Could not get vm pool"
 end
 
+ds_pool = OpenNebula::DatastorePool.new(client)
+rc = ds_pool.info_all
+
+if OpenNebula.is_error?(rc)
+    exit_error "Could not get datastore pool"
+end
+
 # STATE=3: ACTIVE (LCM unknown)
 # STATE=5: SUSPENDED
 # STATE=8: POWEROFF
@@ -272,6 +279,16 @@ if vm_ids_array
 
         if OpenNebula.is_error?(rc)
             log_error "Could not get info of VM #{vm_id}"
+            next
+        end
+
+        vm_ds_id  = vm.retrieve_elements("/VM/HISTORY_RECORDS/HISTORY[last()]/DS_ID")[0]
+
+        ds_xpath  = "/DATASTORE_POOL/DATASTORE[ID=\"#{vm_ds_id}\"]/TEMPLATE/SHARED"
+        is_shared = ds_pool.retrieve_elements(ds_xpath)[0]
+
+        if is_shared == "NO"
+            log "Skipping VM #{vm_id} deployed on non-shared datastore"
             next
         end
 

--- a/share/hooks/ft/host_error.rb
+++ b/share/hooks/ft/host_error.rb
@@ -290,15 +290,21 @@ if vm_ids_array
             log "delete #{vm_id}"
             vm.delete
         when :migrate
-            vm_ds_id  = vm.retrieve_elements("/VM/HISTORY_RECORDS/HISTORY[position()=last()]/DS_ID")[0]
+            begin
+                vm_ds_id  = vm.retrieve_elements('/VM/HISTORY_RECORDS/HISTORY[last()]/DS_ID')[0]
 
-            ds_xpath  = "/DATASTORE_POOL/DATASTORE[ID=\"#{vm_ds_id}\"]/TEMPLATE/SHARED"
-            is_shared = ds_pool.retrieve_elements(ds_xpath)[0]
+                ds_xpath  = "/DATASTORE_POOL/DATASTORE[ID=\"#{vm_ds_id}\"]/TEMPLATE/SHARED"
+                is_shared = ds_pool.retrieve_elements(ds_xpath)[0]
 
-            if is_shared == "NO"
-                log "Skipping VM #{vm_id} deployed on non-shared datastore"
+                if is_shared == "NO"
+                    log "Skipping VM #{vm_id} deployed on non-shared datastore"
+                    next
+                end
+            rescue
+                log_error "Could not get Datastore ID or SHARED attribute for VM #{vm_id}"
                 next
             end
+
             log "resched #{vm_id}"
             vm.resched
         else

--- a/share/hooks/ft/host_error.rb
+++ b/share/hooks/ft/host_error.rb
@@ -282,16 +282,6 @@ if vm_ids_array
             next
         end
 
-        vm_ds_id  = vm.retrieve_elements("/VM/HISTORY_RECORDS/HISTORY[last()]/DS_ID")[0]
-
-        ds_xpath  = "/DATASTORE_POOL/DATASTORE[ID=\"#{vm_ds_id}\"]/TEMPLATE/SHARED"
-        is_shared = ds_pool.retrieve_elements(ds_xpath)[0]
-
-        if is_shared == "NO"
-            log "Skipping VM #{vm_id} deployed on non-shared datastore"
-            next
-        end
-
         case mode
         when :recreate
             log "recreate #{vm_id}"
@@ -300,6 +290,15 @@ if vm_ids_array
             log "delete #{vm_id}"
             vm.delete
         when :migrate
+            vm_ds_id  = vm.retrieve_elements("/VM/HISTORY_RECORDS/HISTORY[last()]/DS_ID")[0]
+
+            ds_xpath  = "/DATASTORE_POOL/DATASTORE[ID=\"#{vm_ds_id}\"]/TEMPLATE/SHARED"
+            is_shared = ds_pool.retrieve_elements(ds_xpath)[0]
+
+            if is_shared == "NO"
+                log "Skipping VM #{vm_id} deployed on non-shared datastore"
+                next
+            end
             log "resched #{vm_id}"
             vm.resched
         else

--- a/share/hooks/ft/host_error.rb
+++ b/share/hooks/ft/host_error.rb
@@ -290,7 +290,7 @@ if vm_ids_array
             log "delete #{vm_id}"
             vm.delete
         when :migrate
-            vm_ds_id  = vm.retrieve_elements("/VM/HISTORY_RECORDS/HISTORY[last()]/DS_ID")[0]
+            vm_ds_id  = vm.retrieve_elements("/VM/HISTORY_RECORDS/HISTORY[position()=last()]/DS_ID")[0]
 
             ds_xpath  = "/DATASTORE_POOL/DATASTORE[ID=\"#{vm_ds_id}\"]/TEMPLATE/SHARED"
             is_shared = ds_pool.retrieve_elements(ds_xpath)[0]


### PR DESCRIPTION
Adds checks to the "migrate" option of the Fault Tolerance hook script `host_error.rb` to skip virtual machines which are hosted on the failed host but are not deployed to a shared datastore.

The whole datastore pool is gathered at first, and that pool is used to reference the shared value to keep the API calls low.

This resolves https://github.com/OpenNebula/one/issues/6099

Should apply to 6.6 and up