### PR TITLE
Fix #6692

### DIFF
--- a/src/scheduler/src/pool/VMGroupXML.cc
+++ b/src/scheduler/src/pool/VMGroupXML.cc
@@ -176,6 +176,11 @@ void VMGroupXML::set_antiaffinity_requirements(VirtualMachinePoolXML * vmpool,
 
             VMGroupRole * r = roles.get(i);
 
+            if ( r == 0 )
+            {
+                continue;
+            }
+
             const std::set<int>& vms = r->get_vms();
 
             for ( auto vm_id : vms )


### PR DESCRIPTION
Check VMGroupRole in Inter-role Anti-affinity rules

### Description

Fix for #6692

### Branches to which this PR applies

- [ ] master

<hr>

- [ ] Check this if this PR should **not** be squashed
