### PR TITLE
Fix: add exclusive lock retry to create_repo_if_not_exists and unify lock timeout

### DIFF
--- a/src/datastore_mad/remotes/restic/restic.rb
+++ b/src/datastore_mad/remotes/restic/restic.rb
@@ -130,6 +130,9 @@ class Restic
         raise StandardError, 'Invalid value for RESTIC_PRUNE_MAX_UNUSED' \
             unless @max_unused.nil? || @max_unused.match(/^\d+[kKmMgGtT%]?$|^unlimited$/)
 
+        # Max retries when waiting for an exclusive Restic lock (5 s between each retry).
+        @lock_retries = Integer(safe_get("#{prefix}TEMPLATE/RESTIC_LOCK_RETRIES", 720))
+
         create_repo_if_not_exists if @options[:create_repo] && @repo_id
     rescue StandardError => e
         raise StandardError, "Wrong restic datastore configuration: #{e.message}"
@@ -176,12 +179,19 @@ class Restic
         script = <<~EOS
             set -e -o pipefail; shopt -qs failglob
             #{resticenv_sh(RESTIC_BIN_PATHS[:frontend])}
-            #{restic('stats')} || #{restic('init')}
+            #{restic('stats')} || { ec=$?; if [ "$ec" -eq 11 ]; then exit 11; fi; #{restic('init')}; }
         EOS
 
-        rc = LocalCommand.run '/bin/bash -s', nil, script
+        rc = nil
+        @lock_retries.times do
+            rc = LocalCommand.run '/bin/bash -s', nil, script
+            return if rc.code == 0
+            break unless rc.code == 11
 
-        raise StandardError, rc.stderr if rc.code != 0
+            sleep 5
+        end
+
+        raise StandardError, rc.stderr
     end
 
     # Gets (from Restic) full metadata of a specific snapshot.
@@ -268,7 +278,7 @@ class Restic
     # @return [nil]
     def remove_snapshots(snaps, rhost = @sftp, opts = {})
         options = {
-            :retries => 60,
+            :retries => @lock_retries,
             :delay   => 5 # seconds
         }.merge!(opts)
 
@@ -339,7 +349,7 @@ class Restic
     # @return [Object] RC struct
     def run_with_lock_retry(name, script, rhost, opts = {})
         options = {
-            :retries => 60,
+            :retries => @lock_retries,
             :delay   => 5
         }.merge!(opts)
 

--- a/src/fireedge/src/modules/components/Forms/Datastore/CreateForm/Steps/ConfigurationAttributes/Fields/restic.js
+++ b/src/fireedge/src/modules/components/Forms/Datastore/CreateForm/Steps/ConfigurationAttributes/Fields/restic.js
@@ -192,6 +192,19 @@ const RESTIC_SPARSIFY = {
   grid: { xs: 12, md: 6 },
 }
 
+/** @type {Field} - Max retries when waiting for an exclusive Restic lock */
+const RESTIC_LOCK_RETRIES = {
+  name: 'RESTIC_LOCK_RETRIES',
+  label: T.ResticLockRetries,
+  tooltip: T.ResticLockRetriesConcept,
+  dependOf: '$general.STORAGE_BACKEND',
+  type: INPUT_TYPES.TEXT,
+  htmlType: (type) =>
+    typeIsOneOf(type, [isRestic]) ? 'number' : INPUT_TYPES.HIDDEN,
+  validation: number(),
+  grid: { xs: 12, md: 6 },
+}
+
 export const RESTIC_FIELDS = [
   RESTIC_PASSWORD,
   RESTIC_SFTP_SERVER,
@@ -205,5 +218,6 @@ export const RESTIC_FIELDS = [
   RESTIC_MAX_WIOPS,
   RESTIC_CPU_QUOTA,
   RESTIC_MAXPROC,
+  RESTIC_LOCK_RETRIES,
   RESTIC_SPARSIFY,
 ]

--- a/src/fireedge/src/modules/constants/translates.js
+++ b/src/fireedge/src/modules/constants/translates.js
@@ -947,6 +947,9 @@ module.exports = {
   MaxNumberOSThreads: 'Max number of OS threads',
   MaxNumberOSThreadsConcept:
     'Sets GOMAXPROCS for restic to limit the OS threads that execute user-level Go code simultaneously.',
+  ResticLockRetries: 'Restic lock retries',
+  ResticLockRetriesConcept:
+    'Maximum number of retries (5 s apart) when waiting for an exclusive Restic repository lock to be released. Increase this for repositories where prune operations take a long time. Default: 720 (60 min).',
   Sparsify: 'Sparsify',
   SparsifyConcept:
     'Runs virt-sparsify on flatten backups to reduce backup size. It requires libguestfs package.',


### PR DESCRIPTION
## Problem

When a backup job runs and a concurrent `restic forget --prune` (triggered by old image deletion) holds the **exclusive Restic repository lock**, subsequent VM backups fail immediately with:

```
unable to create lock in backend: repository is already locked exclusively
```

This happens because `create_repo_if_not_exists` runs `restic stats` which needs to acquire a lock, gets exit code 11 (lock contention), and has **no retry logic** — it raises immediately.

`remove_snapshots` and `run_with_lock_retry` already handle lock contention via retry loops (fixed in #7403 / #7404), but `create_repo_if_not_exists` was missed.

With `RESTIC_PRUNE_MAX_UNUSED=0` (the default), a prune can take 50+ minutes on large repositories, so a 60-minute wait budget is needed.

## Root cause

The shell script in `create_repo_if_not_exists`:
```bash
restic stats || restic init
```
When `restic stats` exits 11 (locked), the shell runs `restic init`, which exits non-zero with "config already exists". The Ruby code sees a non-zero exit but **not exit code 11**, so the existing "retry on code 11" pattern cannot work. The script must be changed to propagate exit code 11 explicitly.

## Fix

**`src/datastore_mad/remotes/restic/restic.rb`**

1. Read a new `RESTIC_LOCK_RETRIES` datastore attribute (default `720`, i.e. 720 × 5 s = 60 min) in `initialize`, replacing the hard-coded `60` in `remove_snapshots` and `run_with_lock_retry`.

2. Restructure the shell script so exit code 11 from `restic stats` is propagated:
   ```bash
   restic stats || { ec=$?; if [ "$ec" -eq 11 ]; then exit 11; fi; restic init; }
   ```

3. Add the same retry loop used elsewhere (`rc.code == 11` → sleep → retry) to `create_repo_if_not_exists`.

**`src/fireedge/src/modules/constants/translates.js`** — add `ResticLockRetries` / `ResticLockRetriesConcept` i18n keys.

**`src/fireedge/src/modules/components/Forms/Datastore/CreateForm/Steps/ConfigurationAttributes/Fields/restic.js`** — add `RESTIC_LOCK_RETRIES` numeric field to the datastore configuration form.

## New datastore attribute

| Attribute | Default | Description |
|---|---|---|
| `RESTIC_LOCK_RETRIES` | `720` | Number of retries (5 s each) when waiting for an exclusive lock. Default gives a 60-minute wait budget. |

## Testing

Verified on OpenNebula 6.10.1 with restic 0.17.3 (frontend) / 0.18.0 (backup server):
- A daily backup job with 5 VMs was failing every day because `restic forget --prune --max-unused 0` held an exclusive lock for ~54 minutes.
- After this fix, all 5 VMs backed up successfully in both a manual re-run and the following scheduled run.

## Relation to existing issues

| Issue | Scope | Status |
|---|---|---|
| #7403 | `remove_snapshots` retry (broken regex → rc.code==11) | Fixed |
| #7404 | `pull_disks` / `pull_other` retry via `run_with_lock_retry` | Fixed |
| This PR | `create_repo_if_not_exists` retry (never had any) + unified timeout | New |