### PR TITLE
B #7588: apply iothread on virtio-blk disk hotplug

### DIFF
--- a/src/mad/sh/scripts_common.sh
+++ b/src/mad/sh/scripts_common.sh
@@ -975,7 +975,7 @@ function get_disk_information {
                         $DISK_XPATH/WRITE_IOPS_SEC_MAX_LENGTH \
                         $DISK_XPATH/SIZE_IOPS_SEC \
                         $DISK_XPATH/VIRTIO_BLK_QUEUES \
-                        $DISK_XPATH/IOTHREAD \
+                        $DISK_XPATH/IOTHREADS \
                         $DISK_XPATH/SERIAL )
 
     VMID="${XPATH_ELEMENTS[j++]}"

--- a/src/vmm_mad/remotes/kvm/attach_disk
+++ b/src/vmm_mad/remotes/kvm/attach_disk
@@ -83,6 +83,37 @@ if [ "${VIRTIO_BLK_QUEUES}" = "auto" ]; then
     VIRTIO_BLK_QUEUES="$VCPU"
 fi
 
+if [[ "${TARGET:0:2}" == "vd" ]]; then
+    # get the defined iothreads for the domain
+    read -r DOMAIN_IOTHREADS <<<"$(virsh --connect "${LIBVIRT_URI}" dumpxml "${DOMAIN}" | \
+                                     xmllint --xpath '/domain/iothreads/text()' - 2>/dev/null)"
+    if [[ -n "${DOMAIN_IOTHREADS}" ]] && [[ ${DOMAIN_IOTHREADS} -gt 0 ]]; then
+        if [[ -z "${IOTHREAD}" ]] ; then
+            # There is no explicit iothread id defined.
+            # Apply the default one from the kvmrc file
+            _DEFAULT_IOTHREAD="${DEFAULT_ATTACH_VIRTIO_BLK_IOTHREAD//[^[:digit:]]}"
+            if [[ -n "${_DEFAULT_IOTHREAD}" ]]; then
+                if [[ ${_DEFAULT_IOTHREAD} -gt ${DOMAIN_IOTHREADS} ]]; then
+                    # Ceil when the default iothread id is bigger than
+                    # the defined number of threads
+                    IOTHREAD="${DOMAIN_IOTHREAD}"
+                elif [[ ${_DEFAULT_IOTHREAD} -gt 0 ]]; then
+                    IOTHREAD="${_DEFAULT_IOTHREAD}"
+               fi
+            fi
+        elif [[ -z "${IOTHREAD//[[:digit:]-]}" ]]; then
+            if [[ ${IOTHREAD} -gt ${DOMAIN_IOTHREADS} ]]; then
+                IOTHREAD="${DOMAIN_IOTHREADS}"
+            elif [[ ${IOTHREAD} -lt 1 ]]; then
+                IOTHREAD=""
+            fi
+        else
+            # The value is not numeric
+            IOTHREAD=""
+        fi
+    fi
+fi
+
 # disk XML
 XML=''
 

--- a/src/vmm_mad/remotes/kvm/kvmrc
+++ b/src/vmm_mad/remotes/kvm/kvmrc
@@ -55,6 +55,9 @@ DEFAULT_ATTACH_DISCARD=unmap
 # The default number of queues for virtio-blk driver.
 #DEFAULT_ATTACH_VIRTIO_BLK_QUEUES=
 
+# The default iothread id to assign on virtio-blk hotplug.
+#DEFAULT_ATTACH_VIRTIO_BLK_IOTHREAD=
+
 # These parameters set the default DISK I/O throttling attributes
 # for the new attached disk in case they aren't set.
 #DEFAULT_ATTACH_TOTAL_BYTES_SEC=


### PR DESCRIPTION
### Description

The proposed patch handles a typo in the VM metadata parser. 
Also, when the target is a `vd`(virtio-blk) disk:
 * Check if there are iothreads defined for the domain.
 * If there is speciffic thread id defined for the disk
 * If no - the optional default attach virtio iothread id
 * check the values: use the max iothreads if the suggested iothread is bigger than the defined iothreads, or do not define if the suggested iothread is 0 or less.

### Branches to which this PR applies

- [x] master
- [x] one-7.0
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
