### PR TITLE
F #783 Fix randomly failing GOCA tests

### DIFF
--- a/src/oca/go/src/goca/context_test.go
+++ b/src/oca/go/src/goca/context_test.go
@@ -37,7 +37,7 @@ func (s *ContextSuite) TestDefaultContext(c *C) {
 
 func (s *ContextSuite) TestContextTimeout(c *C) {
 	// Simple example, which shows the timeout is triggered
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
 
 	userC := testCtrl.User(0)

--- a/src/oca/go/src/goca/virtualnetwork_test.go
+++ b/src/oca/go/src/goca/virtualnetwork_test.go
@@ -82,7 +82,7 @@ func TestVirtualNetwork(t *testing.T) {
 	}
 
 	vnetC := testCtrl.VirtualNetwork(id)
-	
+
 	WaitState(t, vnetC, "READY")
 
 	vnet, err = vnetC.Info(false)
@@ -165,10 +165,10 @@ func TestVirtualNetworkRecover(t *testing.T) {
 	var err error
 
 	vnTpl := "NAME = vn_invalid_ar\n" +
-			 "BRIDGE = vbr0\n" +
-			 "VN_MAD = dummy\n" +
-			 "NETWORK_ADDRESS = 192.168.0.0\n"+
-			 "AR = [ TYPE = IP4, IP = 192.168.0.1, SIZE = -1 ]\n"
+		"BRIDGE = vbr0\n" +
+		"VN_MAD = dummy\n" +
+		"NETWORK_ADDRESS = 192.168.0.0\n" +
+		"AR = [ TYPE = IP4, IP = 192.168.0.1, SIZE = -1 ]\n"
 
 	id, err := testCtrl.VirtualNetworks().Create(vnTpl, -1)
 	if err != nil {

--- a/src/oca/go/src/goca/virtualnetwork_test.go
+++ b/src/oca/go/src/goca/virtualnetwork_test.go
@@ -82,6 +82,9 @@ func TestVirtualNetwork(t *testing.T) {
 	}
 
 	vnetC := testCtrl.VirtualNetwork(id)
+	
+	WaitState(t, vnetC, "READY")
+
 	vnet, err = vnetC.Info(false)
 	if err != nil {
 		t.Error(err)

--- a/src/oca/go/src/goca/virtualrouter_test.go
+++ b/src/oca/go/src/goca/virtualrouter_test.go
@@ -185,6 +185,8 @@ func TestVirtualRouter(t *testing.T) {
 	vn_tmpl.Add(vnkeys.VNMad, "dummy")
 
 	vnet_id, _ := testCtrl.VirtualNetworks().Create(vn_tmpl.String(), 0)
+	vnetC := testCtrl.VirtualNetwork(vnet_id)
+	WaitState(t, vnetC, "READY")
 
 	nic_tmpl := shared.NewNIC()
 	nic_tmpl.Add(shared.Network, "go-net")


### PR DESCRIPTION
### Description

Modifies the GOCA tests to address cases of intermittent test failures, particularly when working with resources that are not ready yet. This update aims to enhance test reliability by adding controls to ensure that the desired state is achieved before managing resources.

Modified tests:
- vm
- context
- hook
- virtualrouter 
- virtualnetwork

Depends on [#2645](https://github.com/OpenNebula/development/pull/2645)

### Branches to which this PR applies

- [X] master
- [ ] one-X.X

<hr>
