### PR TITLE
B #6464: backup execution PARALLEL mode fix

### DIFF
--- a/include/BackupJob.h
+++ b/include/BackupJob.h
@@ -92,7 +92,7 @@ public:
         {
             exec = SEQUENTIAL;
         }
-        else if ( str_exec == "PARALELL" )
+        else if ( str_exec == "PARALLEL" )
         {
             exec = PARALLEL;
         }


### PR DESCRIPTION

### Description

There is a typo causing the PARALLEL execution mode to be not recognized

### Branches to which this PR applies


- [x] master
- [x] one-6.8

<hr>

- [ ] Check this if this PR should **not** be squashed
