### PR TITLE
Fix iptables commands on versions > 1.8.7

### DIFF
--- a/src/vnm_mad/remotes/lib/command.rb
+++ b/src/vnm_mad/remotes/lib/command.rb
@@ -45,7 +45,7 @@ module VNMMAD
 
             iptables_version = Gem::Version.new(stdout.match(regex)[:version])
 
-            if Gem::Version.new('1.6.1') > iptables_version
+            if Gem::Version.new('1.6.1') > iptables_version || iptables_version > Gem::Version.new('1.8.7')
                 COMMANDS[:iptables]  = 'sudo -n iptables -w 3'
                 COMMANDS[:ip6tables] = 'sudo -n ip6tables -w 3'
             end


### PR DESCRIPTION
iptables version > 1.8.7 (nf_tables) on EL9 doesn't support --wait option.


https://manpages.debian.org/testing/iptables/ebtables-nft-save.8.en.html#DIFFERENCES_TO_LEGACY_IPTABLES

https://lwn.net/Articles/759184/
