### PR TITLE
Fix for getting a clean struct in each VM looped in scheduler

### DIFF
--- a/src/scheduler/src/sched/Scheduler.cc
+++ b/src/scheduler/src/sched/Scheduler.cc
@@ -873,8 +873,6 @@ void Scheduler::match_schedule()
 {
     VirtualMachineXML * vm;
 
-    HostShareCapacity sr;
-
     int n_resources;
     int n_matched;
     int n_auth;
@@ -905,6 +903,7 @@ void Scheduler::match_schedule()
 
     for (auto vm_it=pending_vms.begin(); vm_it != pending_vms.end(); vm_it++)
     {
+        HostShareCapacity sr{};
         vm = static_cast<VirtualMachineXML*>(vm_it->second);
 
         vm->get_capacity(sr);
@@ -1319,8 +1318,6 @@ void Scheduler::dispatch()
     ostringstream dss;
     string        error;
 
-    HostShareCapacity sr;
-
     int hid, dsid, cid, netid;
 
     unsigned int dispatched_vms = 0;
@@ -1355,6 +1352,7 @@ void Scheduler::dispatch()
     for (k = vm_rs.rbegin(); k != vm_rs.rend() &&
          ( dispatch_limit == 0 || dispatched_vms < dispatch_limit ); ++k)
     {
+        HostShareCapacity sr{};
         dispatched = false;
 
         vm = vmpool->get((*k)->oid);


### PR DESCRIPTION
### Description

When looping through VMs in the scheduler, not all previous data was cleared before or at get_capacity. This leaked old VM requirements to the next one blocking the scheduler in certain circumstances. This fix will ensure a clean struct for each VM in the loop.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
