### PR TITLE
B #7432: test PHYDEV for empty string

### DIFF
--- a/src/vnm_mad/remotes/lib/no_vlan.rb
+++ b/src/vnm_mad/remotes/lib/no_vlan.rb
@@ -47,7 +47,7 @@ module VNMMAD
                 TProxy.setup_tproxy(@nic, :up)
 
                 # Skip if vlan device is already in the bridge.
-                next if !@nic[:phydev] || @nic[:phydev].empty? ||
+                next if @nic[:phydev].nil? || @nic[:phydev].empty? ||
                         @bridges[@nic[:bridge]].include?(@nic[:phydev])
 
                 # Add phydev device to the bridge.
@@ -178,7 +178,8 @@ module VNMMAD
             process do |nic|
                 @nic = nic
 
-                next if @nic[:phydev].nil? || @nic[:bridge].nil? || !@nic.vlan_trunk?
+                next if @nic[:phydev].nil? || @nic[:phydev].empty?
+                next if @nic[:bridge].nil? || !@nic.vlan_trunk?
 
                 vlan_set = @nic.vlan_trunk
 

--- a/src/vnm_mad/remotes/lib/vlan.rb
+++ b/src/vnm_mad/remotes/lib/vlan.rb
@@ -45,7 +45,7 @@ module VNMMAD
             process do |nic|
                 @nic = nic
 
-                next if @nic[:phydev].nil?
+                next if @nic[:phydev].nil? || @nic[:phydev].empty?
 
                 # generate the name of the vlan device.
                 gen_vlan_dev_name
@@ -111,7 +111,7 @@ module VNMMAD
 
                 @nic = nic
 
-                next if @nic[:phydev].nil?
+                next if @nic[:phydev].nil? || @nic[:phydev].empty?
                 next if @bridges[@nic[:bridge]].nil?
 
                 # Get the name of the vlan device.
@@ -167,7 +167,7 @@ module VNMMAD
             process do |nic|
                 next unless Integer(nic[:network_id]) == vnet_id
 
-                next if nic[:phydev].nil?
+                next if nic[:phydev].nil? || nic[:phydev].empty?
 
                 # the bridge should already exist as we're updating
                 next if @bridges[nic[:bridge]].nil?


### PR DESCRIPTION
### Description

The change extends the tests for nil(not defined) with a test for an empty string to cover the case when the element is defined but has no value.

### Branches to which this PR applies

- [x] master
- [x] one-6.10
- [x] one-7.0

<hr>

- [ ] Check this if this PR should **not** be squashed
