### PR TITLE
F #7675: option to configure FQDN for remote_addr

### DIFF
--- a/src/vnm_mad/remotes/OpenNebulaNetwork.conf
+++ b/src/vnm_mad/remotes/OpenNebulaNetwork.conf
@@ -124,7 +124,9 @@
 # - :networks: [0, vnet1]
 #
 # The simplest example of an OneGate proxy config applied to all VNETs:
+# When a FQDN is configured for :remote_addr:, the host resolver will resolve
+# it to an IP.
 # :tproxy:
 # - :service_port: 5030
-#   :remote_addr: 10.11.12.13 # HA VIP
+#   :remote_addr: 10.11.12.13 # HA VIP or FQDN
 #   :remote_port: 5030

--- a/src/vnm_mad/remotes/lib/tproxy.rb
+++ b/src/vnm_mad/remotes/lib/tproxy.rb
@@ -44,7 +44,20 @@ module VNMMAD
                      && (nets & nic.slice(:network, :network_id).values.map(&:to_s)).empty?
 
                 next if conf[:service_port].nil?
-                next if conf[:remote_addr].nil? || conf[:remote_addr] !~ Resolv::IPv4::Regex
+                next if conf[:remote_addr].nil? || conf[:remote_addr].to_s.strip.empty?
+
+                unless conf[:remote_addr] =~ Resolv::IPv4::Regex
+                    begin
+                        remote_ip = Resolv.getaddress(conf[:remote_addr])
+                        next unless remote_ip =~ Resolv::IPv4::Regex
+
+                        OpenNebula::DriverLogger.log_info "Resolved remote_addr #{conf[:remote_addr]} to #{remote_ip}"
+                        conf[:remote_addr] = remote_ip
+                    rescue Resolv::ResolvError
+                        OpenNebula::DriverLogger.log_warning "Can't resolve remote_addr #{conf[:remote_addr]}. Skipping."
+                        next
+                    end
+                end
                 next if conf[:remote_port].nil?
 
                 opts = {


### PR DESCRIPTION
### Description
This way the resolver on the host will provide the IP address for tproxy to communicate with the opennebula-gate service. So, with a DNS view or a line in /etc/hosts file on the host(s) the tproxy service will pick the desired IP to connect to the opennebula-gate endpoint.

### Branches to which this PR applies


- [x] master
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
