### PR TITLE
B OpenNebula/one#6487: Fixed bug on the cloning scripts where the SPARSE parameter from the Datastore was ignored.

### DIFF
--- a/src/tm_mad/qcow2/clone
+++ b/src/tm_mad/qcow2/clone
@@ -68,12 +68,14 @@ done < <(onevm show -x $VMID| $XPATH \
                     /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/SIZE \
                     /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/FORMAT \
                     /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/ORIGINAL_SIZE \
-                    /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/QCOW2_STANDALONE)
+                    /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/QCOW2_STANDALONE \
+                    /VM/HISTORY_RECORDS/HISTORY[last\(\)]/DS_ID)
 
 SIZE="${XPATH_ELEMENTS[j++]}"
 FORMAT="${XPATH_ELEMENTS[j++]}"
 ORIGINAL_SIZE="${XPATH_ELEMENTS[j++]}"
 QCOW2_STANDALONE="${XPATH_ELEMENTS[j++]}"
+SYS_DS_ID="${XPATH_ELEMENTS[j++]}"
 
 ssh_make_path $DST_HOST $DST_DIR
 disable_local_monitoring $DST_HOST $DST_DIR
@@ -81,9 +83,14 @@ disable_local_monitoring $DST_HOST $DST_DIR
 #-------------------------------------------------------------------------------
 # Clone (cp) SRC into DST
 #-------------------------------------------------------------------------------
+SPARSE=$(get_ds_attribute $SYS_DS_ID "SPARSE")
 
 if [ -n "$ORIGINAL_SIZE" ] && [ "$SIZE" -gt "$ORIGINAL_SIZE" ]; then
-   RESIZE_CMD="qemu-img resize ${DST_PATH} ${SIZE}M"
+    if [[ "${SPARSE}" =~ ^(no|NO)$ ]]; then
+        RESIZE_CMD="qemu-img resize --preallocation=falloc ${DST_PATH} ${SIZE}M"
+    else
+        RESIZE_CMD="qemu-img resize ${DST_PATH} ${SIZE}M"
+    fi
 fi
 
 if [ "$FORMAT" = "qcow2" ] && is_yes "${QCOW2_STANDALONE}"; then
@@ -92,6 +99,11 @@ elif [ "$FORMAT" = "qcow2" ]; then
     CLONE_CMD=$(qcow_dir_cmd $SRC_PATH $DST_PATH "create")
 else
     CLONE_CMD="cp $SRC_PATH $DST_PATH"
+fi
+
+if [[ "${SPARSE}" =~ ^(no|NO)$ ]]; then
+    CLONE_CMD=$(qcow_dir_cmd "$SRC_PATH" "$DST_PATH" "convert")
+    CLONE_CMD="${CLONE_CMD/-O qcow2/-O qcow2 -S 0}"
 fi
 
 CLONE_RESIZE_CMD=$(cat <<EOF

--- a/src/tm_mad/qcow2/clone.ssh
+++ b/src/tm_mad/qcow2/clone.ssh
@@ -66,24 +66,36 @@ while IFS= read -r -d '' element; do
 done < <(onevm show -x $VMID| $XPATH \
                     /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/SIZE \
                     /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/FORMAT \
-                    /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/ORIGINAL_SIZE)
+                    /VM/TEMPLATE/DISK\[DISK_ID=$DISK_ID\]/ORIGINAL_SIZE \
+                    /VM/HISTORY_RECORDS/HISTORY[last\(\)]/DS_ID)
 
 SIZE="${XPATH_ELEMENTS[j++]}"
 FORMAT="${XPATH_ELEMENTS[j++]}"
 ORIGINAL_SIZE="${XPATH_ELEMENTS[j++]}"
+SYS_DS_ID="${XPATH_ELEMENTS[j++]}"
 
 #-------------------------------------------------------------------------------
 # Copy files to the remote host
 #-------------------------------------------------------------------------------
+SPARSE=$(get_ds_attribute $SYS_DS_ID "SPARSE")
 
 if [ -n "$ORIGINAL_SIZE" ] && [ "$SIZE" -gt "$ORIGINAL_SIZE" ]; then
-    RESIZE_CMD="qemu-img resize ${DST_PATH} ${SIZE}M"
+    if [[ "${SPARSE}" =~ ^(no|NO)$ ]]; then
+        RESIZE_CMD="qemu-img resize --preallocation=falloc ${DST_PATH} ${SIZE}M"
+    else
+        RESIZE_CMD="qemu-img resize ${DST_PATH} ${SIZE}M"
+    fi
 fi
 
 if [ "$FORMAT" = "qcow2" ]; then
     CLONE_CMD=$(qcow_dir_cmd "$SRC_PATH" "$DST_PATH" "convert")
 else
     CLONE_CMD="cp $SRC_PATH $DST_PATH"
+fi
+
+if [[ "${SPARSE}" =~ ^(no|NO)$ ]]; then
+    CLONE_CMD=$(qcow_dir_cmd "$SRC_PATH" "$DST_PATH" "convert")
+    CLONE_CMD="${CLONE_CMD/-O qcow2/-O qcow2 -S 0}"
 fi
 
 CLONE_RESIZE_CMD=$(cat <<EOF

--- a/src/tm_mad/ssh/clone
+++ b/src/tm_mad/ssh/clone
@@ -99,6 +99,7 @@ fi
 # Copy files to the remote host
 #-------------------------------------------------------------------------------
 log "Cloning $SRC_PATH in $DST_PATH"
+SPARSE=$(get_ds_attribute $SYS_DS_ID "SPARSE")
 
 COPY_CMD=$(cat <<EOF
     set -e -o pipefail
@@ -107,8 +108,13 @@ COPY_CMD=$(cat <<EOF
         SRC_SNAP="${SRC_FILE}.snap"
     fi
 
-    $TAR -C $SRC_DIR --transform="flags=r;s|$SRC_FILE|$DST_FILE|" -cSf - $SRC_FILE \$SRC_SNAP | \
-        $SSH $DST_HOST "$TAR -xSf - -C $DST_DIR"
+    if [[ "${SPARSE}" =~ ^(no|NO)$ ]]; then
+        $TAR -C $SRC_DIR --transform="flags=r;s|$SRC_FILE|$DST_FILE|" -cf - $SRC_FILE \$SRC_SNAP | \
+            $SSH $DST_HOST "$TAR -xf - -C $DST_DIR"
+    else
+        $TAR -C $SRC_DIR --transform="flags=r;s|$SRC_FILE|$DST_FILE|" -cSf - $SRC_FILE \$SRC_SNAP | \
+            $SSH $DST_HOST "$TAR -xSf - -C $DST_DIR"
+    fi
 EOF
 )
 
@@ -116,7 +122,12 @@ ssh_forward ssh_exec_and_log "$SRC_HOST" "$COPY_CMD" \
                              "Error copying $SRC_PATH to $DST"
 
 if [ -n "$ORIGINAL_SIZE" ] && [ "$SIZE" -gt "$ORIGINAL_SIZE" ]; then
-   RESIZE_CMD="qemu-img resize ${DST_PATH} ${SIZE}M"
-   ssh_exec_and_log "$DST_HOST" "$RESIZE_CMD" \
-       "Error resizing image $DST"
+    if [[ "${SPARSE}" =~ ^(no|NO)$ ]]; then
+        RESIZE_CMD="qemu-img resize --preallocation=falloc ${DST_PATH} ${SIZE}M"
+    else
+        RESIZE_CMD="qemu-img resize ${DST_PATH} ${SIZE}M"
+    fi
+
+    ssh_exec_and_log "$DST_HOST" "$RESIZE_CMD" \
+        "Error resizing image $DST"
 fi

--- a/src/tm_mad/tm_common.sh
+++ b/src/tm_mad/tm_common.sh
@@ -260,3 +260,16 @@ function is_yes
 {
     [[ "$1" =~ ^(yes|YES|true|TRUE)$ ]]
 }
+
+# ------------------------------------------------------------------------------
+# Returns given attribute value from DATASTORE template
+# ------------------------------------------------------------------------------
+function get_ds_attribute {
+    local DS_ID=$1
+    local ATTRIBUTE=$2
+
+    XPATH="${ONE_LOCAL_VAR}/remotes/datastore/xpath.rb --stdin"
+    LOC="/DATASTORE/TEMPLATE/$ATTRIBUTE"
+
+    echo "$(awk 'gsub(/[\0]/, x)' <(onedatastore show $DS_ID -x|$XPATH $LOC))"
+}


### PR DESCRIPTION
### Description
Fixed bug on the cloning scripts where the SPARSE parameter from the Datastore was ignored.

- Added function get_ds_attribute to tm_common.sh to get a given attribute from a Datastore
- Using falloc preallocation mode on the qemu-img commands since it is faster than using full preallocation
- Note the cloning script when using the TM_MAD = ssh does not use qemu-img command. Instead it uses the tar command, hence it ignores the QCOW2_OPTIONS parameter

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-6.8
- [ ] one-6.4

<hr>

- [ ] Check this if this PR should **not** be squashed
