### PR TITLE
B #7717: Fix sshwrap to prevent ssh from consuming following shell input

### DIFF
--- a/src/tm_mad/lib/shell.rb
+++ b/src/tm_mad/lib/shell.rb
@@ -304,7 +304,7 @@ module TransferManager
         cmd
       else
         <<~EOF.strip
-          ssh '#{host}' '\
+          ssh -n '#{host}' '\
               script="$(mktemp)"; \
               echo "#{Base64.strict_encode64(cmd)}" | base64 -d > "$script"; \
               trap "rm $script" EXIT; \


### PR DESCRIPTION
## Description

Fixes the `sshwrap` helper so that `ssh` does not consume input intended for subsequent commands in the calling shell (e.g., the `while read` loops used during RBD snapshot cleanup). This avoids truncated/skipped iterations when cleaning up snapshots over SSH.

Closes OpenNebula/one#7717

## Changes
- Pass `-n` (or redirect stdin from `/dev/null`) in `sshwrap` so `ssh` does not read from the parent shell's stdin.

## Testing
- Verified RBD snapshot cleanup loops process all entries when invoked via `sshwrap`.

### Branches to which this PR applies

- [x] master
- [x] one-7.4
- [x] one-7.2

<hr>

- [ ] Check this if this PR should **not** be squashed