### PR TITLE
Dual stack default prometheus exporters

### DIFF
--- a/src/oneprometheus/opennebula-exporter/src/opennebula_exporter.rb
+++ b/src/oneprometheus/opennebula-exporter/src/opennebula_exporter.rb
@@ -84,7 +84,7 @@ end
 
 # Default Options
 set :port, 9925
-set :bind, '0.0.0.0'
+set :bind, '::'
 
 # Run the Sinatra application
 set :run, false

--- a/src/oneprometheus/opennebula-libvirt-exporter/src/libvirt_exporter.rb
+++ b/src/oneprometheus/opennebula-libvirt-exporter/src/libvirt_exporter.rb
@@ -55,7 +55,7 @@ get '/' do
 end
 
 # Default Options
-set :bind, '0.0.0.0'
+set :bind, '::'
 set :port, 9926
 
 # Run the Sinatra application


### PR DESCRIPTION
### Description

To be frank with you: it's 2025, IPv6 only deployments exist, make sure OpenNebula is able to support such environments. An IPv6 only test environment would help catch such issues before they make it into a public release.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
