### PR TITLE
F #-: Redesign Sunstone admin dashboard with operational widgets

### DIFF
--- a/src/fireedge/src/modules/components/Cards/WavesCard.js
+++ b/src/fireedge/src/modules/components/Cards/WavesCard.js
@@ -89,7 +89,7 @@ const Wave = styled('span')(({ theme, bgcolor, duration = 1 }) => {
 })
 
 const WavesCard = memo(
-  ({ text, value, bgColor, icon: Icon, onClick }) => (
+  ({ text, value, subtitle, bgColor, icon: Icon, onClick }) => (
     <Card title={Tr(text)} bgcolor={bgColor} onClick={onClick || undefined}>
       <Typography variant="h6" zIndex={2} noWrap>
         <Translate word={text} />
@@ -97,6 +97,11 @@ const WavesCard = memo(
       <Typography variant="h4" zIndex={2}>
         {value}
       </Typography>
+      {subtitle && (
+        <Typography variant="body2" zIndex={2} sx={{ opacity: 0.85 }}>
+          {subtitle}
+        </Typography>
+      )}
       <Wave bgcolor={bgColor} duration={7} />
       <Wave bgcolor={bgColor} duration={5} />
       {Icon && (
@@ -106,7 +111,7 @@ const WavesCard = memo(
       )}
     </Card>
   ),
-  (prev, next) => prev.value === next.value
+  (prev, next) => prev.value === next.value && prev.subtitle === next.subtitle
 )
 
 WavesCard.propTypes = {
@@ -116,6 +121,7 @@ WavesCard.propTypes = {
     PropTypes.number,
     PropTypes.element,
   ]),
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   bgColor: PropTypes.string,
   icon: PropTypes.any,
   onClick: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
@@ -124,6 +130,7 @@ WavesCard.propTypes = {
 WavesCard.defaultProps = {
   text: undefined,
   value: undefined,
+  subtitle: undefined,
   bgColor: '#ffffff00',
   icon: undefined,
   onClick: undefined,

--- a/src/fireedge/src/modules/constants/translates.js
+++ b/src/fireedge/src/modules/constants/translates.js
@@ -2691,4 +2691,19 @@ module.exports = {
   RunBackground: 'Run in background',
 
   LearnMore: 'Learn more',
+
+  /* Admin Dashboard */
+  InfrastructureUtilization: 'Infrastructure Utilization',
+  StorageCapacity: 'Storage Capacity',
+  VmStateDistribution: 'VM State Distribution',
+  QuickActions: 'Quick Actions',
+  CreateVM: 'Create VM',
+  ViewHosts: 'View Hosts',
+  ViewDatastores: 'View Datastores',
+  NRunning: '%s running',
+  NMonitored: '%s monitored',
+  ImageDatastores: 'Image Datastores',
+  SystemDatastores: 'System Datastores',
+  FileDatastores: 'File Datastores',
+  NoDataAvailableYet: 'No data available yet',
 }

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/General.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/General.js
@@ -13,41 +13,32 @@
  * See the License for the specific language governing permissions and       *
  * limitations under the License.                                            *
  * ------------------------------------------------------------------------- */
-import { Box, CircularProgress, Grid } from '@mui/material'
-import {
-  BoxIso as ImageIcon,
-  NetworkAlt as NetworkIcon,
-  EmptyPage as TemplatesIcon,
-  ModernTv as VmsIcons,
-} from 'iconoir-react'
+import { Box, Grid } from '@mui/material'
 import PropTypes from 'prop-types'
-import { ReactElement, memo, useEffect, useMemo } from 'react'
-import { useHistory } from 'react-router-dom'
+import { ReactElement, useEffect, useMemo } from 'react'
 
-import {
-  ImageAPI,
-  VmAPI,
-  VmTemplateAPI,
-  VnAPI,
-  useAuth,
-  useGeneralApi,
-  useViews,
-} from '@FeaturesModule'
-
-import {
-  NumberEasing,
-  PATH,
-  TranslateProvider,
-  WavesCard,
-} from '@ComponentsModule'
-import { RESOURCE_NAMES, T, VM_POOL_PAGINATION_SIZE } from '@ConstantsModule'
+import { useAuth, useGeneralApi, useViews } from '@FeaturesModule'
+import { TranslateProvider } from '@ComponentsModule'
+import { RESOURCE_NAMES } from '@ConstantsModule'
 import { stringToBoolean } from '@ModelsModule'
 
-const { VM, VM_TEMPLATE, IMAGE, VNET } = RESOURCE_NAMES
+import {
+  ResourceSummaryCards,
+  InfrastructureUtilization,
+  StorageCapacity,
+  HostMonitoringGraphs,
+  VmStateDistribution,
+  QuickActions,
+} from './widgets'
+
+const { HOST, DATASTORE } = RESOURCE_NAMES
 
 /**
+ * Sunstone admin dashboard with resource overview, utilization metrics,
+ * monitoring graphs, state distribution, and quick actions.
+ *
  * @param {object} props - Props
- * @param {object} props.view - View
+ * @param {string} props.view - Current view name
  * @returns {ReactElement} Sunstone dashboard container
  */
 export default function SunstoneDashboard({ view }) {
@@ -55,16 +46,14 @@ export default function SunstoneDashboard({ view }) {
   const { DISABLE_ANIMATIONS } = fireedge
   const { hasAccessToResource } = useViews()
 
-  // Delete second title
   const { setSecondTitle } = useGeneralApi()
   useEffect(() => setSecondTitle({}), [])
 
-  const { push: goTo } = useHistory()
-
-  const vmAccess = useMemo(() => hasAccessToResource(VM), [view])
-  const templateAccess = useMemo(() => hasAccessToResource(VM_TEMPLATE), [view])
-  const imageAccess = useMemo(() => hasAccessToResource(IMAGE), [view])
-  const vnetAccess = useMemo(() => hasAccessToResource(VNET), [view])
+  const hostAccess = useMemo(() => hasAccessToResource(HOST), [view])
+  const datastoreAccess = useMemo(
+    () => hasAccessToResource(DATASTORE),
+    [view]
+  )
 
   const styles = useMemo(() => {
     if (stringToBoolean(DISABLE_ANIMATIONS))
@@ -76,43 +65,45 @@ export default function SunstoneDashboard({ view }) {
   return (
     <TranslateProvider>
       <Box py={3} sx={styles}>
-        <Grid
-          container
-          data-cy="dashboard-widget-total-sunstone-resources"
-          spacing={3}
-        >
-          <ResourceWidget
-            type="vms"
-            bgColor="#fa7892"
-            text={T.VMs}
-            icon={VmsIcons}
-            onClick={vmAccess && (() => goTo(PATH.INSTANCE.VMS.LIST))}
-            disableAnimations={DISABLE_ANIMATIONS}
-          />
-          <ResourceWidget
-            type="vmtemples"
-            bgColor="#b25aff"
-            text={T.VMTemplates}
-            icon={TemplatesIcon}
-            onClick={templateAccess && (() => goTo(PATH.TEMPLATE.VMS.LIST))}
-            disableAnimations={DISABLE_ANIMATIONS}
-          />
-          <ResourceWidget
-            type="images"
-            bgColor="#1fbbc6"
-            text={T.Images}
-            icon={ImageIcon}
-            onClick={imageAccess && (() => goTo(PATH.STORAGE.IMAGES.LIST))}
-            disableAnimations={DISABLE_ANIMATIONS}
-          />
-          <ResourceWidget
-            type="vnets"
-            bgColor="#f09d42"
-            text={T.VirtualNetworks}
-            icon={NetworkIcon}
-            onClick={vnetAccess && (() => goTo(PATH.NETWORK.VNETS.LIST))}
-            disableAnimations={DISABLE_ANIMATIONS}
-          />
+        {/* Row 1: Enhanced Resource Summary Cards */}
+        <ResourceSummaryCards
+          disableAnimations={DISABLE_ANIMATIONS}
+          view={view}
+        />
+
+        {/* Row 2: Infrastructure Utilization + Storage Capacity */}
+        {(hostAccess || datastoreAccess) && (
+          <Grid container spacing={3} sx={{ mt: 0 }}>
+            {hostAccess && (
+              <Grid item xs={12} md={6}>
+                <InfrastructureUtilization view={view} />
+              </Grid>
+            )}
+            {datastoreAccess && (
+              <Grid item xs={12} md={6}>
+                <StorageCapacity view={view} />
+              </Grid>
+            )}
+          </Grid>
+        )}
+
+        {/* Row 3: Host CPU + Memory Monitoring Graphs */}
+        {hostAccess && (
+          <Box sx={{ mt: 3 }}>
+            <HostMonitoringGraphs />
+          </Box>
+        )}
+
+        {/* Row 4: VM State Distribution + Quick Actions */}
+        <Grid container spacing={3} sx={{ mt: 0 }}>
+          <Grid item xs={12} md={8}>
+            <VmStateDistribution
+              disableAnimations={stringToBoolean(DISABLE_ANIMATIONS)}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <QuickActions view={view} />
+          </Grid>
         </Grid>
       </Box>
     </TranslateProvider>
@@ -123,53 +114,4 @@ SunstoneDashboard.displayName = 'SunstoneDashboard'
 
 SunstoneDashboard.propTypes = {
   view: PropTypes.string,
-}
-
-const ResourceWidget = memo(
-  ({ type = 'vms', onClick, text, bgColor, icon, disableAnimations }) => {
-    const options = {
-      vmtemples: VmTemplateAPI.useGetTemplatesQuery(undefined, {
-        skip: type !== 'vmtemples',
-      }),
-      images: ImageAPI.useGetImagesQuery(undefined, {
-        skip: type !== 'images',
-      }),
-      vnets: VnAPI.useGetVNetworksQuery(undefined, { skip: type !== 'vnets' }),
-      vms: VmAPI.useGetVmsPaginatedQuery(
-        { extended: 0, pageSize: VM_POOL_PAGINATION_SIZE },
-        { skip: type !== 'vms' }
-      ),
-    }
-
-    const { data = [], isFetching } = options[type] || {}
-
-    const NumberElement = useMemo(() => {
-      if (stringToBoolean(disableAnimations)) return data?.length
-
-      return <NumberEasing value={data?.length} />
-    }, [disableAnimations, data?.length])
-
-    return (
-      <Grid item xs={12} sm={6} md={3}>
-        <WavesCard
-          bgColor={bgColor}
-          icon={icon}
-          text={text}
-          value={isFetching ? <CircularProgress size={20} /> : NumberElement}
-          onClick={onClick || undefined}
-        />
-      </Grid>
-    )
-  }
-)
-
-ResourceWidget.displayName = 'ResourceWidget'
-
-ResourceWidget.propTypes = {
-  type: PropTypes.string,
-  onClick: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-  text: PropTypes.string,
-  bgColor: PropTypes.string,
-  icon: PropTypes.any,
-  disableAnimations: PropTypes.string,
 }

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/HostMonitoringGraphs.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/HostMonitoringGraphs.js
@@ -1,0 +1,143 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+import { Box, Grid, Typography, useTheme } from '@mui/material'
+import { css } from '@emotion/css'
+import PropTypes from 'prop-types'
+import { memo, useMemo } from 'react'
+
+import { HostAPI } from '@FeaturesModule'
+import { Graph, Tr, Translate } from '@ComponentsModule'
+import { T } from '@ConstantsModule'
+import { interpolationValue, interpolationBytes } from '@UtilsModule'
+
+const styles = ({ palette, typography }) => ({
+  root: css({
+    padding: typography.pxToRem(24),
+    borderRadius: typography.pxToRem(16),
+    backgroundColor: palette.background.paper,
+  }),
+  title: css({
+    marginBottom: typography.pxToRem(16),
+    fontSize: typography.pxToRem(21),
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: typography.pxToRem(20),
+  }),
+})
+
+const hostCpuConfig = (theme) => ({
+  title: T.CpuHost,
+  key: 'CPU',
+  graph: {
+    x: [(point) => new Date(parseInt(point.TIMESTAMP) * 1000).getTime()],
+    y: ['USED_CPU'],
+    lineColors: [theme?.palette?.graphs?.cloud?.hostCpu?.real],
+    interpolation: interpolationValue,
+  },
+  shouldFill: ['CPU'],
+  showLegends: false,
+})
+
+const hostMemConfig = (theme) => ({
+  title: T.MemoryHost,
+  key: 'MEMORY',
+  graph: {
+    x: [(point) => new Date(parseInt(point.TIMESTAMP) * 1000).getTime()],
+    y: ['USED_MEMORY'],
+    lineColors: [theme?.palette?.graphs?.cloud?.hostMemory?.real],
+    interpolation: interpolationBytes,
+  },
+  shouldFill: ['MEMORY'],
+  showLegends: false,
+})
+
+const HostMonitoringGraphs = memo(() => {
+  const theme = useTheme()
+  const classes = useMemo(() => styles(theme), [theme])
+
+  const { data, isFetching } = HostAPI.useGetHostMonitoringPoolQuery({
+    seconds: 3600,
+  })
+
+  const monitoring = data?.MONITORING_DATA?.MONITORING
+
+  const transformedData = useMemo(
+    () =>
+      (Array.isArray(monitoring) ? monitoring : [monitoring])
+        .filter(Boolean)
+        .map(({ TIMESTAMP, CAPACITY }) => ({
+          TIMESTAMP,
+          ...CAPACITY,
+        })),
+    [monitoring]
+  )
+
+  if (!monitoring?.length) return null
+
+  const cpuConfig = hostCpuConfig(theme)
+  const memConfig = hostMemConfig(theme)
+
+  return (
+    <Grid container spacing={3} data-cy="dashboard-widget-host-monitoring">
+      <Grid item xs={12} md={6}>
+        <Box className={classes.root}>
+          <Typography variant="h6" className={classes.title}>
+            <Translate word={cpuConfig.title} />
+          </Typography>
+          <Graph
+            name={Tr(cpuConfig.title)}
+            filter={cpuConfig.graph.y}
+            data={transformedData}
+            y={cpuConfig.graph.y}
+            x={cpuConfig.graph.x}
+            legendNames={cpuConfig.title}
+            lineColors={cpuConfig.graph.lineColors}
+            interpolationY={cpuConfig.graph.interpolation}
+            showLegends={cpuConfig.showLegends}
+            sortX
+            isFetching={isFetching}
+            shouldFill={cpuConfig.shouldFill}
+          />
+        </Box>
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Box className={classes.root}>
+          <Typography variant="h6" className={classes.title}>
+            <Translate word={memConfig.title} />
+          </Typography>
+          <Graph
+            name={Tr(memConfig.title)}
+            filter={memConfig.graph.y}
+            data={transformedData}
+            y={memConfig.graph.y}
+            x={memConfig.graph.x}
+            legendNames={memConfig.title}
+            lineColors={memConfig.graph.lineColors}
+            interpolationY={memConfig.graph.interpolation}
+            showLegends={memConfig.showLegends}
+            sortX
+            isFetching={isFetching}
+            shouldFill={memConfig.shouldFill}
+          />
+        </Box>
+      </Grid>
+    </Grid>
+  )
+})
+
+HostMonitoringGraphs.displayName = 'HostMonitoringGraphs'
+
+export default HostMonitoringGraphs

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/InfrastructureUtilization.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/InfrastructureUtilization.js
@@ -1,0 +1,169 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+import {
+  Box,
+  LinearProgress,
+  linearProgressClasses,
+  Typography,
+  useTheme,
+} from '@mui/material'
+import { css } from '@emotion/css'
+import PropTypes from 'prop-types'
+import { memo, useMemo } from 'react'
+
+import { HostAPI } from '@FeaturesModule'
+import { Translate } from '@ComponentsModule'
+import { T, COLOR } from '@ConstantsModule'
+
+const styles = ({ palette, typography }) => ({
+  root: css({
+    padding: typography.pxToRem(24),
+    borderRadius: typography.pxToRem(16),
+    backgroundColor: palette.background.paper,
+  }),
+  title: css({
+    marginBottom: typography.pxToRem(16),
+    fontSize: typography.pxToRem(21),
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: typography.pxToRem(20),
+  }),
+  barLabel: css({
+    fontSize: '1rem',
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: '1.25rem',
+    paddingBottom: '0.5rem',
+  }),
+  progressBar: css({
+    height: typography.pxToRem(8),
+    borderRadius: typography.pxToRem(4),
+    marginBottom: typography.pxToRem(16),
+  }),
+})
+
+/**
+ * Returns the appropriate color for a utilization percentage.
+ *
+ * @param {number} percentage - The utilization percentage (0-100)
+ * @returns {string} Hex color string
+ */
+const getBarColor = (percentage) => {
+  if (percentage >= 90) return COLOR.error.main
+  if (percentage >= 70) return COLOR.warning.main
+
+  return COLOR.success.main
+}
+
+/**
+ * Infrastructure Utilization widget showing aggregate CPU and Memory
+ * usage across all hosts as progress bars.
+ *
+ * @param {object} props - Props
+ * @param {string} props.view - Current view name
+ * @returns {ReactElement|null} Utilization panel or null when no data
+ */
+const InfrastructureUtilization = memo(({ view }) => {
+  const theme = useTheme()
+  const { palette } = theme
+  const classes = useMemo(() => styles(theme), [theme])
+
+  const { data: hosts = [] } = HostAPI.useGetHostsQuery()
+
+  const { cpuPercent, memPercent } = useMemo(() => {
+    if (!hosts?.length) return { cpuPercent: 0, memPercent: 0 }
+
+    let totalMaxCpu = 0
+    let totalCpuUsage = 0
+    let totalMaxMem = 0
+    let totalMemUsage = 0
+
+    hosts.forEach((host) => {
+      const share = host?.HOST_SHARE || {}
+
+      totalMaxCpu += parseInt(share.MAX_CPU || '0', 10)
+      totalCpuUsage += parseInt(share.CPU_USAGE || '0', 10)
+      totalMaxMem += parseInt(share.MAX_MEM || '0', 10)
+      totalMemUsage += parseInt(share.MEM_USAGE || '0', 10)
+    })
+
+    return {
+      cpuPercent: totalMaxCpu > 0
+        ? Math.min((totalCpuUsage / totalMaxCpu) * 100, 100)
+        : 0,
+      memPercent: totalMaxMem > 0
+        ? Math.min((totalMemUsage / totalMaxMem) * 100, 100)
+        : 0,
+    }
+  }, [hosts])
+
+  if (!hosts?.length) return null
+
+  return (
+    <Box className={classes.root} data-cy="dashboard-widget-infrastructure">
+      <Typography variant="h6" className={classes.title}>
+        <Translate word={T.InfrastructureUtilization} />
+      </Typography>
+
+      <Typography className={classes.barLabel}>
+        {`CPU: ${cpuPercent.toFixed(0)}%`}
+      </Typography>
+      <LinearProgress
+        variant="determinate"
+        value={cpuPercent}
+        sx={{
+          [`&.${linearProgressClasses.colorPrimary}`]: {
+            backgroundColor:
+              palette?.graphs?.cloud?.bars?.total || palette.action.hover,
+          },
+          [`& .${linearProgressClasses.bar}`]: {
+            borderRadius: 4,
+            backgroundColor: getBarColor(cpuPercent),
+          },
+        }}
+        className={classes.progressBar}
+      />
+
+      <Typography className={classes.barLabel}>
+        {`Memory: ${memPercent.toFixed(0)}%`}
+      </Typography>
+      <LinearProgress
+        variant="determinate"
+        value={memPercent}
+        sx={{
+          [`&.${linearProgressClasses.colorPrimary}`]: {
+            backgroundColor:
+              palette?.graphs?.cloud?.bars?.total || palette.action.hover,
+          },
+          [`& .${linearProgressClasses.bar}`]: {
+            borderRadius: 4,
+            backgroundColor: getBarColor(memPercent),
+          },
+        }}
+        className={classes.progressBar}
+      />
+    </Box>
+  )
+})
+
+InfrastructureUtilization.displayName = 'InfrastructureUtilization'
+
+InfrastructureUtilization.propTypes = {
+  view: PropTypes.string,
+}
+
+export { InfrastructureUtilization }
+export default InfrastructureUtilization

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/QuickActions.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/QuickActions.js
@@ -1,0 +1,129 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+import { Box, Button, Stack, Typography, useTheme } from '@mui/material'
+import { css } from '@emotion/css'
+import {
+  ModernTv as VmIcon,
+  Server as HostIcon,
+  Database as DatastoreIcon,
+  Settings as SettingsIcon,
+} from 'iconoir-react'
+import PropTypes from 'prop-types'
+import { memo, useMemo } from 'react'
+import { useHistory } from 'react-router-dom'
+
+import { useViews } from '@FeaturesModule'
+import { Translate, PATH } from '@ComponentsModule'
+import { RESOURCE_NAMES, T } from '@ConstantsModule'
+
+const { VM_TEMPLATE, HOST, DATASTORE } = RESOURCE_NAMES
+
+const styles = ({ palette, typography }) => ({
+  root: css({
+    padding: typography.pxToRem(24),
+    borderRadius: typography.pxToRem(16),
+    backgroundColor: palette.background.paper,
+    height: '100%',
+  }),
+  title: css({
+    marginBottom: typography.pxToRem(16),
+    fontSize: typography.pxToRem(21),
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: typography.pxToRem(20),
+  }),
+})
+
+/**
+ * Quick Actions widget — navigation shortcuts for common admin actions.
+ *
+ * @param {object} props - Props
+ * @param {string} props.view - Current view name
+ * @returns {ReactElement} QuickActions panel
+ */
+const QuickActions = memo(({ view }) => {
+  const theme = useTheme()
+  const classes = useMemo(() => styles(theme), [theme])
+
+  const { hasAccessToResource } = useViews()
+  const { push: goTo } = useHistory()
+
+  const templateAccess = useMemo(
+    () => hasAccessToResource(VM_TEMPLATE),
+    [view]
+  )
+  const hostAccess = useMemo(() => hasAccessToResource(HOST), [view])
+  const datastoreAccess = useMemo(
+    () => hasAccessToResource(DATASTORE),
+    [view]
+  )
+
+  return (
+    <Box className={classes.root}>
+      <Typography variant="h6" className={classes.title}>
+        <Translate word={T.QuickActions} />
+      </Typography>
+      <Stack spacing={2}>
+        {templateAccess && (
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<VmIcon />}
+            onClick={() => goTo(PATH.TEMPLATE.VMS.INSTANTIATE)}
+          >
+            <Translate word={T.CreateVM} />
+          </Button>
+        )}
+        {hostAccess && (
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<HostIcon />}
+            onClick={() => goTo(PATH.INFRASTRUCTURE.HOSTS.LIST)}
+          >
+            <Translate word={T.ViewHosts} />
+          </Button>
+        )}
+        {datastoreAccess && (
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<DatastoreIcon />}
+            onClick={() => goTo(PATH.STORAGE.DATASTORES.LIST)}
+          >
+            <Translate word={T.ViewDatastores} />
+          </Button>
+        )}
+        <Button
+          variant="outlined"
+          fullWidth
+          startIcon={<SettingsIcon />}
+          onClick={() => goTo(PATH.SETTINGS)}
+        >
+          <Translate word={T.Settings} />
+        </Button>
+      </Stack>
+    </Box>
+  )
+})
+
+QuickActions.displayName = 'QuickActions'
+
+QuickActions.propTypes = {
+  view: PropTypes.string,
+}
+
+export default QuickActions

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/ResourceSummaryCards.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/ResourceSummaryCards.js
@@ -1,0 +1,194 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+import { CircularProgress, Grid } from '@mui/material'
+import {
+  Database as DatastoreIcon,
+  NetworkAlt as NetworkIcon,
+  Server as HostIcon,
+  ModernTv as VmsIcons,
+} from 'iconoir-react'
+import PropTypes from 'prop-types'
+import { ReactElement, memo, useMemo } from 'react'
+import { useHistory } from 'react-router-dom'
+
+import {
+  DatastoreAPI,
+  HostAPI,
+  VmAPI,
+  VnAPI,
+  useViews,
+} from '@FeaturesModule'
+
+import { NumberEasing, PATH, Tr, WavesCard } from '@ComponentsModule'
+import { RESOURCE_NAMES, T, VM_POOL_PAGINATION_SIZE } from '@ConstantsModule'
+import { prettyBytes } from '@UtilsModule'
+import { stringToBoolean } from '@ModelsModule'
+
+const { VM, HOST, DATASTORE, VNET } = RESOURCE_NAMES
+
+/**
+ * Resource summary cards showing counts with live subtitles.
+ *
+ * @param {object} props - Props
+ * @param {string} props.disableAnimations - Whether to disable animations
+ * @param {string} props.view - Current view name
+ * @returns {ReactElement} Grid of resource summary WavesCards
+ */
+const ResourceSummaryCards = memo(({ disableAnimations, view }) => {
+  const { hasAccessToResource } = useViews()
+  const { push: goTo } = useHistory()
+
+  const vmAccess = useMemo(() => hasAccessToResource(VM), [view])
+  const hostAccess = useMemo(() => hasAccessToResource(HOST), [view])
+  const datastoreAccess = useMemo(() => hasAccessToResource(DATASTORE), [view])
+  const vnetAccess = useMemo(() => hasAccessToResource(VNET), [view])
+
+  const { data: vms = [], isFetching: isFetchingVms } =
+    VmAPI.useGetVmsPaginatedQuery({
+      extended: 0,
+      pageSize: VM_POOL_PAGINATION_SIZE,
+    })
+
+  const { data: hosts = [], isFetching: isFetchingHosts } =
+    HostAPI.useGetHostsQuery()
+
+  const { data: datastores = [], isFetching: isFetchingDatastores } =
+    DatastoreAPI.useGetDatastoresQuery()
+
+  const { data: vnets = [], isFetching: isFetchingVnets } =
+    VnAPI.useGetVNetworksQuery()
+
+  const noAnimation = stringToBoolean(disableAnimations)
+
+  // VM subtitle: count running VMs (STATE === '3' && LCM_STATE === '3')
+  const runningCount = useMemo(
+    () =>
+      isFetchingVms
+        ? null
+        : vms.filter((vm) => vm?.STATE === '3' && vm?.LCM_STATE === '3')
+            .length,
+    [vms, isFetchingVms]
+  )
+  const vmSubtitle =
+    runningCount != null ? Tr([T.NRunning, [runningCount]]) : null
+
+  // Host subtitle: count monitored hosts (STATE === '2')
+  const monitoredCount = useMemo(
+    () =>
+      isFetchingHosts
+        ? null
+        : hosts.filter((host) => host?.STATE === '2').length,
+    [hosts, isFetchingHosts]
+  )
+  const hostSubtitle =
+    monitoredCount != null ? Tr([T.NMonitored, [monitoredCount]]) : null
+
+  // Datastore subtitle: total used / total capacity
+  const datastoreSubtitle = useMemo(() => {
+    if (isFetchingDatastores || !datastores?.length) return null
+
+    let totalMB = 0
+    let usedMB = 0
+
+    datastores.forEach((ds) => {
+      totalMB += parseInt(ds?.TOTAL_MB || '0', 10)
+      usedMB += parseInt(ds?.USED_MB || '0', 10)
+    })
+
+    return `${prettyBytes(usedMB, 'MB', 1)} / ${prettyBytes(totalMB, 'MB', 1)}`
+  }, [datastores, isFetchingDatastores])
+
+  /**
+   * Renders the count value with optional animation.
+   *
+   * @param {number} count - The count to display
+   * @param {boolean} isFetching - Whether data is still loading
+   * @returns {ReactElement|number} Animated or static count
+   */
+  const renderCount = (count, isFetching) => {
+    if (isFetching) return <CircularProgress size={20} />
+
+    if (noAnimation) return count
+
+    return <NumberEasing value={count} />
+  }
+
+  return (
+    <Grid
+      container
+      data-cy="dashboard-widget-total-sunstone-resources"
+      spacing={3}
+    >
+      {vmAccess && (
+        <Grid item xs={12} sm={6} md={3}>
+          <WavesCard
+            bgColor="#fa7892"
+            icon={VmsIcons}
+            text={T.VMs}
+            value={renderCount(vms?.length, isFetchingVms)}
+            subtitle={vmSubtitle}
+            onClick={() => goTo(PATH.INSTANCE.VMS.LIST)}
+          />
+        </Grid>
+      )}
+      {hostAccess && (
+        <Grid item xs={12} sm={6} md={3}>
+          <WavesCard
+            bgColor="#b25aff"
+            icon={HostIcon}
+            text={T.Hosts}
+            value={renderCount(hosts?.length, isFetchingHosts)}
+            subtitle={hostSubtitle}
+            onClick={() => goTo(PATH.INFRASTRUCTURE.HOSTS.LIST)}
+          />
+        </Grid>
+      )}
+      {datastoreAccess && (
+        <Grid item xs={12} sm={6} md={3}>
+          <WavesCard
+            bgColor="#1fbbc6"
+            icon={DatastoreIcon}
+            text={T.Datastores}
+            value={renderCount(datastores?.length, isFetchingDatastores)}
+            subtitle={datastoreSubtitle}
+            onClick={() => goTo(PATH.STORAGE.DATASTORES.LIST)}
+          />
+        </Grid>
+      )}
+      {vnetAccess && (
+        <Grid item xs={12} sm={6} md={3}>
+          <WavesCard
+            bgColor="#f09d42"
+            icon={NetworkIcon}
+            text={T.VirtualNetworks}
+            value={renderCount(vnets?.length, isFetchingVnets)}
+            onClick={() => goTo(PATH.NETWORK.VNETS.LIST)}
+          />
+        </Grid>
+      )}
+    </Grid>
+  )
+})
+
+ResourceSummaryCards.displayName = 'ResourceSummaryCards'
+
+ResourceSummaryCards.propTypes = {
+  disableAnimations: PropTypes.string,
+  view: PropTypes.string,
+}
+
+export { ResourceSummaryCards }
+export default ResourceSummaryCards

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/StorageCapacity.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/StorageCapacity.js
@@ -1,0 +1,166 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+import {
+  Box,
+  LinearProgress,
+  linearProgressClasses,
+  Typography,
+  useTheme,
+} from '@mui/material'
+import { css } from '@emotion/css'
+import PropTypes from 'prop-types'
+import { memo, useMemo } from 'react'
+
+import { DatastoreAPI } from '@FeaturesModule'
+import { Translate } from '@ComponentsModule'
+import { T, COLOR, DATASTORE_TYPES } from '@ConstantsModule'
+import { prettyBytes } from '@UtilsModule'
+
+const styles = ({ palette, typography }) => ({
+  root: css({
+    padding: typography.pxToRem(24),
+    borderRadius: typography.pxToRem(16),
+    backgroundColor: palette.background.paper,
+  }),
+  title: css({
+    marginBottom: typography.pxToRem(16),
+    fontSize: typography.pxToRem(21),
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: typography.pxToRem(20),
+  }),
+  barLabel: css({
+    fontSize: '1rem',
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: '1.25rem',
+    paddingBottom: '0.5rem',
+  }),
+  progressBar: css({
+    height: typography.pxToRem(8),
+    borderRadius: typography.pxToRem(4),
+    marginBottom: typography.pxToRem(16),
+  }),
+})
+
+/**
+ * Returns the appropriate color for a utilization percentage.
+ *
+ * @param {number} percentage - The utilization percentage (0-100)
+ * @returns {string} Hex color string
+ */
+const getBarColor = (percentage) => {
+  if (percentage >= 90) return COLOR.error.main
+  if (percentage >= 70) return COLOR.warning.main
+
+  return COLOR.success.main
+}
+
+/** Datastore type definitions for grouping and display. */
+const DS_GROUPS = [
+  {
+    typeId: String(DATASTORE_TYPES.IMAGE.id),
+    label: T.ImageDatastores,
+  },
+  {
+    typeId: String(DATASTORE_TYPES.SYSTEM.id),
+    label: T.SystemDatastores,
+  },
+  {
+    typeId: String(DATASTORE_TYPES.FILE.id),
+    label: T.FileDatastores,
+  },
+]
+
+/**
+ * Storage Capacity widget showing datastore usage grouped by type
+ * (Image, System, File) with capacity bars.
+ *
+ * @param {object} props - Props
+ * @param {string} props.view - Current view name
+ * @returns {ReactElement|null} Storage capacity panel or null when no data
+ */
+const StorageCapacity = memo(({ view }) => {
+  const theme = useTheme()
+  const { palette } = theme
+  const classes = useMemo(() => styles(theme), [theme])
+
+  const { data: datastores = [] } = DatastoreAPI.useGetDatastoresQuery()
+
+  const groups = useMemo(() => {
+    if (!datastores?.length) return []
+
+    return DS_GROUPS.map(({ typeId, label }) => {
+      const filtered = datastores.filter((ds) => String(ds?.TYPE) === typeId)
+
+      let totalMB = 0
+      let usedMB = 0
+
+      filtered.forEach((ds) => {
+        totalMB += parseInt(ds?.TOTAL_MB || '0', 10)
+        usedMB += parseInt(ds?.USED_MB || '0', 10)
+      })
+
+      const percent =
+        totalMB > 0 ? Math.min((usedMB / totalMB) * 100, 100) : 0
+
+      return { label, totalMB, usedMB, percent, count: filtered.length }
+    }).filter(({ count }) => count > 0)
+  }, [datastores])
+
+  if (!datastores?.length || !groups.length) return null
+
+  return (
+    <Box className={classes.root} data-cy="dashboard-widget-storage-capacity">
+      <Typography variant="h6" className={classes.title}>
+        <Translate word={T.StorageCapacity} />
+      </Typography>
+
+      {groups.map(({ label, totalMB, usedMB, percent }) => (
+        <Box key={label}>
+          <Typography className={classes.barLabel}>
+            <Translate word={label} />
+            {`: ${prettyBytes(usedMB, 'MB', 1)} / ${prettyBytes(totalMB, 'MB', 1)}`}
+          </Typography>
+          <LinearProgress
+            variant="determinate"
+            value={percent}
+            sx={{
+              [`&.${linearProgressClasses.colorPrimary}`]: {
+                backgroundColor:
+                  palette?.graphs?.cloud?.bars?.total || palette.action.hover,
+              },
+              [`& .${linearProgressClasses.bar}`]: {
+                borderRadius: 4,
+                backgroundColor: getBarColor(percent),
+              },
+            }}
+            className={classes.progressBar}
+          />
+        </Box>
+      ))}
+    </Box>
+  )
+})
+
+StorageCapacity.displayName = 'StorageCapacity'
+
+StorageCapacity.propTypes = {
+  view: PropTypes.string,
+}
+
+export { StorageCapacity }
+export default StorageCapacity

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/VmStateDistribution.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/VmStateDistribution.js
@@ -1,0 +1,148 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+import { Box, Typography, useTheme } from '@mui/material'
+import { css } from '@emotion/css'
+import PropTypes from 'prop-types'
+import { memo, useMemo } from 'react'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+
+import { VmAPI } from '@FeaturesModule'
+import { Translate, Tr } from '@ComponentsModule'
+import { T, VM_STATES, VM_POOL_PAGINATION_SIZE } from '@ConstantsModule'
+
+const styles = ({ palette, typography }) => ({
+  root: css({
+    padding: typography.pxToRem(24),
+    borderRadius: typography.pxToRem(16),
+    backgroundColor: palette.background.paper,
+  }),
+  title: css({
+    marginBottom: typography.pxToRem(16),
+    fontSize: typography.pxToRem(21),
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: typography.pxToRem(20),
+  }),
+})
+
+/**
+ * Capitalizes the first letter of a string.
+ *
+ * @param {string} str - The string to capitalize
+ * @returns {string} The capitalized string
+ */
+const capitalize = (str) =>
+  str ? str.charAt(0).toUpperCase() + str.slice(1) : ''
+
+const VmStateDistribution = memo(({ disableAnimations }) => {
+  const theme = useTheme()
+  const classes = useMemo(() => styles(theme), [theme])
+
+  const { data: vms = [], isFetching } = VmAPI.useGetVmsPaginatedQuery({
+    extended: 0,
+    pageSize: VM_POOL_PAGINATION_SIZE,
+  })
+
+  const { chartData, totalCount } = useMemo(() => {
+    if (!vms?.length) return { chartData: [], totalCount: 0 }
+
+    const stateCounts = {}
+    vms.forEach((vm) => {
+      const stateIndex = parseInt(vm.STATE, 10)
+      stateCounts[stateIndex] = (stateCounts[stateIndex] || 0) + 1
+    })
+
+    const entries = Object.entries(stateCounts)
+      .map(([stateIndex, count]) => {
+        const stateInfo = VM_STATES[parseInt(stateIndex, 10)]
+        if (!stateInfo || count === 0) return null
+
+        return {
+          name: capitalize(stateInfo.name),
+          value: count,
+          color: stateInfo.color,
+        }
+      })
+      .filter(Boolean)
+
+    return { chartData: entries, totalCount: vms.length }
+  }, [vms])
+
+  if (isFetching) return null
+
+  return (
+    <Box className={classes.root} data-cy="dashboard-widget-vm-state">
+      <Typography variant="h6" className={classes.title}>
+        <Translate word={T.VmStateDistribution} />
+      </Typography>
+      {!chartData.length ? (
+        <Typography variant="body1" color="text.secondary" align="center">
+          {Tr(T.NoDataAvailableYet)}
+        </Typography>
+      ) : (
+        <Box sx={{ position: 'relative' }}>
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={60}
+                outerRadius={100}
+                dataKey="value"
+                paddingAngle={2}
+                isAnimationActive={!disableAnimations}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+          <Typography
+            variant="h4"
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              pointerEvents: 'none',
+            }}
+          >
+            {totalCount}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  )
+})
+
+VmStateDistribution.displayName = 'VmStateDistribution'
+
+VmStateDistribution.propTypes = {
+  disableAnimations: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+}
+
+export default VmStateDistribution

--- a/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/index.js
+++ b/src/fireedge/src/modules/containers/Dashboard/Sunstone/widgets/index.js
@@ -1,0 +1,21 @@
+/* ------------------------------------------------------------------------- *
+ * Copyright 2002-2025, OpenNebula Project, OpenNebula Systems               *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain   *
+ * a copy of the License at                                                  *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ * ------------------------------------------------------------------------- */
+export { default as ResourceSummaryCards } from './ResourceSummaryCards'
+export { default as InfrastructureUtilization } from './InfrastructureUtilization'
+export { default as StorageCapacity } from './StorageCapacity'
+export { default as HostMonitoringGraphs } from './HostMonitoringGraphs'
+export { default as VmStateDistribution } from './VmStateDistribution'
+export { default as QuickActions } from './QuickActions'


### PR DESCRIPTION
<img width="1442" height="783" alt="image" src="https://github.com/user-attachments/assets/b19d5687-38df-4a50-ae28-765d52c6d46c" />

## Summary

Replaces the 4 static WavesCard counters on the Sunstone admin dashboard with an operations-focused layout that surfaces real-time infrastructure metrics at a glance:

- **Row 1** — Enhanced WavesCards with live subtitles (running VMs, monitored hosts, storage used/total)
- **Row 2** — Infrastructure utilization (aggregate CPU/Memory bars with color thresholds) + Storage capacity (per-datastore-type progress bars)
- **Row 3** — Host CPU and Memory monitoring graphs (uPlot 1h time-series)
- **Row 4** — VM state distribution donut chart (Recharts) + Quick Actions navigation panel

### Design decisions
- **No new npm dependencies** — uses existing MUI, Recharts, and uPlot already in the project
- **5 unique API calls** shared across all widgets via RTK Query cache deduplication
- Respects `DISABLE_ANIMATIONS` setting, dark/light theme, responsive breakpoints, and per-resource access control gating
- All new widget components are self-contained under `widgets/` with a barrel export

### Files changed
| File | Change |
|------|--------|
| `General.js` | Rewritten layout: 4-row Grid with new widget components |
| `widgets/ResourceSummaryCards.js` | New — enhanced WavesCards with live subtitles |
| `widgets/InfrastructureUtilization.js` | New — CPU/Memory aggregate bars |
| `widgets/StorageCapacity.js` | New — per-type datastore capacity bars |
| `widgets/HostMonitoringGraphs.js` | New — uPlot CPU/Memory time-series |
| `widgets/VmStateDistribution.js` | New — Recharts donut chart |
| `widgets/QuickActions.js` | New — navigation buttons (Deploy VM, Hosts, Datastores, Settings) |
| `widgets/index.js` | New — barrel export |
| `WavesCard.js` | Added optional `subtitle` prop |
| `translates.js` | Added translation keys for new widget labels |

## How to test

### Option A: Build from source

```bash
# 1. Clone the fork and checkout the branch
git clone https://github.com/pablodelarco/one.git
cd one
git checkout feat/fireedge-admin-dashboard-redesign

# 2. Build FireEdge
cd src/fireedge
npm install
npm run build

# 3. Copy built bundles to your OpenNebula installation
sudo cp -r dist/* /usr/lib/one/fireedge/dist/

# 4. Restart FireEdge
sudo systemctl restart opennebula-fireedge

# 5. Open the Sunstone dashboard
# https://<your-server>:2616/fireedge/sunstone/dashboard
```

### Option B: Build only the ContainersModule (faster)

```bash
cd one/src/fireedge
npm install
npm run build:containers   # builds only the dashboard module

# Copy the built ContainersModule
sudo cp -r dist/modules/ContainersModule/* \
  /usr/lib/one/fireedge/dist/modules/ContainersModule/

sudo systemctl restart opennebula-fireedge
```

### What to verify
- [ ] Dashboard loads without console errors
- [ ] WavesCards show resource counts with live subtitles
- [ ] CPU/Memory utilization bars reflect host aggregate data
- [ ] Storage capacity shows per-datastore-type breakdown
- [ ] Host monitoring graphs render 1h time-series for CPU and Memory
- [ ] VM state distribution donut shows correct state breakdown
- [ ] Quick Actions buttons navigate to correct pages
- [ ] Dark mode renders correctly
- [ ] Responsive layout works on narrow viewports (md breakpoint)
- [ ] Access control: widgets hidden when user lacks resource permissions

## Checklist
- [x] No new npm dependencies
- [x] Follows existing code patterns (React.memo, PropTypes, RTK Query hooks)
- [x] Apache 2.0 license headers on all new files
- [x] Tested on OpenNebula 7.0.1 CE