### PR TITLE
Add option for group based authorization with AD schema

### DIFF
--- a/src/authm_mad/remotes/ldap/authenticate
+++ b/src/authm_mad/remotes/ldap/authenticate
@@ -114,9 +114,15 @@ order.each do |servers|
                 end
 
                 if server_conf[:group]
-                    if !ldap.is_in_group?(user_group_name, server_conf[:group])
-                        STDERR.puts "User #{user} is not in group #{server_conf[:group]}"
-                        break
+                    if server_conf[:ldap_schema] && server_conf[:ldap_schema] == "AD"
+                        if !user_group_name.member?(server_conf[:group])
+                                break
+                        end
+                    else
+                      if !ldap.is_in_group?(user_group_name, server_conf[:group])
+                          STDERR.puts "User #{user} is not in group #{server_conf[:group]}"
+                          break
+                      end
                     end
                 end
 


### PR DESCRIPTION
### Description
In AD schema all groups are listed as memberOf attribute under the user record. In this case there is no need for ldap search to check group membership since it's already available.


### Branches to which this PR applies

- [x] master

<hr>

- [ ] Check this if this PR should **not** be squashed
