### PR TITLE
F #5823: Update the way Python bindings are built and installed

### DIFF
--- a/src/oca/python/Makefile
+++ b/src/oca/python/Makefile
@@ -15,6 +15,7 @@
 
 # Use full path to ensure virtualenv compatibility
 PYTHON = $(shell which python3)
+PIP = ${shell which pip3}
 GDS = $(shell which generateDS)
 PWD = $(shell pwd)
 
@@ -40,10 +41,10 @@ clean:
 	rm -rf build dist pyone/bindings *.egg-info doc
 
 dist:
-	${PYTHON} setup.py sdist bdist_wheel
+	${PIP} wheel --no-deps -w dist .
 
 install:
-	${PYTHON} setup.py install ${root}
+	${PIP} install --root-user-action=ignore ${PWD}/dist/*.whl
 
 doc:
 	mkdir -p doc


### PR DESCRIPTION
### Description
Change deprecated way of building and installing:
```python
python setup.py ...
```
to the modern one compliant with [PEP517](https://peps.python.org/pep-0517/)

**NOTE:** Installing contains an option `--root-user-action=ignore` to ignore warning about installing as root user. To avoid that flag, a virtual environment should be considered (but it then requires more thorough changes.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
