### PR TITLE
Added serial attribute for disks in VM

### DIFF
--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -546,6 +546,7 @@ int LibVirtDriver::deployment_description_kvm(
     string discard;
     string source;
     string clone;
+    string serial;
     string blk_queues;
     string shareable;
     string ceph_host;
@@ -1108,6 +1109,7 @@ int LibVirtDriver::deployment_description_kvm(
         discard   = disk[i]->vector_value("DISCARD");
         source    = disk[i]->vector_value("SOURCE");
         clone     = disk[i]->vector_value("CLONE");
+        serial    = disk[i]->vector_value("SERIAL");
         blk_queues= disk[i]->vector_value("VIRTIO_BLK_QUEUES");
         shareable = disk[i]->vector_value("SHAREABLE");
 
@@ -1433,6 +1435,17 @@ int LibVirtDriver::deployment_description_kvm(
         if (shareable == "YES")
         {
             file << "\t\t\t<shareable/>" << endl;
+        }
+
+        // ---- serial attribute for the disk ---
+
+        if (serial.empty())
+        {
+            file << "\t\t\t<serial>" << vm->get_oid() << "-" << disk_id  << "</serial>" <<endl;
+        }
+        else
+        {
+            file << "\t\t\t<serial>" << serial << "</serial>" <<endl;
         }
 
         // ---- Image Format using qemu driver ----


### PR DESCRIPTION
### Description

Sometimes I need to have unique serials for disk in the VM - serials are created from the VM ID and next number, e.g.:

```
7771-1
7771-2
7771-3
7771-4
.
.
.
7771-N
```

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
