### PR TITLE
Fix: avoid throwing MissingSamlUserInfoError when remote/x509 header …

### DIFF
--- a/src/fireedge/src/server/routes/entrypoints/App.js
+++ b/src/fireedge/src/server/routes/entrypoints/App.js
@@ -125,14 +125,17 @@ router.get('*', async (req, res) => {
           httpOnly: true,
           sameSite: 'lax',
         })
-      } else {
-        if (validateAuth && !findHeader) {
+      } else if (validateAuth) {
+        // Remote/x509 auth is configured. If header missing, raise MissingHeaderError.
+        if (!findHeader) {
           throw new MissingHeaderError(JSON.stringify(req.headers))
-        } else {
-          throw new MissingSamlUserInfoError(req?.cookies?.saml_user)
         }
+        // If header is present, continue — remoteUser was already built above.
+      } else {
+        // No remote auth and no saml user info: this is the expected missing SAML info case.
+        throw new MissingSamlUserInfoError(req?.cookies?.saml_user)
       }
-
+      
       const paramsAxios = {
         method: POST,
         url: `${defaultProtocol}://${defaultIP}:${


### PR DESCRIPTION
…er is present

### Description

Fix logic that raised MissingSamlUserInfoError during remote/x509 authentication even when the remote header existed. Now the code only throws MissingSamlUserInfoError if neither SAML nor remote/x509 auth info is available; MissingHeaderError remains for the case where remote auth is configured but the header is missing.

This was broken in 7.0.1 by commit c22c843

Issue (https://github.com/OpenNebula/one/issues/7378)

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
