### PR TITLE
B #7962: fix normalize_extents in lvm OneBEX exporter

### DIFF
--- a/src/onebex/exporters/lvm.rb
+++ b/src/onebex/exporters/lvm.rb
@@ -285,8 +285,10 @@ module OneBEX
                 sorted.each do |extent|
                     last = merged.last
 
-                    if extent[:start] <= last[:end]
-                        last[:end] = [last[:end], extent[:end]].max
+                    if extent[:start] <= last[:start] + last[:length]
+                        new_end = [last[:start]  + last[:length],
+                                   extent[:start] + extent[:length]].max
+                        last[:length] = new_end - last[:start]
                     else
                         merged << extent.dup
                     end


### PR DESCRIPTION
### Description

Use defined/populated elements

### Branches to which this PR applies

- [x] master
- [x] one-7.4

<hr>

- [ ] Check this if this PR should **not** be squashed
