### PR TITLE
F #6782: Extend GOCA OSVec keys

### DIFF
--- a/src/oca/go/src/goca/dynamic/dyntemplate.go
+++ b/src/oca/go/src/goca/dynamic/dyntemplate.go
@@ -403,6 +403,8 @@ func MakePair(key string, v interface{}) (*Pair, error) {
 		val = fmt.Sprintf("%f", v)
 	case int, uint:
 		val = fmt.Sprintf("%d", v)
+	case bool:
+		val = strconv.FormatBool(v)
 	case string:
 		val = v
 	}

--- a/src/oca/go/src/goca/schemas/vm/keys/template.go
+++ b/src/oca/go/src/goca/schemas/vm/keys/template.go
@@ -51,16 +51,20 @@ type OS string
 const (
 	OSVec string = "OS"
 
-	Arch       OS = "ARCH"
-	Machine    OS = "MACHINE"
-	Kernel     OS = "KERNEL"
-	KernelDS   OS = "KERNEL_DS"
-	Initrd     OS = "INITRD"
-	InitrdDS   OS = "INITRD_DS"
-	Root       OS = "ROOT"
-	KernelCmd  OS = "KERNEL_CMD"
-	Bootloader OS = "BOOTLOADER"
-	Boot       OS = "BOOT"
+	Arch           OS = "ARCH"
+	Machine        OS = "MACHINE"
+	Kernel         OS = "KERNEL"
+	KernelDS       OS = "KERNEL_DS"
+	Initrd         OS = "INITRD"
+	InitrdDS       OS = "INITRD_DS"
+	Root           OS = "ROOT"
+	KernelCmd      OS = "KERNEL_CMD"
+	Bootloader     OS = "BOOTLOADER"
+	Boot           OS = "BOOT"
+	SDDiskBus      OS = "SD_DISK_BUS"
+	UUID           OS = "UUID"
+	Firmware       OS = "FIRMWARE"
+	FirmwareSecure OS = "FIRMWARE_SECURE"
 )
 
 // CPUModel define keys for the VM CPU model

--- a/src/oca/go/src/goca/schemas/vm/template.go
+++ b/src/oca/go/src/goca/schemas/vm/template.go
@@ -187,7 +187,7 @@ func (t *Template) GetShowback(key keys.Showback) (string, error) {
 
 // OS template part
 
-func (t *Template) AddOS(key keys.OS, value string) error {
+func (t *Template) AddOS(key keys.OS, value interface{}) error {
 	return t.Template.AddPairToVec(keys.OSVec, string(key), value)
 }
 


### PR DESCRIPTION
### Description

The OSVec const in GOCA does not accurately reflect all the OS attributes. This update adds the following fields:
- SD_DISK_BUS
- UUID
- FIRMWARE
- FIRMWARE_SECURE

Close #6782 

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [X] master
- [ ] one-X.X

<hr>
