### PR TITLE
B #7691: loosen inherited ARP strictness in netns

### DIFF
--- a/share/pkgs/sudoers/centos/opennebula
+++ b/share/pkgs/sudoers/centos/opennebula
@@ -9,7 +9,7 @@ Cmnd_Alias ONE_LXC = /usr/bin/mount, /usr/bin/umount, /usr/bin/bindfs, /usr/sbin
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_NET = /usr/sbin/iptables, /usr/sbin/ip6tables, /usr/sbin/ipset, /usr/sbin/ip link *, /usr/sbin/ip neighbour *, /usr/sbin/ip route *, /usr/sbin/ip rule *, /usr/sbin/ip tuntap *, /usr/sbin/nft, /var/tmp/one/vnm/tproxy, /usr/sbin/bridge vlan *
 Cmnd_Alias ONE_SCSI = /usr/sbin/blockdev, /usr/sbin/multipath, /usr/sbin/multipathd, /usr/sbin/iscsiadm, /usr/bin/tee, /usr/bin/find, /usr/bin/cat /etc/iscsi/initiatorname.iscsi
-Cmnd_Alias ONE_NETNS = /usr/sbin/ip netns add *, /usr/sbin/ip netns delete *, /usr/sbin/ip netns pids *, /var/tmp/one/vnm/ip_netns_exec ip address *, /var/tmp/one/vnm/ip_netns_exec ip link *, /var/tmp/one/vnm/ip_netns_exec ip -j link show *, /var/tmp/one/vnm/ip_netns_exec ip route *
+Cmnd_Alias ONE_NETNS = /usr/sbin/ip netns add *, /usr/sbin/ip netns delete *, /usr/sbin/ip netns pids *, /var/tmp/one/vnm/ip_netns_exec ip address *, /var/tmp/one/vnm/ip_netns_exec ip link *, /var/tmp/one/vnm/ip_netns_exec ip -j link show *, /var/tmp/one/vnm/ip_netns_exec ip route *, /var/tmp/one/vnm/ip_netns_exec sysctl -w net.ipv4.conf.*.arp_ignore=0
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl, /usr/bin/ovs-appctl
 Cmnd_Alias ONE_MEM = /usr/sbin/sysctl vm.drop_caches=3 vm.compact_memory=1
 Cmnd_Alias ONE_VGPU = /var/tmp/one/vgpu

--- a/share/pkgs/sudoers/debian/opennebula
+++ b/share/pkgs/sudoers/debian/opennebula
@@ -9,7 +9,7 @@ Cmnd_Alias ONE_LXC = /usr/bin/mount, /usr/bin/umount, /usr/bin/bindfs, /usr/sbin
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_NET = /usr/sbin/iptables, /usr/sbin/ip6tables, /usr/sbin/ipset, /usr/sbin/ip link *, /usr/sbin/ip neighbour *, /usr/sbin/ip route *, /usr/sbin/ip rule *, /usr/sbin/ip tuntap *, /usr/sbin/nft, /var/tmp/one/vnm/tproxy, /usr/sbin/bridge vlan *
 Cmnd_Alias ONE_SCSI = /usr/sbin/blockdev, /usr/sbin/multipath, /usr/sbin/multipathd, /usr/sbin/iscsiadm, /usr/bin/tee, /usr/bin/find, /usr/bin/cat /etc/iscsi/initiatorname.iscsi
-Cmnd_Alias ONE_NETNS = /usr/sbin/ip netns add *, /usr/sbin/ip netns delete *, /usr/sbin/ip netns pids *, /var/tmp/one/vnm/ip_netns_exec ip address *, /var/tmp/one/vnm/ip_netns_exec ip link *, /var/tmp/one/vnm/ip_netns_exec ip -j link show *, /var/tmp/one/vnm/ip_netns_exec ip route *
+Cmnd_Alias ONE_NETNS = /usr/sbin/ip netns add *, /usr/sbin/ip netns delete *, /usr/sbin/ip netns pids *, /var/tmp/one/vnm/ip_netns_exec ip address *, /var/tmp/one/vnm/ip_netns_exec ip link *, /var/tmp/one/vnm/ip_netns_exec ip -j link show *, /var/tmp/one/vnm/ip_netns_exec ip route *, /var/tmp/one/vnm/ip_netns_exec sysctl -w net.ipv4.conf.*.arp_ignore=0
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl, /usr/bin/ovs-appctl
 Cmnd_Alias ONE_MEM = /usr/sbin/sysctl vm.drop_caches=3 vm.compact_memory=1
 Cmnd_Alias ONE_VGPU = /var/tmp/one/vgpu

--- a/share/pkgs/sudoers/suse/opennebula
+++ b/share/pkgs/sudoers/suse/opennebula
@@ -9,7 +9,7 @@ Cmnd_Alias ONE_LXC = /usr/bin/mount, /usr/bin/umount, /usr/bin/bindfs, /usr/sbin
 Cmnd_Alias ONE_MARKET = /usr/lib/one/sh/create_container_image.sh
 Cmnd_Alias ONE_NET = /usr/sbin/iptables, /usr/sbin/ip6tables, /usr/sbin/ipset, /usr/sbin/ip link *, /usr/sbin/ip neighbour *, /usr/sbin/ip route *, /usr/sbin/ip rule *, /usr/sbin/ip tuntap *, /usr/sbin/nft, /var/tmp/one/vnm/tproxy, /usr/sbin/bridge vlan *
 Cmnd_Alias ONE_SCSI = /usr/sbin/blockdev, /usr/sbin/multipath, /usr/sbin/multipathd, /sbin/iscsiadm, /usr/bin/tee, /usr/bin/find, /usr/bin/cat /etc/iscsi/initiatorname.iscsi
-Cmnd_Alias ONE_NETNS = /usr/sbin/ip netns add *, /usr/sbin/ip netns delete *, /usr/sbin/ip netns pids *, /var/tmp/one/vnm/ip_netns_exec ip address *, /var/tmp/one/vnm/ip_netns_exec ip link *, /var/tmp/one/vnm/ip_netns_exec ip -j link show *, /var/tmp/one/vnm/ip_netns_exec ip route *
+Cmnd_Alias ONE_NETNS = /usr/sbin/ip netns add *, /usr/sbin/ip netns delete *, /usr/sbin/ip netns pids *, /var/tmp/one/vnm/ip_netns_exec ip address *, /var/tmp/one/vnm/ip_netns_exec ip link *, /var/tmp/one/vnm/ip_netns_exec ip -j link show *, /var/tmp/one/vnm/ip_netns_exec ip route *, /var/tmp/one/vnm/ip_netns_exec sysctl -w net.ipv4.conf.*.arp_ignore=0
 Cmnd_Alias ONE_OVS = /usr/bin/ovs-ofctl, /usr/bin/ovs-vsctl, /usr/bin/ovs-appctl
 Cmnd_Alias ONE_MEM = /usr/sbin/sysctl vm.drop_caches=3 vm.compact_memory=1
 Cmnd_Alias ONE_VGPU = /var/tmp/one/vgpu

--- a/share/sudoers/sudoers.rb
+++ b/share/sudoers/sudoers.rb
@@ -44,7 +44,8 @@ class Sudoers
                 '/var/tmp/one/vnm/ip_netns_exec ip address *',
                 '/var/tmp/one/vnm/ip_netns_exec ip link *',
                 '/var/tmp/one/vnm/ip_netns_exec ip -j link show *',
-                '/var/tmp/one/vnm/ip_netns_exec ip route *'
+                '/var/tmp/one/vnm/ip_netns_exec ip route *',
+                '/var/tmp/one/vnm/ip_netns_exec sysctl -w net.ipv4.conf.*.arp_ignore=0'
             ],
             :LVM => [
                 'lvcreate', 'lvremove', 'lvs', 'vgdisplay', 'lvchange', 'lvscan', 'lvextend',

--- a/src/vnm_mad/remotes/lib/tproxy.rb
+++ b/src/vnm_mad/remotes/lib/tproxy.rb
@@ -98,6 +98,9 @@ module VNMMAD
 
             ip_netns_exec(brdev, "ip route replace default dev #{brdev}a")
 
+            ip_netns_exec(brdev, 'sysctl -w net.ipv4.conf.all.arp_ignore=0')
+            ip_netns_exec(brdev, "sysctl -w net.ipv4.conf.#{brdev.tr('.', '/')}a.arp_ignore=0")
+
             # Prevent ARP requests from being propagated to other HV machines.
             # It reduces network traffic and ensures that the closest HV handles
             # proxied packets.


### PR DESCRIPTION
### Description
to allow cross-subnet ARP replies.

Network namespaces can inherit strict ARP policies (where arp_ignore is greater than 0) from the host's default configurations. When this strictness is inherited, it breaks cross-subnet ARP resolution. Specifically, the namespace silently drops and fails to reply to the VM's cross-subnet ARP requests for local endpoints, such as the 169.254.16.9.

This PR explicitly loosens the inherited ARP strictness by forcing arp_ignore=0 inside the namespace. By applying this to both all and the specific interface, it guarantees the namespace will successfully reply to the VM's ARP requests for local IPs.

### Branches to which this PR applies

- [x] master
- [x] one-6.10.1+
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed
