### PR TITLE
B #7915: Fix PREDICTIVE config lookup in one_drs

### DIFF
--- a/src/schedm_mad/remotes/one_drs/lib/optimizer_parser.py
+++ b/src/schedm_mad/remotes/one_drs/lib/optimizer_parser.py
@@ -972,7 +972,7 @@ class OptimizerParser:
     def _apply_predictive_adjustment(
         self, current: float, forecast: float = None
     ) -> float:
-        predictive = self.config.get("predictive", 0)
+        predictive = self.config.get("PREDICTIVE") or 0
         if predictive > 0 and forecast > 0:
             return current * (1 - predictive) + forecast * predictive
         return current


### PR DESCRIPTION
### Description
Read the lowercase "predictive" config key while the config stores PREDICTIVE, so the predictive factor was always 0 and forecasts were never blended in. Also guard against a None value coming from a cluster ONE_DRS template without PREDICTIVE defined.

### Branches to which this PR applies

- [x] master
- [ ] one-X.X

<hr>

- [ ] Check this if this PR should **not** be squashed
