### PR TITLE
B #7590: set target bus on disk hotplug

### DIFF
--- a/src/mad/sh/scripts_common.sh
+++ b/src/mad/sh/scripts_common.sh
@@ -931,6 +931,7 @@ function get_disk_information {
         XPATH_ELEMENTS[i++]="$element"
     done < <($CMD       /VMM_DRIVER_ACTION_DATA/VM/ID \
                         /VMM_DRIVER_ACTION_DATA/VM/TEMPLATE/VCPU \
+                        /VMM_DRIVER_ACTION_DATA//OS/SD_DISK_BUS \
                         $DISK_XPATH/DRIVER \
                         $DISK_XPATH/TYPE \
                         $DISK_XPATH/READONLY \
@@ -980,6 +981,7 @@ function get_disk_information {
 
     VMID="${XPATH_ELEMENTS[j++]}"
     VCPU="${XPATH_ELEMENTS[j++]:-1}"
+    SD_DISK_BUS="${XPATH_ELEMENTS[j++]}"
     DRIVER="${XPATH_ELEMENTS[j++]:-$DEFAULT_TYPE}"
     TYPE="${XPATH_ELEMENTS[j++]}"
     READONLY="${XPATH_ELEMENTS[j++]}"

--- a/src/vmm_mad/remotes/kvm/attach_disk
+++ b/src/vmm_mad/remotes/kvm/attach_disk
@@ -118,7 +118,14 @@ XML+="</source>"
 
 [ -n "${AUTH}" ] && XML+=" ${AUTH}"
 
-XML+="<target dev='$(xml_esc "${TARGET}")'/>"
+if [[ -n "${SD_DISK_BUS}" ]] && [[ "${TARGET:0:2}" == "sd" ]]; then
+    if [[ "${SD_DISK_BUS,,}" == "sata" ]]; then
+        log_error "The SATA disks are not hot-pluggable!"
+        exit 1
+    fi
+    TARGET_BUS="bus='$(xml_esc "${SD_DISK_BUS,,}")'"
+fi
+XML+="<target dev='$(xml_esc "${TARGET}")'${TARGET_BUS:+ ${TARGET_BUS}}/>"
 [ -n "${ORDER}" ] && XML+=" <boot order='$(xml_esc "${ORDER}")'/>"
 [ "${READONLY}" = 'yes' ] && XML+="<readonly/>"
 [ "${SHAREABLE}" = 'yes' ] && XML+="<shareable/>"


### PR DESCRIPTION
### Description
set target bus on disk hotplug using SD_DISK_BUS when available.

Check if the bus is SATA and raise an error as it is unsupported.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->

- [x] master
- [x] one-7.0
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
