### PR TITLE
B #7032: Fix README.md links to old paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ You can quickly and easily try out OpenNebula’s functionality by installing [m
 
 ## Installation
 
-You can find more information about OpenNebula’s architecture, installation, configuration and references to configuration files in this [documentation section](https://docs.opennebula.io/stable/deployment/index.html).
+You can find more information about OpenNebula’s architecture, installation, configuration and references to configuration files in this [documentation section](https://docs.opennebula.io/stable/installation_and_configuration/index.html).
 
-It is very useful to learn where [log files of the main OpenNebula components are placed](http://docs.opennebula.io/5.12/deployment/references/log_debug.html). Also check the [reference about the main OpenNebula daemon configuration file](https://docs.opennebula.io/stable/installation_and_configuration/opennebula_services/oned.html).
+It is very useful to learn where [log files of the main OpenNebula components are placed](http://docs.opennebula.io/stable/installation_and_configuration/opennebula_services/troubleshooting.html). Also check the [reference about the main OpenNebula daemon configuration file](https://docs.opennebula.io/stable/installation_and_configuration/opennebula_services/oned.html).
 
 ### Front-end Installation
 


### PR DESCRIPTION
### Description

Some rather trivial updates to change the pointers to moved documents, while I was checking the main README:
 * non-existing link updated to "Installation and Configuration"
 * version hardcoding updated to current log files list

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X
