### PR TITLE
B #6689: append --block to change-media call in reconfigure

### DIFF
--- a/src/vmm_mad/remotes/kvm/reconfigure
+++ b/src/vmm_mad/remotes/kvm/reconfigure
@@ -25,8 +25,9 @@ ISO_PATH=$3
 
 if [[ -n "$DOMAIN" ]] && [[ -n "$TARGET_DEVICE" ]] && [[ -n "$ISO_PATH" ]]
 then
+    test -b "$ISO_PATH" && EXTRA_ARGS="--block" || EXTRA_ARGS=""
     CMD="virsh --connect $LIBVIRT_URI \
-        change-media $DOMAIN $TARGET_DEVICE $ISO_PATH --insert"
+        change-media $DOMAIN $TARGET_DEVICE $ISO_PATH --insert $EXTRA_ARGS"
 
     exec_and_log "$CMD" "Could not insert CDROM $ISO_PATH to $TARGET_DEVICE"
 fi


### PR DESCRIPTION
### Description

when the $ISO_PATH is a block device.
So libvirt's change media should be called with additional argument `-block`


### Branches to which this PR applies

- [x] master
- [x] one-6.10

<hr>

- [ ] Check this if this PR should **not** be squashed
