### PR TITLE
F #4188: Enabled custom attributes at Python binding

### DIFF
--- a/src/oca/python/pyone/util.py
+++ b/src/oca/python/pyone/util.py
@@ -174,6 +174,9 @@ class TemplatedType(object):
     '''
     Mixin class for Templated bindings
     '''
+    def _buildAttributes(self, node, attrs, already_processed):
+        vars(self)['custom_attrs'] = dict(attrs)
+
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
         if not build_template_node(self, nodeName_, child_):
             super(TemplatedType, self)._buildChildren(child_,node,nodeName_,fromsubclass_,gds_collector_)


### PR DESCRIPTION
### Description

Added `TemplatedType._buildAttributes` that will be inherited by binding classes and called indirectly from `bindings.parseString`.

It will add `custom_attrs` field of type `dict` to the result of `parseString`, e.g.:

```python
>>> result.custom_attrs
{'x': 'y'}
>>> result.HOST[0].custom_attrs
{'a': 'b', 'c': 'd'}
```

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.8
- [ ] one-6.4

<hr>

- [ ] Check this if this PR should **not** be squashed
