### PR TITLE
goca: parse HostShare Datastores struct from HostXML.cc

### DIFF
--- a/src/oca/go/src/goca/schemas/host/host.go
+++ b/src/oca/go/src/goca/schemas/host/host.go
@@ -73,11 +73,11 @@ type Share struct {
 }
 
 type Datastores struct {
-	DiskUsage int       `xml:"DISK_USAGE,omitempty"`
-	FreeDisk  int       `xml:"FREE_DISK,omitempty"`
-	MaxDisk   int       `xml:"MAX_DISK,omitempty"`
-	UsedDisk  int       `xml:"USED_DISK,omitempty"`
-	Datastore Datastore `xml:"DS,omitempty"`
+	DiskUsage  int         `xml:"DISK_USAGE,omitempty"`
+	FreeDisk   int         `xml:"FREE_DISK,omitempty"`
+	MaxDisk    int         `xml:"MAX_DISK,omitempty"`
+	UsedDisk   int         `xml:"USED_DISK,omitempty"`
+	Datastores []Datastore `xml:"DS,omitempty"`
 }
 
 type Datastore struct {

--- a/src/oca/go/src/goca/schemas/host/host.go
+++ b/src/oca/go/src/goca/schemas/host/host.go
@@ -73,10 +73,18 @@ type Share struct {
 }
 
 type Datastores struct {
-	DiskUsage int `xml:"DISK_USAGE,omitempty"`
-	FreeDisk  int `xml:"FREE_DISK,omitempty"`
-	MaxDisk   int `xml:"MAX_DISK,omitempty"`
-	UsedDisk  int `xml:"USED_DISK,omitempty"`
+	DiskUsage int       `xml:"DISK_USAGE,omitempty"`
+	FreeDisk  int       `xml:"FREE_DISK,omitempty"`
+	MaxDisk   int       `xml:"MAX_DISK,omitempty"`
+	UsedDisk  int       `xml:"USED_DISK,omitempty"`
+	Datastore Datastore `xml:"DS,omitempty"`
+}
+
+type Datastore struct {
+	ID      int `xml:"ID,omitempty"`
+	TotalMB int `xml:"TOTAL_MB,omitempty"`
+	FreeMB  int `xml:"FREE_MB,omitempty"`
+	UsedMB  int `xml:"USED_MB,omitempty"`
 }
 
 type PCIDevices struct {


### PR DESCRIPTION
Allow parse extra data generated from:

https://github.com/OpenNebula/one/blob/08bb8f7684a2b773f33aac3bd3e81e8e2f23c50b/src/scheduler/src/pool/HostXML.cc#L62-L68

