### PR TITLE
Use Round Robin in Address Ranges

### DIFF
--- a/include/AddressRange.h
+++ b/include/AddressRange.h
@@ -120,6 +120,7 @@ public:
      *    - IP
      *    - ULA_PREFIX
      *    - GLOBAL_PREFIX
+     *    - NEXT_INDEX*
      *
      *  The following can be defined to override VNET values:
      *    - BRIDGE
@@ -437,7 +438,7 @@ protected:
      *  Base constructor it cannot be called directly but from the
      *  AddressRange factory constructor.
      */
-    AddressRange(unsigned int _id):id(_id) {};
+    AddressRange(unsigned int _id):id(_id), next(0) {};
 
     /* ---------------------------------------------------------------------- */
     /* Address/AR helper functions to build/parse driver messages             */
@@ -556,6 +557,11 @@ protected:
      *  Address = First Address + index
      */
     std::map<unsigned int, long long> allocated;
+
+    /**
+     *  Lookup index for the next free address lease
+     */
+    unsigned int next;
 
 private:
     /* ---------------------------------------------------------------------- */

--- a/include/AddressRangeInternal.h
+++ b/include/AddressRangeInternal.h
@@ -26,7 +26,7 @@ class VectorAttribute;
 class AddressRangeInternal : public AddressRange
 {
 public:
-    AddressRangeInternal(unsigned int _id):AddressRange(_id), next(0) {};
+    AddressRangeInternal(unsigned int _id):AddressRange(_id) {};
 
     virtual ~AddressRangeInternal() {};
 
@@ -91,11 +91,6 @@ public:
 
 private:
     /**
-     *  Lookup index for the next free address lease
-     */
-    unsigned int next;
-
-    /**
      *  Get a free lease
      *    @param index of the free lease, undefined if error
      *    @param msg with error description if any
@@ -110,7 +105,7 @@ private:
      *    @param msg with error description if any
      *    @return 0 on success -1 otherwise
      */
-    int get_range_addr(unsigned int& index, unsigned int sz, std::string& msg) const;
+    int get_range_addr(unsigned int& index, unsigned int sz, std::string& msg);
 };
 
 #endif

--- a/share/doc/xsd/vnet_pool.xsd
+++ b/share/doc/xsd/vnet_pool.xsd
@@ -97,6 +97,7 @@
                           <xs:element name="MAC" type="xs:string"/>
                           <xs:element name="PARENT_NETWORK_AR_ID" type="xs:string" minOccurs="0"/>
                           <xs:element name="SIZE" type="xs:integer"/>
+                          <xs:element name="NEXT_INDEX" type="xs:integer"/>
                           <xs:element name="TYPE" type="xs:string"/>
                           <xs:element name="ULA_PREFIX" type="xs:string" minOccurs="0"/>
                           <xs:element name="VN_MAD" type="xs:string"  minOccurs="0"/>

--- a/src/oca/go/src/goca/schemas/virtualnetwork/virtualnetwork.go
+++ b/src/oca/go/src/goca/schemas/virtualnetwork/virtualnetwork.go
@@ -67,6 +67,7 @@ type AR struct {
 	MAC               string        `xml:"MAC,omitempty"`
 	ParentNetworkARID string        `xml:"PARENT_NETWORK_AR_ID,omitempty"` // minOccurs=0
 	Size              int           `xml:"SIZE"`
+        NextIndex         int           `xml:"NEXT_INDEX,omitempty"`
 	Type              string        `xml:"TYPE"`
 	ULAPrefix         string        `xml:"ULA_PREFIX,omitempty"` // minOccurs=0
 	VNMAD             string        `xml:"VN_MAD,omitempty"`     // minOccurs=0

--- a/src/vnm/AddressRange.cc
+++ b/src/vnm/AddressRange.cc
@@ -263,6 +263,13 @@ int AddressRange::from_attr(VectorAttribute *vattr, string& error_msg)
         return -1;
     }
 
+    /* ------------------------- Next Index -------------------------------- */
+
+    if ( vattr->vector_value("NEXT_INDEX", next) != 0 )
+    {
+        next = 0;
+    }
+
     /* ------------------------- Security Groups ---------------------------- */
 
     value = vattr->vector_value("SECURITY_GROUPS");
@@ -488,6 +495,8 @@ int AddressRange::update_attributes(
 
     vup->replace("SIZE", size);
 
+    vup->replace("NEXT_INDEX", next);
+
     string value = vup->vector_value("SECURITY_GROUPS");
 
     security_groups.clear();
@@ -561,6 +570,11 @@ int AddressRange::from_vattr_db(VectorAttribute *vattr)
     type  = str_to_type(value);
 
     rc += vattr->vector_value("SIZE", size);
+
+    if ( vattr->vector_value("NEXT_INDEX", next) != 0 )
+    {
+        next = 0;
+    }
 
     rc += mac_to_i(vattr->vector_value("MAC"), mac);
 
@@ -737,6 +751,7 @@ void AddressRange::to_xml(ostringstream &oss) const
     }
 
     oss << "<USED_LEASES>" << get_used_addr() << "</USED_LEASES>";
+    oss << "<NEXT_INDEX>" << next << "</NEXT_INDEX>";
     oss << "</AR>";
 }
 
@@ -907,7 +922,7 @@ void AddressRange::to_xml(ostringstream &oss, const vector<int>& vms,
 
         oss << "</LEASES>";
     }
-
+    oss << "<NEXT_INDEX>" << next << "</NEXT_INDEX>";
     oss << "</AR>";
 }
 
@@ -1429,6 +1444,8 @@ void AddressRange::allocated_to_attr()
     }
 
     attr->replace("ALLOCATED", oss.str());
+
+    attr->replace("NEXT_INDEX", next);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1854,6 +1871,7 @@ const char * AddressRange::SG_RULE_ATTRIBUTES[] =
     "AR_ID",
     "TYPE",
     "SIZE",
+    "NEXT_INDEX",
     "MAC",
     "IP",
     "IP6"
@@ -2005,6 +2023,8 @@ int AddressRange::reserve_addr(int vid, unsigned int rsize, AddressRange *rar)
 
     new_ar->replace("SIZE", rsize);
 
+    new_ar->replace("NEXT_INDEX", next);
+
     new_ar->remove("IPAM_MAD");
 
     rar->from_vattr(new_ar, errmsg);
@@ -2063,6 +2083,8 @@ int AddressRange::reserve_addr_by_index(int vid, unsigned int rsize,
     }
 
     new_ar->replace("SIZE", rsize);
+
+    new_ar->replace("NEXT_INDEX", next);
 
     new_ar->remove("IPAM_MAD");
 

--- a/src/vnm/AddressRangeInternal.cc
+++ b/src/vnm/AddressRangeInternal.cc
@@ -19,38 +19,42 @@
 int AddressRangeInternal::get_single_addr(unsigned int& index, std::string& msg)
 {
     unsigned int ar_size = get_size();
+    unsigned int next_original = next;
 
     for ( unsigned int i=0; i<ar_size; i++, next = (next+1)%ar_size )
     {
         if ( allocated.count(next) == 0 )
         {
             index = next;
+            next = (next+1)%ar_size;
             return 0;
         }
     }
 
+    next = next_original;
     msg = "Not free addresses available";
     return -1;
 }
 
 int AddressRangeInternal::get_range_addr(unsigned int& index,
-                                         unsigned int rsize, std::string& msg) const
+                                         unsigned int rsize, std::string& msg)
 {
     unsigned int ar_size = get_size();
+    unsigned int next_original = next;
     bool valid;
 
-    for (unsigned int i=0; i< ar_size; i++)
+    for (unsigned int i=0; i< ar_size; i++, next = (next+1)%ar_size )
     {
-        if ( allocated.count(i) != 0 )
+        if ( allocated.count(next) != 0 )
         {
             continue;
         }
 
         valid = true;
 
-        for (unsigned int j=0; j<rsize; j++, i++)
+        for (unsigned int j=0; j<rsize; j++, i++, next++)
         {
-            if ( allocated.count(i) != 0 || i >= ar_size )
+            if ( allocated.count(next) != 0 || i >= ar_size || next >= ar_size )
             {
                 valid = false;
                 break;
@@ -59,11 +63,13 @@ int AddressRangeInternal::get_range_addr(unsigned int& index,
 
         if (valid == true)
         {
-            index = i - rsize;
+            index = next - rsize;
+            next = next%ar_size;
             return 0;
         }
     }
 
+    next = next_original;
     msg = "There isn't a continuous range big enough";
     return -1;
 }


### PR DESCRIPTION
### Description

Reusing same MAC addresses too fast has been occasionally an issue.

This pull request implements Round Robin algorithm for finding free addresses in address ranges.
NEXT_INDEX value is stored to the database for each Address range, and parsed when instantiating
AddressRange object. This has been tested on one-6.10-ce branch.

I am not 100% confident about all the places where NEXT_INDEX value needs to be stored or read. Please review and I'll make any modifications needed.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ X ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
