### PR TITLE
B #6772: Fix for NUMA and CPU Pinning Discrepancies During VM Save and Live Migration

### DIFF
--- a/include/History.h
+++ b/include/History.h
@@ -114,11 +114,13 @@ private:
     std::string  deployment_file;
     std::string  context_file;
     std::string  token_file;
+    std::string  migrate_file;
 
     // Remote paths
     std::string  checkpoint_file;
     std::string  rdeployment_file;
     std::string  system_dir;
+    std::string  rmigrate_file;
 
     /**
      *  Writes the history record in the DB

--- a/include/VirtualMachine.h
+++ b/include/VirtualMachine.h
@@ -586,6 +586,19 @@ public:
     }
 
     /**
+     *  Returns the migrate filename. The migrate file is in the form:
+     *          $ONE_LOCATION/var/vms/$VM_ID/migrate.$SEQ
+     *  or, in case that OpenNebula is installed in root
+     *          /var/lib/one/vms/$VM_ID/migrate.$SEQ
+     *  The hasHistory() function MUST be called before this one.
+     *    @return the migrate file path
+     */
+    const std::string & get_migrate_file() const
+    {
+        return history->migrate_file;
+    };
+
+    /**
      *  Returns the remote deployment filename. The file is in the form:
      *          $DS_LOCATION/$SYSTEM_DS/$VM_ID/deployment.$SEQ
      *  The hasHistory() function MUST be called before this one.
@@ -594,6 +607,17 @@ public:
     const std::string & get_remote_deployment_file() const
     {
         return history->rdeployment_file;
+    };
+
+    /**
+     *  Returns the remote migrate filename. The file is in the form:
+     *          $DS_LOCATION/$SYSTEM_DS/$VM_ID/migrate.$SEQ
+     *  The hasHistory() function MUST be called before this one.
+     *    @return the migrate filename
+     */
+    const std::string & get_rmigrate_file() const
+    {
+        return history->rmigrate_file;
     };
 
     /**

--- a/include/VirtualMachineManager.h
+++ b/include/VirtualMachineManager.h
@@ -376,7 +376,9 @@ private:
             const std::string& tmpl,
             int ds_id,
             int sgid = -1,
-            int nicid = -1);
+            int nicid = -1,
+            const std::string& lmfile = "",
+            const std::string& rmfile = "");
 
 public:
     /**

--- a/src/lcm/LifeCycleActions.cc
+++ b/src/lcm/LifeCycleActions.cc
@@ -350,7 +350,11 @@ void LifeCycleManager::trigger_migrate(int vid, const RequestAttributes& ra,
 
             if ( vm->get_hid() != vm->get_previous_hid() )
             {
-                hpool->del_capacity(vm->get_previous_hid(), sr);
+                HostShareCapacity prev_sr;
+                Template tmpl;
+                vm->get_previous_capacity(prev_sr, tmpl);
+
+                hpool->del_capacity(vm->get_previous_hid(), prev_sr);
 
                 vm->release_previous_vnc_port();
             }
@@ -1038,6 +1042,8 @@ void LifeCycleManager::clean_up_vm(VirtualMachine * vm, bool dispose,
                                    int& image_id, int uid, int gid, int req_id, Template& quota_tmpl)
 {
     HostShareCapacity sr;
+    HostShareCapacity prev_sr;
+    Template tmpl;
 
     time_t the_time = time(0);
 
@@ -1245,11 +1251,13 @@ void LifeCycleManager::clean_up_vm(VirtualMachine * vm, bool dispose,
             case VirtualMachine::MIGRATE:
                 vm->set_running_etime(the_time);
 
+                vm->get_previous_capacity(prev_sr, tmpl);
+
                 vm->set_previous_etime(the_time);
                 vm->set_previous_vm_info();
                 vm->set_previous_running_etime(the_time);
 
-                hpool->del_capacity(vm->get_previous_hid(), sr);
+                hpool->del_capacity(vm->get_previous_hid(), prev_sr);
 
                 vmpool->update_previous_history(vm);
 
@@ -1268,11 +1276,13 @@ void LifeCycleManager::clean_up_vm(VirtualMachine * vm, bool dispose,
             case VirtualMachine::SAVE_MIGRATE:
                 vm->set_running_etime(the_time);
 
+                vm->get_previous_capacity(prev_sr, tmpl);
+
                 vm->set_previous_etime(the_time);
                 vm->set_previous_vm_info();
                 vm->set_previous_running_etime(the_time);
 
-                hpool->del_capacity(vm->get_previous_hid(), sr);
+                hpool->del_capacity(vm->get_previous_hid(), prev_sr);
 
                 vmpool->update_previous_history(vm);
 

--- a/src/lcm/LifeCycleStates.cc
+++ b/src/lcm/LifeCycleStates.cc
@@ -44,16 +44,6 @@ void LifeCycleManager::start_prolog_migrate(VirtualMachine* vm)
 
     vm->set_state(VirtualMachine::PROLOG_MIGRATE);
 
-    vm->set_previous_etime(the_time);
-
-    vm->set_previous_running_etime(the_time);
-
-    vmpool->update_previous_history(vm);
-
-    vm->set_prolog_stime(the_time);
-
-    vmpool->update_history(vm);
-
     if ( vm->get_hid() != vm->get_previous_hid() )
     {
         Template tmpl;
@@ -63,6 +53,16 @@ void LifeCycleManager::start_prolog_migrate(VirtualMachine* vm)
 
         vm->release_previous_vnc_port();
     }
+
+    vm->set_previous_etime(the_time);
+
+    vm->set_previous_running_etime(the_time);
+
+    vmpool->update_previous_history(vm);
+
+    vm->set_prolog_stime(the_time);
+
+    vmpool->update_history(vm);
 
     vmpool->update(vm);
 
@@ -290,6 +290,9 @@ void LifeCycleManager::trigger_deploy_success(int vid)
 
             vm->set_running_stime(the_time);
 
+            Template tmpl;
+            vm->get_previous_capacity(sr, tmpl);
+
             vmpool->update_history(vm.get());
 
             vm->set_previous_etime(the_time);
@@ -297,8 +300,6 @@ void LifeCycleManager::trigger_deploy_success(int vid)
             vm->set_previous_running_etime(the_time);
 
             vmpool->update_previous_history(vm.get());
-
-            vm->get_capacity(sr);
 
             hpool->del_capacity(vm->get_previous_hid(), sr);
 

--- a/src/rm/RequestManagerVirtualMachine.cc
+++ b/src/rm/RequestManagerVirtualMachine.cc
@@ -1160,14 +1160,6 @@ void VirtualMachineMigrate::request_execute(xmlrpc_c::paramList const& paramList
         return;
     }
 
-    if (live && vm->is_pinned())
-    {
-        att.resp_msg = "VM with a pinned NUMA topology cannot be live-migrated";
-        failure_response(ACTION, att);
-
-        return;
-    }
-
     // Get System DS information from current History record
     c_ds_id  = vm->get_ds_id();
     c_tm_mad = vm->get_tm_mad();

--- a/src/vm/History.cc
+++ b/src/vm/History.cc
@@ -128,6 +128,11 @@ void History::non_persistent_data()
 
     token_file = os.str();
 
+    os.str("");
+    os << vm_lhome << "/migrate." << seq;
+
+    migrate_file = os.str();
+
     // ----------- Remote Locations ------------
     os.str("");
     os << ds_location << "/" << ds_id << "/" << oid;
@@ -141,6 +146,11 @@ void History::non_persistent_data()
     os << system_dir << "/deployment." << seq;
 
     rdeployment_file = os.str();
+
+    os.str("");
+    os << system_dir << "/migrate." << seq;
+
+    rmigrate_file = os.str();
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/vmm/LibVirtDriverKVM.cc
+++ b/src/vmm/LibVirtDriverKVM.cc
@@ -2298,5 +2298,7 @@ int LibVirtDriver::deployment_description_kvm(
 
     file << "</domain>" << endl;
 
+    file.close();
+
     return 0;
 }

--- a/src/vmm_mad/exec/one_vmm_exec.rb
+++ b/src/vmm_mad/exec/one_vmm_exec.rb
@@ -549,27 +549,27 @@ class ExecDriver < VirtualMachineDriver
 
             # Save migration data to remote location
             steps << {
-              :driver   => :vmm,
-              :action   => "/bin/cat - >#{mfile}",
-              :is_local => false,
-              :stdin    => mdata,
-              :no_extra_params => true
+                :driver   => :vmm,
+                :action   => "/bin/cat - >#{mfile}",
+                :is_local => false,
+                :stdin    => mdata,
+                :no_extra_params => true
             }
         end
 
         steps.concat([
-                        # Save the Virtual Machine state
-                        {
-                          :driver     => :vmm,
-                          :action     => :save,
-                          :parameters => [:deploy_id, :checkpoint_file, :host]
-                        },
-                        # Execute networking clean up operations
-                        {
-                          :driver      => :vnm,
-                          :action      => :clean,
-                          :parameters  => [:host]
-                        }
+            # Save the Virtual Machine state
+            {
+                :driver     => :vmm,
+                :action     => :save,
+                :parameters => [:deploy_id, :checkpoint_file, :host]
+            },
+            # Execute networking clean up operations
+            {
+                :driver      => :vnm,
+                :action      => :clean,
+                :parameters  => [:host]
+            }
         ])
 
         action.run(steps)
@@ -597,32 +597,32 @@ class ExecDriver < VirtualMachineDriver
         action = VmmAction.new(self, id, :restore, drv_message)
 
         steps.concat([
-                         # Execute pre-boot networking setup
-                         {
-                             :driver     => :vnm,
-                             :action     => :pre
-                         },
-                         # Restore the Virtual Machine from checkpoint
-                         {
-                             :driver     => :vmm,
-                             :action     => :restore,
-                             :parameters => [:checkpoint_file, :host,
-                                             :deploy_id]
-                         },
-                         # Execute post-boot networking setup
-                         {
-                             :driver       => :vnm,
-                             :action       => :post,
-                             :parameters   => [:deploy_id, :host],
-                             :fail_actions => [
-                                 {
-                                     :driver     => :vmm,
-                                     :action     => :cancel,
-                                     :parameters => [:deploy_id, :host]
-                                 }
-                             ]
-                         }
-                     ])
+            # Execute pre-boot networking setup
+            {
+                :driver     => :vnm,
+                :action     => :pre
+            },
+            # Restore the Virtual Machine from checkpoint
+            {
+                :driver     => :vmm,
+                :action     => :restore,
+                :parameters => [:checkpoint_file, :host,
+                                :deploy_id]
+            },
+            # Execute post-boot networking setup
+            {
+                :driver       => :vnm,
+                :action       => :post,
+                :parameters   => [:deploy_id, :host],
+                :fail_actions => [
+                    {
+                        :driver     => :vmm,
+                        :action     => :cancel,
+                        :parameters => [:deploy_id, :host]
+                    }
+                ]
+            }
+        ])
 
         action.run(steps)
     end
@@ -658,69 +658,69 @@ class ExecDriver < VirtualMachineDriver
 
             # Save migration data to remote location
             steps << {
-              :driver   => :vmm,
-              :action   => "/bin/cat - >#{mfile}",
-              :is_local => false,
-              :stdin    => mdata,
-              :no_extra_params => true
+                :driver   => :vmm,
+                :action   => "/bin/cat - >#{mfile}",
+                :is_local => false,
+                :stdin    => mdata,
+                :no_extra_params => true
             }
         end
 
         steps.concat([
-            # Execute a pre-migrate TM setup
-            {
-                :driver     => :tm,
-                :action     => :tm_premigrate,
-                :parameters => pre.split,
-                :stdin      => action.data[:vm]
-            },
-            # Execute pre-boot networking setup on migrating host
-            {
-                :driver      => :vnm,
-                :action      => :pre,
-                :destination => true
-            },
-            # Migrate the Virtual Machine
-            {
-                :driver     => :vmm,
-                :action     => :migrate,
-                :parameters => [:deploy_id, :dest_host, :host],
-                :fail_actions => [
-                    {
-                        :driver     => :tm,
-                        :action     => :tm_failmigrate,
-                        :parameters => failed.split,
-                        :stdin      => action.data[:vm],
-                        :no_fail    => true
-                    }
-                ]
-            },
-            # Execute networking clean up operations
-            # NOTE: VM is now in the new host. If we fail from now on, oned will
-            # assume that the VM is in the previous host but it is in fact
-            # migrated. Log errors will be shown in vm.log
-            {
-                :driver       => :vnm,
-                :action       => :clean,
-                :parameters   => [:host],
-                :no_fail      => true
-            },
-            # Execute post-boot networking setup on migrating host
-            {
-                :driver       => :vnm,
-                :action       => :post,
-                :parameters   => [:deploy_id, :host],
-                :destination  => true,
-                :no_fail      => true
-            },
-            {
-                :driver     => :tm,
-                :action     => :tm_postmigrate,
-                :parameters => post.split,
-                :stdin      => action.data[:vm],
-                :no_fail    => true
-            }
-        ])
+                          # Execute a pre-migrate TM setup
+                          {
+                              :driver     => :tm,
+                              :action     => :tm_premigrate,
+                              :parameters => pre.split,
+                              :stdin      => action.data[:vm]
+                          },
+                          # Execute pre-boot networking setup on migrating host
+                          {
+                              :driver      => :vnm,
+                              :action      => :pre,
+                              :destination => true
+                          },
+                          # Migrate the Virtual Machine
+                          {
+                              :driver     => :vmm,
+                              :action     => :migrate,
+                              :parameters => [:deploy_id, :dest_host, :host],
+                              :fail_actions => [
+                                  {
+                                      :driver     => :tm,
+                                      :action     => :tm_failmigrate,
+                                      :parameters => failed.split,
+                                      :stdin      => action.data[:vm],
+                                      :no_fail    => true
+                                  }
+                              ]
+                          },
+                          # Execute networking clean up operations
+                          # NOTE: VM is now in the new host. If we fail from now on, oned will
+                          # assume that the VM is in the previous host but it is in fact
+                          # migrated. Log errors will be shown in vm.log
+                          {
+                              :driver       => :vnm,
+                              :action       => :clean,
+                              :parameters   => [:host],
+                              :no_fail      => true
+                          },
+                          # Execute post-boot networking setup on migrating host
+                          {
+                              :driver       => :vnm,
+                              :action       => :post,
+                              :parameters   => [:deploy_id, :host],
+                              :destination  => true,
+                              :no_fail      => true
+                          },
+                          {
+                              :driver     => :tm,
+                              :action     => :tm_postmigrate,
+                              :parameters => post.split,
+                              :stdin      => action.data[:vm],
+                              :no_fail    => true
+                          }
+                      ])
 
         action.run(steps)
     end

--- a/src/vmm_mad/remotes/kvm/migrate
+++ b/src/vmm_mad/remotes/kvm/migrate
@@ -69,6 +69,7 @@ load_remote_env
 #     - @dst_host
 #     - @vm_dir
 #     - @shared
+#     - @migrate_file
 # ------------------------------------------------------------------------------
 
 # sync paths to the destination VM folder
@@ -192,7 +193,7 @@ def local_migration(kvm_vm)
 
     rsync_paths(pre_sync)
 
-    rc, _out, err = kvm_vm.live_migrate_disks(@dst_host, devs)
+    rc, _out, err = kvm_vm.live_migrate_disks(@dst_host, devs, @migrate_file)
 
     cleanup_host(err) if rc != 0
 
@@ -212,6 +213,7 @@ begin
 
     @vm_dir = Pathname.new(action_xml['/VMM_DRIVER_ACTION_DATA/DISK_TARGET_PATH']).cleanpath
     @shared = action_xml['/VMM_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/SHARED'].casecmp('YES') == 0
+    @migrate_file = Pathname.new(action_xml['/VMM_DRIVER_ACTION_DATA/REMOTE_MIGRATE_FILE']).cleanpath
 
     kvm_vm  = KvmDomain.new(@deploy_id)
 
@@ -220,7 +222,7 @@ begin
 
     # Migrate VMs using shared/local storage
     if @shared
-        rc, _out, err = kvm_vm.live_migrate(@dst_host)
+        rc, _out, err = kvm_vm.live_migrate(@dst_host, @migrate_file)
 
         cleanup_host(kvm_vm, err) if rc != 0
     else

--- a/src/vmm_mad/remotes/kvm/migrate
+++ b/src/vmm_mad/remotes/kvm/migrate
@@ -213,16 +213,16 @@ begin
 
     @vm_dir = Pathname.new(action_xml['/VMM_DRIVER_ACTION_DATA/DISK_TARGET_PATH']).cleanpath
     @shared = action_xml['/VMM_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/SHARED'].casecmp('YES') == 0
-    @migrate_file = Pathname.new(action_xml['/VMM_DRIVER_ACTION_DATA/REMOTE_MIGRATE_FILE']).cleanpath
+    @mig_file = Pathname.new(action_xml['/VMM_DRIVER_ACTION_DATA/REMOTE_MIGRATE_FILE']).cleanpath
 
-    kvm_vm  = KvmDomain.new(@deploy_id)
+    kvm_vm = KvmDomain.new(@deploy_id)
 
     # Migration can't be done with domain snapshots, drop them first
     kvm_vm.snapshots_delete
 
     # Migrate VMs using shared/local storage
     if @shared
-        rc, _out, err = kvm_vm.live_migrate(@dst_host, @migrate_file)
+        rc, _out, err = kvm_vm.live_migrate(@dst_host, @mig_file)
 
         cleanup_host(kvm_vm, err) if rc != 0
     else

--- a/src/vmm_mad/remotes/kvm/migrate_local
+++ b/src/vmm_mad/remotes/kvm/migrate_local
@@ -16,12 +16,23 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
-source $(dirname $0)/../../etc/vmm/kvm/kvmrc
-source $(dirname $0)/../../scripts_common.sh
+DRIVER_PATH=$(dirname $0)
+source "$DRIVER_PATH/../../etc/vmm/kvm/kvmrc"
+source "$DRIVER_PATH/../../scripts_common.sh"
+XPATH="$DRIVER_PATH/../../datastore/xpath.rb"
 
+STDIN=$(cat -)
 deploy_id=$1
 dest_host=$2
 src_host=$3
+
+unset i j XPATH_ELEMENTS
+while IFS= read -r -d '' element; do
+    XPATH_ELEMENTS[i++]="$element"
+done < <($XPATH -b $STDIN \
+            /VMM_DRIVER_ACTION_DATA/LOCAL_MIGRATE_FILE)
+
+LOCAL_MIGRATE_FILE="${XPATH_ELEMENTS[j++]}"
 
 # migration can't be done with domain snapshots, drop them first
 snaps=$(monitor_and_log \
@@ -42,7 +53,7 @@ fi
 
 # do live migration, but cleanup target host in case of error
 virsh --connect $QEMU_PROTOCOL://$src_host/system \
-    migrate --live $deploy_id $MIGRATE_OPTIONS $QEMU_PROTOCOL://$dest_host/system
+    migrate --live $deploy_id $MIGRATE_OPTIONS --xml $LOCAL_MIGRATE_FILE $QEMU_PROTOCOL://$dest_host/system
 
 RC=$?
 

--- a/src/vmm_mad/remotes/kvm/save
+++ b/src/vmm_mad/remotes/kvm/save
@@ -21,11 +21,10 @@ DRIVER_PATH=$(dirname $0)
 source $DRIVER_PATH/../../etc/vmm/kvm/kvmrc
 source $DRIVER_PATH/../../scripts_common.sh
 
+DRV_MESSAGE=$(cat)
+
 DEPLOY_ID=$1
 FILE=$2
-
-VM_ID=$4
-DS_ID=$5
 
 if [ -f "$FILE" ]; then
     log "Moving old checkpoint file $FILE"
@@ -38,9 +37,20 @@ fi
 touch "$FILE"
 chmod 666 "$FILE"
 
-retry_if "active block job" 3 5 \
+# Extracting the migrate file
+XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"
+IFS= read -r -d '' MIGRATE_FILE < <(echo "$DRV_MESSAGE" | $XPATH /VMM_DRIVER_ACTION_DATA/REMOTE_MIGRATE_FILE)
+
+# Check if MIGRATE_FILE is not empty and the file exists
+if [ -n "$MIGRATE_FILE" ] && [ -f "$MIGRATE_FILE" ]; then
+    retry_if "active block job" 3 5 \
+    exec_and_log "virsh --connect $LIBVIRT_URI save $DEPLOY_ID $FILE --xml $MIGRATE_FILE" \
+    "Could not save $DEPLOY_ID to $FILE"
+else
+    retry_if "active block job" 3 5 \
     exec_and_log "virsh --connect $LIBVIRT_URI save $DEPLOY_ID $FILE" \
     "Could not save $DEPLOY_ID to $FILE"
+fi
 
 # Compact memory
 if [ "x$CLEANUP_MEMORY_ON_STOP" = "xyes" ]; then
@@ -52,12 +62,9 @@ fi
 #-------------------------------------------------------------------------------
 
 # Exit if no stdin data is available
-if [ -t 0 ]; then
+if [ -z "$DRV_MESSAGE" ]; then
     exit 0
 fi
-
-# There is data in stdin, read it
-DRV_MESSAGE=$(cat)
 
 # The data is the driver message. Extracting the System DS TM_MAD
 XPATH="${DRIVER_PATH}/../../datastore/xpath.rb --stdin"

--- a/src/vmm_mad/remotes/lib/kvm/opennebula_vm.rb
+++ b/src/vmm_mad/remotes/lib/kvm/opennebula_vm.rb
@@ -290,8 +290,8 @@ module VirtualMachineManagerKVM
 
         # Live migrate the domain to the target host (SHARED STORAGE variant)
         #   @param host[String] name of the target host
-        def live_migrate(host)
-            cmd =  "migrate --live #{ENV['MIGRATE_OPTIONS']} #{@domain}"
+        def live_migrate(host, mfile)
+            cmd =  "migrate --live #{ENV['MIGRATE_OPTIONS']} --xml #{mfile} #{@domain}"
             cmd << " #{virsh_uri(host)}"
 
             virsh_retry(cmd, 'active block job', virsh_tries)
@@ -300,8 +300,8 @@ module VirtualMachineManagerKVM
         # Live migrate the domain to the target host (LOCAL STORAGE variant)
         #   @param host[String] name of the target host
         #   @param devs[Array] of the disks that will be copied
-        def live_migrate_disks(host, devs)
-            cmd =  "migrate --live #{ENV['MIGRATE_OPTIONS']} --suspend"
+        def live_migrate_disks(host, devs, mfile)
+            cmd =  "migrate --live #{ENV['MIGRATE_OPTIONS']} --xml #{mfile} --suspend"
             cmd << " #{@domain} #{virsh_uri(host)}"
 
             if !devs.empty?


### PR DESCRIPTION
### Description

This pull request addresses the issue with NUMA node and CPU pinning inconsistencies that occur during VM save and live migration. The migration process has been updated to ensure proper NUMA topology and CPU pinning adjustments, even for pinned VMs. Specifically, during save and live migration operations, the updated NUMA topology is now correctly passed using the --xml option, aligning the VM's configuration with the target host's resources.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
