### PR TITLE
B #6759: finalize the SG rules on sg rule error

### DIFF
--- a/src/vnm_mad/remotes/lib/sg_driver.rb
+++ b/src/vnm_mad/remotes/lib/sg_driver.rb
@@ -102,6 +102,7 @@ module VNMMAD
             end
 
             # Process the rules for each NIC
+            sg_error = 0
             process do |nic|
                 next if attach_nic_id && attach_nic_id != nic[:nic_id]
 
@@ -124,9 +125,8 @@ module VNMMAD
                         sg.process_rules
                         sg.run!
                     rescue StandardError => e
-                        unlock
-                        SGIPTables.nic_post(@vm, nic)
-                        raise e
+                        sg_error = e
+                        break
                     end
                 end
 
@@ -141,6 +141,10 @@ module VNMMAD
             end
 
             unlock
+
+            unless sg_error == 0
+                raise sg_error
+            end
 
             0
         end

--- a/src/vnm_mad/remotes/lib/sg_driver.rb
+++ b/src/vnm_mad/remotes/lib/sg_driver.rb
@@ -125,7 +125,7 @@ module VNMMAD
                         sg.run!
                     rescue StandardError => e
                         unlock
-                        deactivate(do_all)
+                        SGIPTables.nic_post(@vm, nic)
                         raise e
                     end
                 end


### PR DESCRIPTION
instead of reseting the rules.

### Description

Open Nebula will raise and log the rule error for further investigation, but the VM will not be left unprotected.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-6.10

<hr>

- [ ] Check this if this PR should **not** be squashed
