### PR TITLE
Update onevcenter

### DIFF
--- a/src/cli/onevcenter
+++ b/src/cli/onevcenter
@@ -261,7 +261,7 @@ CommandParser::CmdParser.new(ARGV) do
         Examples:
            - importing first datastore
 
-             onevcenter list -o templates -h <host_id>
+             onevcenter import -o templates -h <host_id>
 
            - importing 2 concrete templates:
 


### PR DESCRIPTION
change first 'import' example from `onevcenter list` to 'onevcenter import`

### Description

Reading through the help menu, noticed that for the import examples, the first one showed a "list" command argument rather than import, I assume it should be 'import'
Also, noticed that the 'import_desc' is used for both `import` and `import_defaults`, not sure if this is the desired case

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
