### PR TITLE
Fix segmentation fault in oned service when configured to cache mode.

### DIFF
--- a/src/rm/Request.cc
+++ b/src/rm/Request.cc
@@ -460,9 +460,12 @@ void Request::execute(
 
     std::string event = HookAPI::format_message(method_name, pl, att);
 
-    if (!event.empty())
+    if (!nd.is_cache())
     {
-        hm->trigger_send_event(event);
+        if (!event.empty())
+        {
+            hm->trigger_send_event(event);
+        }
     }
 
     if ( log_method_call )


### PR DESCRIPTION
Issue #6302 
**Description**
After setting federation mode to be "CACHE" the XML/RPC server crash on segmentation fault.

**To Reproduce**
- Configure "CACHE" API server - in /etc/one/oned.conf set federation mode to "CACHE" and set DB and MASTER_ONED. 
- sudo systemctl restart opennebula
- send "one.zone.raftstatus" request to server.

**Detailes**
- Hypervisor: KVM
- version: 6.4.0

Program crashed when trying to call hm->trigger_send_event in Request.cc (hm is null).

Before :
```
if (!event.empty())
{
    hm->trigger_send_event(event);
}
```

After:
```
if (!nd.is_cache())
{
    if (!event.empty())
    {
        hm->trigger_send_event(event);
    }
}
```

When nebula is cache HookManager isn't initialize, therfore ```hm``` equals to null.