### PR TITLE
M #-: fix a typo in the video config example

### DIFF
--- a/src/vmm_mad/exec/vmm_exec_kvm.conf
+++ b/src/vmm_mad/exec/vmm_exec_kvm.conf
@@ -132,7 +132,7 @@ NIC = [
 # VIDEO = [
 #     TYPE  = "virtio",
 #     IOMMU = "yes",
-#     ATE   = "yes",
+#     ATS   = "yes",
 #     VRAM  = "8192",
 #     RESOLUTION = "1920x1080"
 # ]


### PR DESCRIPTION
### Description

There is a typo in the commented-out example for setting the video device.

### Branches to which this PR applies


- [x] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
