### PR TITLE
B #6472: Fix remove_off_hosts()

### DIFF
--- a/src/datastore_mad/remotes/libfs.sh
+++ b/src/datastore_mad/remotes/libfs.sh
@@ -477,13 +477,12 @@ function check_restricted {
 #-------------------------------------------------------------------------------
 # Filter out hosts which are OFF, ERROR or DISABLED
 #   @param $1 - space separated list of hosts
-#   @return   - space separated list of hosts which are not in OFF, ERROR or
-#               DISABLED sate
+#   @return   - space separated list of hosts which are in ON or UPDATE sate
 #-------------------------------------------------------------------------------
 function remove_off_hosts {
     ALL_HOSTS_ARRAY=($1)
     OFF_HOSTS_STR=$(onehost list --no-pager --csv \
-		--filter="STAT=off,STAT=err,STAT=dsbl" --list=NAME,STAT 2>/dev/null)
+		--filter="STAT!=on,STAT!=update" --list=NAME,STAT 2>/dev/null)
 
     if [ $? -eq 0 ]; then
         OFF_HOSTS_ARRAY=($( echo "$OFF_HOSTS_STR" | awk -F, '{ if (NR>1) print $1 }'))


### PR DESCRIPTION
Return only the hosts in ON or UPDATE state (ONLINE or MONITORING_UPDATE). The original logic include the INIT state too, but there is a possibility that a host could become in ERROR state on failed INIT.

### Description

<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
