### PR TITLE
F #7662: preserve rollback path for recover success

### DIFF
--- a/src/lcm/LifeCycleActions.cc
+++ b/src/lcm/LifeCycleActions.cc
@@ -1358,18 +1358,14 @@ void LifeCycleManager::recover(VirtualMachine * vm, bool success,
         //----------------------------------------------------------------------
         case VirtualMachine::PROLOG:
         case VirtualMachine::PROLOG_MIGRATE:
-        case VirtualMachine::PROLOG_MIGRATE_FAILURE:
         case VirtualMachine::PROLOG_RESUME:
         case VirtualMachine::PROLOG_RESUME_FAILURE:
         case VirtualMachine::PROLOG_UNDEPLOY:
         case VirtualMachine::PROLOG_UNDEPLOY_FAILURE:
         case VirtualMachine::PROLOG_FAILURE:
         case VirtualMachine::PROLOG_MIGRATE_POWEROFF:
-        case VirtualMachine::PROLOG_MIGRATE_POWEROFF_FAILURE:
         case VirtualMachine::PROLOG_MIGRATE_SUSPEND:
-        case VirtualMachine::PROLOG_MIGRATE_SUSPEND_FAILURE:
         case VirtualMachine::PROLOG_MIGRATE_UNKNOWN:
-        case VirtualMachine::PROLOG_MIGRATE_UNKNOWN_FAILURE:
             if (success)
             {
                 trigger_prolog_success(vim);
@@ -1378,6 +1374,16 @@ void LifeCycleManager::recover(VirtualMachine * vm, bool success,
             {
                 trigger_prolog_failure(vim);
             }
+            break;
+
+        case VirtualMachine::PROLOG_MIGRATE_FAILURE:
+        case VirtualMachine::PROLOG_MIGRATE_POWEROFF_FAILURE:
+        case VirtualMachine::PROLOG_MIGRATE_SUSPEND_FAILURE:
+        case VirtualMachine::PROLOG_MIGRATE_UNKNOWN_FAILURE:
+            // These states already represent a failed TM prolog migration. They
+            // can be retried explicitly, but "recover --success" must not skip
+            // straight into boot/deploy on the destination without rolling back.
+            trigger_prolog_failure(vim);
             break;
 
         case VirtualMachine::EPILOG:


### PR DESCRIPTION
## Summary
- stop treating `recover --success` on `PROLOG_MIGRATE_*_FAILURE` states as a direct boot/deploy success path
- route those failure states through the existing prolog-failure recovery path instead
- preserve explicit retry behavior while avoiding a synthetic success transition on the destination side

## Rationale
`PROLOG_MIGRATE_*_FAILURE` already means the transfer-manager prolog migration failed.
Calling `recover --success` from those states should not skip straight into boot/deploy as if the destination-side prolog had succeeded. The existing `trigger_prolog_failure()` path already performs the rollback/history handling for these migration failure states, so this change reuses that logic.

## Validation
- `git diff --check`
- successful `scons mysql=yes grpc=yes systemd=yes rubygems=yes -j32` build on Ubuntu build VM

## Notes
I did not replace the running disposable 7.2.0 lab with this branch because the patch was built from current `master` (`7.3.80.pre`), and forcing a master build over that package-based lab would create unnecessary version skew during validation.
