### PR TITLE
Sunstone host capacity should display gathered data

### DIFF
--- a/src/cli/oneuser
+++ b/src/cli/oneuser
@@ -621,7 +621,7 @@ CommandParser::CmdParser.new(ARGV) do
         Example, request a valid token for a generic driver (e.g. core auth, LDAP...):
           oneuser token-create my_user --time 3600
 
-        Example, request a group spefici token (new resources will be created in that
+        Example, request a group specific token (new resources will be created in that
         group and only resources that belong to that group will be listed):
           oneuser token-create my_user --group <id|group>
 

--- a/src/sunstone/public/app/tabs/datastores-tab/utils/datastore-capacity-bar.js
+++ b/src/sunstone/public/app/tabs/datastores-tab/utils/datastore-capacity-bar.js
@@ -27,7 +27,7 @@ define(function(require) {
    */
   var _html = function(info) {
     var total = parseInt(info.TOTAL_MB);
-    var used = total - parseInt(info.FREE_MB);
+    var used = parseInt(info.USED_MB);
 
     if (total > 0) {
       var ratio = Math.round((used / total) * 100);


### PR DESCRIPTION
### Description

Display gathered monitoring data, sunstone tries to calculate it using it's own formula, wich do not reflect the actual space.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.4

<hr>

- [ ] Check this if this PR should **not** be squashed
