### PR TITLE
F: Skip NUMA probe on systems without NUMA (e.g. ARM64 boards)

### DIFF
--- a/src/im_mad/remotes/node-probes.d/numa_host.rb
+++ b/src/im_mad/remotes/node-probes.d/numa_host.rb
@@ -94,6 +94,8 @@ end
 # ------------------------------------------------------------------------------
 nodes = {}
 
+exit 0 unless Dir.exist? NUMA::NODE_PATH
+
 Dir.foreach(NUMA::NODE_PATH) do |node|
     /node(?<node_id>\d+)/ =~ node
     next unless node_id


### PR DESCRIPTION
### Description
This small change avoids errors in the numa_host.rb probe when executed on systems without NUMA support, such as Raspberry Pi or other ARM64 SBCs.
The probe now exits cleanly if NUMA::NODE_PATH does not exist.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [ ] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
