### PR TITLE
Fix marketplace monitor ignoring proxy auth credentials (#8043)

### DIFF
--- a/src/market_mad/remotes/one/monitor
+++ b/src/market_mad/remotes/one/monitor
@@ -95,8 +95,7 @@ class OneMarket
 
         req['User-Agent'] = @agent
 
-        response = Net::HTTP.start(uri.hostname, uri.port, p_host, p_port,
-                                   :use_ssl => uri.scheme == 'https') do |http|
+        response = Net::HTTP.start(uri.hostname, uri.port, p_host, p_port, p_uri && p_uri.user, p_uri && p_uri.password, :use_ssl => uri.scheme == 'https') do |http|
             http.request(req)
         end
 

--- a/src/market_mad/remotes/one/monitor
+++ b/src/market_mad/remotes/one/monitor
@@ -85,6 +85,9 @@ class OneMarket
             p_uri   = URI(http_proxy)
             p_host  = p_uri.host
             p_port  = p_uri.port
+            # URI keeps percent escapes; proxy authentication needs decoded values.
+            p_user  = URI::DEFAULT_PARSER.unescape(p_uri.user) if p_uri.user
+            p_pass  = URI::DEFAULT_PARSER.unescape(p_uri.password) if p_uri.password
         else
             p_host  = nil
             p_port  = nil
@@ -95,7 +98,9 @@ class OneMarket
 
         req['User-Agent'] = @agent
 
-        response = Net::HTTP.start(uri.hostname, uri.port, p_host, p_port, p_uri && p_uri.user, p_uri && p_uri.password, :use_ssl => uri.scheme == 'https') do |http|
+        response = Net::HTTP.start(uri.hostname, uri.port, p_host, p_port,
+                                   p_user, p_pass,
+                                   :use_ssl => uri.scheme == 'https') do |http|
             http.request(req)
         end
 


### PR DESCRIPTION
### Description
<!--- Please leave a helpful description of the PR here. --->

Fixes #8043

The marketplace monitor script (`src/market_mad/remotes/one/monitor`) parses the proxy URL and extracts host/port, but never passes the proxy username/password to `Net::HTTP.start`. This causes a 407 Proxy Authentication Required error when the configured proxy requires authentication, resulting in the marketplace showing no apps ("No Content" in Sunstone/FireEdge).

This PR passes `p_uri.user` and `p_uri.password` as the `p_user`/`p_pass` arguments to `Net::HTTP.start`.

### Branches to which this PR applies
<!--- Please check you didn't forget a branch this needs to be cherry picked to.
      Leave them unchecked, they will be checked by the merger --->
- [ ] master
- [ ] one-X.X
<hr>
- [ ] Check this if this PR should **not** be squashed